### PR TITLE
fix: missing thinking block reconstruction in claude

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -563,6 +563,19 @@ func (cm *ChatModel) IsCallbacksEnabled() bool {
 func convSchemaMessage(message *schema.Message) (mp anthropic.MessageParam, err error) {
 
 	var messageParams []anthropic.ContentBlockParamUnion
+
+	// Handle thinking content for assistant messages
+	if message.Role == schema.Assistant {
+		thinkingContent, hasThinking := GetThinking(message)
+		if hasThinking && thinkingContent != "" {
+			signature, hasSignature := GetThinkingSignature(message)
+			if !hasSignature || signature == "" {
+				return mp, fmt.Errorf("thinking content provided but no signature found - signature is required for thinking blocks")
+			}
+			messageParams = append(messageParams, anthropic.NewThinkingBlock(signature, thinkingContent))
+		}
+	}
+
 	if len(message.Content) > 0 {
 		if len(message.ToolCallID) > 0 {
 			messageParams = append(messageParams, anthropic.NewToolResultBlock(message.ToolCallID, message.Content, false))
@@ -656,6 +669,7 @@ func convContentBlockToEinoMsg(
 	case anthropic.ThinkingBlock:
 		setThinking(dstMsg, block.Thinking)
 		dstMsg.ReasoningContent = block.Thinking
+		SetThinkingSignature(dstMsg, block.Signature)
 	case anthropic.RedactedThinkingBlock:
 	default:
 		return fmt.Errorf("unknown anthropic content block type: %T", block)
@@ -719,6 +733,11 @@ func convStreamEvent(event anthropic.MessageStreamEventUnion, streamCtx *streamC
 			result.ToolCalls = append(result.ToolCalls,
 				toolEvent(false, "", "", delta.PartialJSON, streamCtx))
 		case anthropic.SignatureDelta:
+			if currentSig, hasSig := GetThinkingSignature(result); hasSig {
+				SetThinkingSignature(result, currentSig+delta.Signature)
+			} else {
+				SetThinkingSignature(result, delta.Signature)
+			}
 		}
 
 		return result, nil

--- a/components/model/claude/message_extra.go
+++ b/components/model/claude/message_extra.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	keyOfThinking          = "_eino_claude_thinking"
-	keyOfThinkingSignature = "_eino_thinking_signature"
+	keyOfThinkingSignature = "_eino_claude_thinking_signature"
 )
 
 func GetThinking(msg *schema.Message) (string, bool) {

--- a/components/model/claude/message_extra.go
+++ b/components/model/claude/message_extra.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	keyOfThinking = "_eino_claude_thinking"
+	keyOfThinking          = "_eino_claude_thinking"
+	keyOfThinkingSignature = "_eino_thinking_signature"
 )
 
 func GetThinking(msg *schema.Message) (string, bool) {
@@ -44,4 +45,25 @@ func setThinking(msg *schema.Message, reasoningContent string) {
 		msg.Extra = make(map[string]interface{})
 	}
 	msg.Extra[keyOfThinking] = reasoningContent
+}
+
+func GetThinkingSignature(msg *schema.Message) (string, bool) {
+	if msg == nil {
+		return "", false
+	}
+	signature, ok := msg.Extra[keyOfThinkingSignature].(string)
+	if !ok {
+		return "", false
+	}
+	return signature, true
+}
+
+func SetThinkingSignature(msg *schema.Message, signature string) {
+	if msg == nil {
+		return
+	}
+	if msg.Extra == nil {
+		msg.Extra = make(map[string]interface{})
+	}
+	msg.Extra[keyOfThinkingSignature] = signature
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 
## 问题

React Agent 集成 Claude thinking 模式时遇到验证错误：
```
thinking content provided but no signature found - signature is required for thinking blocks
```


Eino claude 在处理 thinking 内容时有两个问题：

1. 接收阶段的签名丢失
在处理 claude 返回的 thinking block时，保存了内容但丢了signature：
```go
// convOutputMessage
case anthropic.ThinkingBlock:
    setThinking(dstMsg, block.Thinking)       
    dstMsg.ReasoningContent = block.Thinking  
    // 没有 block.Signature

// convStreamEvent  
case anthropic.SignatureDelta:
    // 没有处理
```

这个会报 `Invalid 'signature' in 'thinking' block`

**发送阶段的内容忽略**  
`convSchemaMessage()` 在重新发送回给 claude 时跳过了 thinking 相关处理：
```go
func convSchemaMessage(message *schema.Message) {
    // 只处理常规文本
    if len(message.Content) > 0 {
        messageParams = append(messageParams, anthropic.NewTextBlock(message.Content))
    }
    // ReasoningContent (or eino claude thinking) 和signature没加上
}
```

这个会报`Expected 'thinking' or 'redacted_thinking', but found 'text'`

## 解决方案
  
1. 添加sig处理
 
2. 让 `convSchemaMessage()` 正确重建完整的 thinking 块


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
