### PR TITLE
feat: Add video message part conversion for Alibaba Cloud vision models

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -247,6 +247,14 @@ func toOpenAIMultiContent(mc []schema.ChatMessagePart) ([]openai.ChatMessagePart
 					URL: part.VideoURL.URL,
 				},
 			})
+		case schema.ChatMessagePartTypeVideo:
+			if part.Video == nil {
+				return nil, fmt.Errorf("Video field must not be nil when Type is ChatMessagePartTypeVideo")
+			}
+			ret = append(ret, openai.ChatMessagePart{
+				Type:  openai.ChatMessagePartTypeVideo,
+				Video: part.Video.Video,
+			})
 		default:
 			return nil, fmt.Errorf("unsupported chat message part type: %s", part.Type)
 		}


### PR DESCRIPTION
## Summary
This PR adds conversion support for the new `video` message part type in the OpenAI adapter, enabling seamless integration with Alibaba Cloud's vision model services.

## Background
Alibaba Cloud's Model Studio vision models require video content to be formatted as arrays of base64-encoded frames. This PR completes the video support chain by adding proper conversion logic between eino's schema and the OpenAI client format.

Reference: https://help.aliyun.com/zh/model-studio/vision#80dbf6ca8fh6s

## Dependencies
This PR requires the following upstream changes:
1. **eino framework**: Video message part type schema support
2. **go-openai client**: Video field support in ChatMessagePart

## Changes
### Updated `toOpenAIMultiContent` Function
```go
case schema.ChatMessagePartTypeVideo:
    if part.Video == nil {
        return nil, fmt.Errorf("Video field must not be nil when Type is ChatMessagePartTypeVideo")
    }
    ret = append(ret, openai.ChatMessagePart{
        Type:  openai.ChatMessagePartTypeVideo,
        Video: part.Video.Video,
    })
```