### PR TITLE
remove deepseek's apikey validation

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -105,9 +105,6 @@ type ChatModel struct {
 }
 
 func NewChatModel(_ context.Context, config *ChatModelConfig) (*ChatModel, error) {
-	if len(config.APIKey) == 0 {
-		return nil, fmt.Errorf("API key is required")
-	}
 	if len(config.Model) == 0 {
 		return nil, fmt.Errorf("model is required")
 	}


### PR DESCRIPTION
In some cases apikey is not required

有些情况下，apikey并不是必须的，比如私有的部署，内部的服务，解除deepseek apikey 的强制校验
