### PR TITLE
feat: langfuse add EndTrace

### DIFF
--- a/libs/acl/langfuse/event.go
+++ b/libs/acl/langfuse/event.go
@@ -56,6 +56,7 @@ type EventType string
 
 const (
 	EventTypeTraceCreate      EventType = "trace-create"
+	EventTypeTraceUpdate      EventType = "trace-update"
 	EventTypeSpanCreate       EventType = "span-create"
 	EventTypeSpanUpdate       EventType = "span-update"
 	EventTypeGenerationCreate EventType = "generation-create"

--- a/libs/acl/langfuse/langfuse.go
+++ b/libs/acl/langfuse/langfuse.go
@@ -32,6 +32,7 @@ const (
 //go:generate mockgen -source=langfuse.go -destination=./mock/langfuse_mock.go -package=mock Langfuse
 type Langfuse interface {
 	CreateTrace(body *TraceEventBody) (string, error)
+	EndTrace(body *TraceEventBody) error
 	CreateSpan(body *SpanEventBody) (string, error)
 	EndSpan(body *SpanEventBody) error
 	CreateGeneration(body *GenerationEventBody) (string, error)
@@ -111,6 +112,21 @@ func (l *langfuseIns) CreateTrace(body *TraceEventBody) (string, error) {
 	return body.ID, l.tm.push(&event{
 		ID:   uuid.NewString(),
 		Type: EventTypeTraceCreate,
+		Body: eventBodyUnion{Trace: body},
+	})
+}
+
+// EndTrace marks an existing span as completed
+//
+// Parameters:
+//   - body: The trace event details to update
+//
+// Returns:
+//   - error: Any error that occurred during the update
+func (l *langfuseIns) EndTrace(body *TraceEventBody) error {
+	return l.tm.push(&event{
+		ID:   uuid.NewString(),
+		Type: EventTypeTraceUpdate,
 		Body: eventBodyUnion{Trace: body},
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
