### PR TITLE
feat:deepseek add path option

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -51,6 +51,10 @@ type ChatModelConfig struct {
 	// Optional. Default: https://api.deepseek.com/
 	BaseURL string `json:"base_url"`
 
+	// Path sets the path for the API request. Defaults to "chat/completions", if not set.
+	// Example usages would be "/c/chat/" or any http after the baseURL extension
+	Path string `json:"path"`
+
 	// The following fields correspond to DeepSeek's chat API parameters
 	// Ref: https://api-docs.deepseek.com/api/create-chat-completion
 
@@ -121,6 +125,9 @@ func NewChatModel(_ context.Context, config *ChatModelConfig) (*ChatModel, error
 			baseURL = baseURL + "/"
 		}
 		opts = append(opts, deepseek.WithBaseURL(baseURL))
+	}
+	if len(config.Path) > 0 {
+		opts = append(opts, deepseek.WithPath(config.Path))
 	}
 
 	cli, err := deepseek.NewClientWithOptions(config.APIKey, opts...)

--- a/components/model/deepseek/go.mod
+++ b/components/model/deepseek/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/bytedance/mockey v1.2.14
 	github.com/cloudwego/eino v0.3.18
-	github.com/cohesion-org/deepseek-go v1.2.3
+	github.com/cohesion-org/deepseek-go v1.2.4
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/components/model/deepseek/go.sum
+++ b/components/model/deepseek/go.sum
@@ -16,8 +16,8 @@ github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJ
 github.com/cloudwego/eino v0.3.18 h1:qz2Khkzp7hyz3mAvhnPElsVHRSRiorSetoSN0p1zoM4=
 github.com/cloudwego/eino v0.3.18/go.mod h1:wUjz990apdsaOraOXdh6CdhVXq8DJsOvLsVlxNTcNfY=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
-github.com/cohesion-org/deepseek-go v1.2.3 h1:2MuEOvNHqmEYuZG8FNn0Hf3hFw3r7ETG/kLuC7I4hDk=
-github.com/cohesion-org/deepseek-go v1.2.3/go.mod h1:Mi/tP7IzBoXxDC606CFbJC5Ofk2HCikCayBXweo1RDg=
+github.com/cohesion-org/deepseek-go v1.2.4 h1:Dk0aGrBvtIsf9xrhv0ScNLL2hVmnNoaP17009o3mFSo=
+github.com/cohesion-org/deepseek-go v1.2.4/go.mod h1:Mi/tP7IzBoXxDC606CFbJC5Ofk2HCikCayBXweo1RDg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
feat:deepseek add path option

In version 1.2.4 of Deepseek Go, developers added a new option called "WithPath" to set the path for requesting URLs. This solves the problem of Deepseek URLs deployed on certain cloud platforms being different from official URLs. In the code, I enabled the use of this new feature in eino without any compatibility issues by specifying the path property of the NewChatModel function in the deepseek package.