### PR TITLE
fix(embedding): Add batch size configuration to support batch

### DIFF
--- a/components/embedding/openai/embedding.go
+++ b/components/embedding/openai/embedding.go
@@ -85,6 +85,10 @@ type EmbeddingConfig struct {
 	// User is a unique identifier representing your end-user
 	// Optional. Helps OpenAI monitor and detect abuse
 	User *string `json:"user,omitempty"`
+
+	// BatchSize specifies the number of texts to embed in a single request
+	// Optional.
+	BatchSize int `json:"batch_size,omitempty"`
 }
 
 var _ embedding.Embedder = (*Embedder)(nil)
@@ -114,6 +118,7 @@ func NewEmbedder(ctx context.Context, config *EmbeddingConfig) (*Embedder, error
 			EncodingFormat: config.EncodingFormat,
 			Dimensions:     config.Dimensions,
 			User:           config.User,
+			BatchSize:      config.BatchSize,
 		}
 	}
 	cli, err := openai.NewEmbeddingClient(ctx, nConf)

--- a/libs/acl/openai/embedding_test.go
+++ b/libs/acl/openai/embedding_test.go
@@ -35,6 +35,7 @@ func TestEmbedStrings(t *testing.T) {
 		APIKey:     "{your-api-key}",
 		APIVersion: "2024-06-01",
 		Model:      "gpt-4o-2024-05-13",
+		BatchSize:  100,
 	})
 
 	assert.NoError(t, err)


### PR DESCRIPTION
为openai的embedding组件增加一个可选的BatchSize参数
作用：避免传入长文本列表时，API服务端返回超出并发处理数量限制问题。