### PR TITLE
feat: add prefix cache to ark model

### DIFF
--- a/components/document/loader/s3/s3_loader_test.go
+++ b/components/document/loader/s3/s3_loader_test.go
@@ -22,12 +22,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/cloudwego/eino/components/document"
-	"github.com/cloudwego/eino/schema"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/bytedance/mockey"
+	"github.com/cloudwego/eino/components/document"
+	"github.com/cloudwego/eino/schema"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/components/model/ark/examples/prefix/prefix.go
+++ b/components/model/ark/examples/prefix/prefix.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+
+	"github.com/cloudwego/eino/schema"
+
+	"github.com/cloudwego/eino-ext/components/model/ark"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Get ARK_API_KEY and ARK_MODEL_ID: https://www.volcengine.com/docs/82379/1399008
+	chatModel, err := ark.NewChatModel(ctx, &ark.ChatModelConfig{
+		APIKey: os.Getenv("ARK_API_KEY"),
+		Model:  os.Getenv("ARK_MODEL_ID"),
+	})
+	if err != nil {
+		log.Fatalf("NewChatModel failed, err=%v", err)
+	}
+
+	info, err := chatModel.CreatePrefixCache(ctx, []*schema.Message{
+		schema.UserMessage("my name is megumin"),
+	}, 3600)
+	if err != nil {
+		log.Fatalf("CreatePrefix failed, err=%v", err)
+	}
+
+	inMsgs := []*schema.Message{
+		{
+			Role:    schema.User,
+			Content: "what id my name?",
+		},
+	}
+
+	msg, err := chatModel.Generate(ctx, inMsgs, ark.WithPrefixCache(info.ContextID))
+	if err != nil {
+		log.Fatalf("Generate failed, err=%v", err)
+	}
+
+	log.Printf("\ngenerate output: \n")
+	log.Printf("  request_id: %s\n", ark.GetArkRequestID(msg))
+	respBody, _ := json.MarshalIndent(msg, "  ", "  ")
+	log.Printf("  body: %s\n", string(respBody))
+
+	outStreamReader, err := chatModel.Stream(ctx, inMsgs, ark.WithPrefixCache(info.ContextID))
+	if err != nil {
+		log.Fatalf("Stream failed, err=%v", err)
+	}
+
+	var msgs []*schema.Message
+	for {
+		item, e := outStreamReader.Recv()
+		if e == io.EOF {
+			break
+		}
+		if e != nil {
+			log.Fatal(e)
+		}
+
+		msgs = append(msgs, item)
+	}
+	msg, err = schema.ConcatMessages(msgs)
+	if err != nil {
+		log.Fatalf("ConcatMessages failed, err=%v", err)
+	}
+	log.Printf("\nstream output: \n")
+	log.Printf("  request_id: %s\n", ark.GetArkRequestID(msg))
+	respBody, _ = json.MarshalIndent(msg, "  ", "  ")
+	log.Printf("  body: %s\n", string(respBody))
+}

--- a/components/model/ark/option.go
+++ b/components/model/ark/option.go
@@ -22,6 +22,7 @@ import (
 
 type arkOptions struct {
 	customHeaders map[string]string
+	contextID     *string
 }
 
 // WithCustomHeader sets custom headers for a single request
@@ -29,5 +30,17 @@ type arkOptions struct {
 func WithCustomHeader(m map[string]string) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
 		o.customHeaders = m
+	})
+}
+
+// WithPrefixCache creates an option to specify a context ID for the request.
+// The context ID is typically obtained from a previous call to CreatePrefix.
+//
+// When this option is provided, the model will use the cached prefix context
+// associated with this ID, allowing you to avoid resending the same context
+// messages in each request, which improves efficiency and reduces token usage.
+func WithPrefixCache(contextID string) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
+		o.contextID = &contextID
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
