### PR TITLE
fix: score reranker is reversed

### DIFF
--- a/components/document/transformer/reranker/score/score.go
+++ b/components/document/transformer/reranker/score/score.go
@@ -105,7 +105,7 @@ func (s sortedDocuments) Len() int {
 	return len(s.docs)
 }
 func (s sortedDocuments) Less(i, j int) bool {
-	return s.scoreGetter(s.docs[i]) < s.scoreGetter(s.docs[j])
+	return s.scoreGetter(s.docs[i]) > s.scoreGetter(s.docs[j])
 }
 func (s sortedDocuments) Swap(i, j int) {
 	s.docs[i], s.docs[j] = s.docs[j], s.docs[i]

--- a/components/document/transformer/reranker/score/score_test.go
+++ b/components/document/transformer/reranker/score/score_test.go
@@ -17,11 +17,12 @@
 package score
 
 import (
-	"github.com/cloudwego/eino/schema"
 	"context"
 	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/cloudwego/eino/schema"
 )
 
 var scoreKey = "score"
@@ -50,13 +51,13 @@ func TestScoreReranker(t *testing.T) {
 			name:   "5cases",
 			config: &Config{ScoreFieldKey: &scoreKey},
 			input:  []*schema.Document{scoredDocs[0], scoredDocs[1], scoredDocs[2], scoredDocs[3], scoredDocs[4]},
-			wanted: []*schema.Document{scoredDocs[0], scoredDocs[2], scoredDocs[4], scoredDocs[3], scoredDocs[1]},
+			wanted: []*schema.Document{scoredDocs[4], scoredDocs[2], scoredDocs[0], scoredDocs[1], scoredDocs[3]},
 		},
 		{
 			name:   "10cases",
 			config: &Config{ScoreFieldKey: &scoreKey},
 			input:  []*schema.Document{scoredDocs[0], scoredDocs[1], scoredDocs[2], scoredDocs[3], scoredDocs[4], scoredDocs[5], scoredDocs[6], scoredDocs[7], scoredDocs[8], scoredDocs[9]},
-			wanted: []*schema.Document{scoredDocs[0], scoredDocs[2], scoredDocs[4], scoredDocs[6], scoredDocs[8], scoredDocs[9], scoredDocs[7], scoredDocs[5], scoredDocs[3], scoredDocs[1]},
+			wanted: []*schema.Document{scoredDocs[9], scoredDocs[7], scoredDocs[5], scoredDocs[3], scoredDocs[1], scoredDocs[0], scoredDocs[2], scoredDocs[4], scoredDocs[6], scoredDocs[8]},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
