### PR TITLE
feat(mcp): Add meta parameters to CallTool

### DIFF
--- a/components/tool/mcp/examples/mcp.go
+++ b/components/tool/mcp/examples/mcp.go
@@ -46,7 +46,7 @@ func main() {
 		fmt.Println("Name:", info.Name)
 		fmt.Println("Desc:", info.Desc)
 		result, err := mcpTool.(tool.InvokableTool).InvokableRun(ctx, `{"operation":"add", "x":1, "y":1}`, mcpp.WithMeta(&mcp.Meta{
-			AdditionalFields: map[string]any{"test": "test"},
+			AdditionalFields: map[string]any{"metadata2": "metadata2"},
 		}))
 		if err != nil {
 			log.Fatal(err)
@@ -78,7 +78,9 @@ func getMCPTool(ctx context.Context) []tool.BaseTool {
 		log.Fatal(err)
 	}
 
-	tools, err := mcpp.GetTools(ctx, &mcpp.Config{Cli: cli})
+	tools, err := mcpp.GetTools(ctx, &mcpp.Config{Cli: cli, Meta: &mcp.Meta{
+		AdditionalFields: map[string]any{"metadata1": "metadata1"},
+	}})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/components/tool/mcp/option.go
+++ b/components/tool/mcp/option.go
@@ -18,14 +18,22 @@ package mcp
 
 import (
 	"github.com/cloudwego/eino/components/tool"
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 type mcpOptions struct {
 	customHeaders map[string]string
+	meta          *mcp.Meta
 }
 
 func WithCustomHeaders(m map[string]string) tool.Option {
 	return tool.WrapImplSpecificOptFn(func(o *mcpOptions) {
 		o.customHeaders = m
+	})
+}
+
+func WithMeta(meta *mcp.Meta) tool.Option {
+	return tool.WrapImplSpecificOptFn(func(o *mcpOptions) {
+		o.meta = meta
 	})
 }


### PR DESCRIPTION
Spring ai 1.1.0-SNAPSHOT supports getting the _meta parameter in tools/call, but eino-ext does not support it yet. It is not possible to pass meta from the mcp client created by eino-ext to the mcp server created by spring ai. Therefore, MetaOptions is added to pass meta parameters.
<img width="1452" height="875" alt="image" src="https://github.com/user-attachments/assets/d0d7b1c3-a69e-4ba7-8916-a2c7fe6166f7" />
