### PR TITLE
fix: `WithTools` does not work for ark model

### DIFF
--- a/components/model/ark/chatmodel.go
+++ b/components/model/ark/chatmodel.go
@@ -26,14 +26,13 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components"
+	fmodel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 	autils "github.com/volcengine/volcengine-go-sdk/service/arkruntime/utils"
-
-	"github.com/cloudwego/eino/callbacks"
-	fmodel "github.com/cloudwego/eino/components/model"
-	"github.com/cloudwego/eino/schema"
 )
 
 var _ fmodel.ToolCallingChatModel = (*ChatModel)(nil)
@@ -488,7 +487,7 @@ func (cm *ChatModel) genRequest(in []*schema.Message, options *fmodel.Options) (
 	if tools != nil {
 		req.Tools = make([]*model.Tool, 0, len(tools))
 
-		for _, tool := range cm.tools {
+		for _, tool := range tools {
 			arkTool := &model.Tool{
 				Type: model.ToolTypeFunction,
 				Function: &model.FunctionDefinition{

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -149,8 +149,6 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.0.185 h1:MIH+YgdWZhO1fNg/vxLohl8ad7hlklaf46wpaTS1TN0=
-github.com/volcengine/volcengine-go-sdk v1.0.185/go.mod h1:gfEDc1s7SYaGoY+WH2dRrS3qiuDJMkwqyfXWCa7+7oA=
 github.com/volcengine/volcengine-go-sdk v1.1.4 h1:xPT4KOy8VkXxhY7dbXzzvLvKQXUe4J6AtkQdNQU3wRY=
 github.com/volcengine/volcengine-go-sdk v1.1.4/go.mod h1:gfEDc1s7SYaGoY+WH2dRrS3qiuDJMkwqyfXWCa7+7oA=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复 `WithTools` 对方舟模型不起作用。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`BindTools` sets the default tools for the model, and `WithTools` should be able to override them in requests. However, it doesn't work for ark models since the incorrect code always checks the length of the default tools.

It follows #137.

zh(optional): 

`BindTools`为模型设置默认工具，而`WithTools`应该能够在请求中覆盖它们。然而，方舟模型没有正确工作，因为不正确的代码总是检查默认工具的长度.

跟随 #137.

#### (Optional) Which issue(s) this PR fixes:

None.

#### (optional) The PR that updates user documentation:

None.
