### PR TITLE
feat: [tool/googlesearch] make googleSearchRequest public

### DIFF
--- a/components/tool/googlesearch/google_search.go
+++ b/components/tool/googlesearch/google_search.go
@@ -86,7 +86,7 @@ type googleSearch struct {
 	cseSvr *customsearch.Service
 }
 
-func (gs *googleSearch) search(ctx context.Context, req *googleSearchRequest) (*customsearch.Search, error) {
+func (gs *googleSearch) search(ctx context.Context, req *SearchRequest) (*customsearch.Search, error) {
 
 	num := req.Num
 	if num <= 0 {
@@ -213,7 +213,7 @@ func getDescFromPageMap(pageMap googleapi.RawMessage) (string, bool, error) {
 	return siteDesc.String(), foundDesc, nil
 }
 
-type googleSearchRequest struct {
+type SearchRequest struct {
 	Query  string `json:"query" jsonschema:"description=queried string to the search engine"`
 	Num    int    `json:"num,omitempty" jsonschema:"description=number of search results to return, valid values are between 1 and 10, inclusive"`
 	Offset int    `json:"offset,omitempty" jsonschema:"description=the index of the first result to return."`

--- a/components/tool/googlesearch/google_search_test.go
+++ b/components/tool/googlesearch/google_search_test.go
@@ -291,7 +291,7 @@ func TestGooGleSearchTool(t *testing.T) {
 
 		assert.JSONEq(t, expectedSchema, string(body))
 
-		gsr := &googleSearchRequest{
+		gsr := &SearchRequest{
 			Query: mockSearchQuery,
 			Lang:  "zh-CN",
 		}


### PR DESCRIPTION
The [google search tool example](https://github.com/cloudwego/cloudwego.github.io/blob/e6903b254674e9dbf9456667dbedbfda3505e12d/content/zh/docs/eino/ecosystem_integration/tool/tool_googlesearch.md?plain=1#L81) on the documentation site is currently not working. Passing maps as parameters does not seem to be by design. 
Therefore, this PR renames the internal `googleSearchRequest` to `SearchRequest` to expose the interface publicly and improve its clarity.


#### What type of PR is this?

feat: make googleSearchRequest public

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### The PR that updates user documentation:
Examples should be updated
https://github.com/cloudwego/cloudwego.github.io/blob/e6903b254674e9dbf9456667dbedbfda3505e12d/content/zh/docs/eino/ecosystem_integration/tool/tool_googlesearch.md?plain=1#L81
