### PR TITLE
fix: OpenAI model panics when specifying tools via options

### DIFF
--- a/components/model/ark/chatmodel.go
+++ b/components/model/ark/chatmodel.go
@@ -386,7 +386,7 @@ func (cm *ChatModel) genRequest(in []*schema.Message, options *fmodel.Options) (
 	}
 
 	if tools != nil {
-		req.Tools = make([]*model.Tool, 0, len(cm.tools))
+		req.Tools = make([]*model.Tool, 0, len(tools))
 
 		for _, tool := range cm.tools {
 			arkTool := &model.Tool{

--- a/components/model/openai/go.sum
+++ b/components/model/openai/go.sum
@@ -13,12 +13,8 @@ github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
-github.com/cloudwego/eino v0.3.10 h1:KQoc+FXt+5VkoStAxkle0J21HjHumu6+cdVHjBT7BuA=
-github.com/cloudwego/eino v0.3.10/go.mod h1:+kmJimGEcKuSI6OKhet7kBedkm1WUZS3H1QRazxgWUo=
 github.com/cloudwego/eino v0.3.13 h1:5fq5hM+UzbLtv4nXMhU6tAxgb7Q3AyaJ6/566XsJqc0=
 github.com/cloudwego/eino v0.3.13/go.mod h1:+kmJimGEcKuSI6OKhet7kBedkm1WUZS3H1QRazxgWUo=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250208100047-4b90fcb10809 h1:eECIUlNWm6xUMZrJsL0S/cnJ0IaaEH4rg2OCf7gNBks=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250208100047-4b90fcb10809/go.mod h1:RNZIloDWjCngfESm93s2lcIKZHFyj0IiWC12rIGOamg=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250221090944-e8ef7aabbe10 h1:M6Z2PeX+MxW7jgoZ0p6qDfVtMe1/4XqSQSAHUrI2HTM=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.0.0-20250221090944-e8ef7aabbe10/go.mod h1:6CThw1XQx/ASXNt31yuvp0X4Yp4GprknQuIvP9VKDpw=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=

--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -24,12 +24,11 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"github.com/sashabaranov/go-openai"
-
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/sashabaranov/go-openai"
 )
 
 type ChatCompletionResponseFormatType string
@@ -333,7 +332,7 @@ func (cm *Client) genRequest(in []*schema.Message, opts ...model.Option) (*opena
 	}
 
 	if len(tools) > 0 {
-		req.Tools = make([]openai.Tool, len(cm.tools))
+		req.Tools = make([]openai.Tool, len(tools))
 		for i := range tools {
 			t := tools[i]
 


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复当 options 指定 tools 时，OpenAI 模型会 panic 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

When there's specified tools in options but none in client settings, an incorrect slice length will lead to index-out-of-range.


zh(optional): 

当在 options 中指定 tools，而 client 设置中没有 tools 时，错误的切片长度会导致下标越界。


#### (Optional) Which issue(s) this PR fixes:

None.

#### (optional) The PR that updates user documentation:

None.
