### PR TITLE
feat(ark): report thinking in callback

### DIFF
--- a/components/model/ark/chat_completion_api.go
+++ b/components/model/ark/chat_completion_api.go
@@ -109,6 +109,7 @@ func (cm *completionAPIChatModel) Generate(ctx context.Context, in []*schema.Mes
 		Messages: in,
 		Tools:    tools, // join tool info from call options
 		Config:   reqConf,
+		Extra:    map[string]any{callbackExtraKeyThinking: arkOpts.thinking},
 	})
 
 	defer func() {
@@ -137,6 +138,7 @@ func (cm *completionAPIChatModel) Generate(ctx context.Context, in []*schema.Mes
 		Message:    outMsg,
 		Config:     reqConf,
 		TokenUsage: cm.toModelCallbackUsage(outMsg.ResponseMeta),
+		Extra:      map[string]any{callbackExtraKeyThinking: arkOpts.thinking},
 	})
 
 	return outMsg, nil
@@ -186,6 +188,7 @@ func (cm *completionAPIChatModel) Stream(ctx context.Context, in []*schema.Messa
 		Messages: in,
 		Tools:    tools,
 		Config:   reqConf,
+		Extra:    map[string]any{callbackExtraKeyThinking: arkOpts.thinking},
 	})
 	defer func() {
 		if err != nil {
@@ -242,6 +245,7 @@ func (cm *completionAPIChatModel) Stream(ctx context.Context, in []*schema.Messa
 				Message:    msg,
 				Config:     reqConf,
 				TokenUsage: cm.toModelCallbackUsage(msg.ResponseMeta),
+				Extra:      map[string]any{callbackExtraKeyThinking: arkOpts.thinking},
 			}, nil)
 			if closed {
 				return

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -76,6 +76,7 @@ func (cm *responsesAPIChatModel) Generate(ctx context.Context, input []*schema.M
 		Messages: input,
 		Tools:    tools,
 		Config:   config,
+		Extra:    map[string]any{callbackExtraKeyThinking: specOptions.thinking},
 	})
 
 	defer func() {
@@ -98,6 +99,7 @@ func (cm *responsesAPIChatModel) Generate(ctx context.Context, input []*schema.M
 		Message:    outMsg,
 		Config:     config,
 		TokenUsage: cm.toModelTokenUsage(resp.Usage),
+		Extra:      map[string]any{callbackExtraKeyThinking: specOptions.thinking},
 	})
 
 	return outMsg, nil
@@ -127,6 +129,7 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 		Messages: input,
 		Tools:    tools,
 		Config:   config,
+		Extra:    map[string]any{callbackExtraKeyThinking: specOptions.thinking},
 	})
 
 	defer func() {
@@ -159,6 +162,10 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 
 	ctx, nsr := callbacks.OnEndWithStreamOutput(ctx, schema.StreamReaderWithConvert(sr,
 		func(src *model.CallbackOutput) (callbacks.CallbackOutput, error) {
+			if src.Extra == nil {
+				src.Extra = make(map[string]any)
+			}
+			src.Extra[callbackExtraKeyThinking] = specOptions.thinking
 			return src, nil
 		}))
 

--- a/components/model/ark/types.go
+++ b/components/model/ark/types.go
@@ -54,3 +54,7 @@ const (
 	cachingEnabled  caching = "enabled"
 	cachingDisabled caching = "disabled"
 )
+
+const (
+	callbackExtraKeyThinking = "thinking"
+)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
