### PR TITLE
feat(model_ark): add InvalidateMessageCaches and GetCacheExpiration method

### DIFF
--- a/components/model/ark/go.mod
+++ b/components/model/ark/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/openai/openai-go v1.10.1
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.11.1
-	github.com/volcengine/volcengine-go-sdk v1.1.37
-
+	github.com/volcengine/volcengine-go-sdk v1.1.41
 )
 
 require (

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -175,8 +175,8 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.1.37 h1:5TvqawYmqO3zIx9dJmzq7fYHypacDoVmUL8Y0NQ4Kxw=
-github.com/volcengine/volcengine-go-sdk v1.1.37/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.1.41 h1:6y/ArIgmoKxl2PHc0uo3n6YGuTrreoiRO0/QzazHjFw=
+github.com/volcengine/volcengine-go-sdk v1.1.41/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/ark/message_extra.go
+++ b/components/model/ark/message_extra.go
@@ -22,15 +22,15 @@ import (
 )
 
 const (
-	keyOfRequestID        = "ark-request-id"
-	keyOfReasoningContent = "ark-reasoning-content"
-	keyOfModelName        = "ark-model-name"
-	videoURLFPS           = "ark-model-video-url-fps"
-	keyOfContextID        = "ark-context-id"
-	keyOfResponseID       = "ark-response-id"
-	keyOfResponseCaching  = "ark-response-caching"
-	keyOfServiceTier      = "ark-service-tier"
-	ImageSizeKey          = "seedream-image-size"
+	keyOfRequestID             = "ark-request-id"
+	keyOfReasoningContent      = "ark-reasoning-content"
+	keyOfModelName             = "ark-model-name"
+	videoURLFPS                = "ark-model-video-url-fps"
+	keyOfContextID             = "ark-context-id"
+	keyOfResponseID            = "ark-response-id"
+	keyOfResponseCacheExpireAt = "ark-response-cache-expire-at"
+	keyOfServiceTier           = "ark-service-tier"
+	ImageSizeKey               = "seedream-image-size"
 )
 
 type arkRequestID string
@@ -38,6 +38,7 @@ type arkModelName string
 type arkServiceTier string
 type arkResponseID string
 type arkContextID string
+type arkResponseCacheExpireAt int64
 
 func init() {
 	compose.RegisterStreamChunkConcatFunc(func(chunks []arkRequestID) (final arkRequestID, err error) {
@@ -63,14 +64,6 @@ func init() {
 		return chunks[len(chunks)-1], nil
 	})
 	schema.RegisterName[arkServiceTier]("_eino_ext_ark_service_tier")
-
-	compose.RegisterStreamChunkConcatFunc(func(chunks []caching) (final caching, err error) {
-		if len(chunks) == 0 {
-			return "", nil
-		}
-		return chunks[len(chunks)-1], nil
-	})
-	schema.RegisterName[caching]("_eino_ext_ark_response_caching")
 
 	compose.RegisterStreamChunkConcatFunc(func(chunks []arkContextID) (final arkContextID, err error) {
 		if len(chunks) == 0 {
@@ -99,6 +92,14 @@ func init() {
 		return "", nil
 	})
 	schema.RegisterName[arkResponseID]("_eino_ext_ark_response_id")
+
+	compose.RegisterStreamChunkConcatFunc(func(chunks []arkResponseCacheExpireAt) (final arkResponseCacheExpireAt, err error) {
+		if len(chunks) == 0 {
+			return 0, nil
+		}
+		return chunks[len(chunks)-1], nil
+	})
+	schema.RegisterName[arkResponseCacheExpireAt]("_eino_ext_ark_response_cache_expire_at")
 }
 
 func GetArkRequestID(msg *schema.Message) string {
@@ -151,6 +152,28 @@ func setContextID(msg *schema.Message, contextID string) {
 	setMsgExtra(msg, keyOfContextID, arkContextID(contextID))
 }
 
+// InvalidateMessageCaches disables caching for the specified messages.
+// When a message is modified, ARK invalidates caches for that message and all subsequent ones.
+// Call this to mark those message caches as invalid.
+func InvalidateMessageCaches(messages []*schema.Message) error {
+	for _, msg := range messages {
+		expireAtSec, ok := getCacheExpiration(msg)
+		if !ok || expireAtSec <= 0 {
+			continue
+		}
+
+		// there may be concurrency
+		extra := make(map[string]any, len(msg.Extra))
+		for k, v := range msg.Extra {
+			extra[k] = v
+		}
+
+		delete(extra, keyOfResponseCacheExpireAt)
+		msg.Extra = extra
+	}
+	return nil
+}
+
 // GetResponseID returns the response ID from the message.
 // Available only for ResponsesAPI responses.
 func GetResponseID(msg *schema.Message) (string, bool) {
@@ -158,8 +181,8 @@ func GetResponseID(msg *schema.Message) (string, bool) {
 	if ok {
 		return string(responseID_), true
 	}
-	// Since registering the concat logic requires defining `arkResponseID` type,
-	// this fallback logic needs to be retained to be compatible with `string` type.
+	// When the user serializes and deserializes the message,
+	// the type will be lost and compatibility with the string type is required.
 	responseIDStr, ok := getMsgExtraValue[string](msg, keyOfResponseID)
 	if !ok {
 		return "", false
@@ -171,23 +194,22 @@ func setResponseID(msg *schema.Message, responseID string) {
 	setMsgExtra(msg, keyOfResponseID, arkResponseID(responseID))
 }
 
-func getResponseCaching(msg *schema.Message) (string, bool) {
-	caching_, ok := getMsgExtraValue[caching](msg, keyOfResponseCaching)
+// getCacheExpiration returns the cache expiration time in seconds.
+// Only available for ResponsesAPI responses.
+func getCacheExpiration(msg *schema.Message) (expireAtSec int64, ok bool) {
+	expireAtSec_, ok := getMsgExtraValue[arkResponseCacheExpireAt](msg, keyOfResponseCacheExpireAt)
 	if ok {
-		return string(caching_), true
+		return int64(expireAtSec_), true
 	}
-	// When the user serializes and deserializes the message,
-	// the type will be lost and compatibility with the string type is required.
-	cachingStr, ok := getMsgExtraValue[string](msg, keyOfResponseCaching)
+	expireAtSec, ok = getMsgExtraValue[int64](msg, keyOfResponseCacheExpireAt)
 	if ok {
-		return cachingStr, true
+		return expireAtSec, true
 	}
-	return "", false
+	return 0, false
 }
 
-// setResponseCaching sets the cached status of the response.
-func setResponseCaching(msg *schema.Message, caching caching) {
-	setMsgExtra(msg, keyOfResponseCaching, caching)
+func setResponseCacheExpireAt(msg *schema.Message, expireAt arkResponseCacheExpireAt) {
+	setMsgExtra(msg, keyOfResponseCacheExpireAt, expireAt)
 }
 
 func getMsgExtraValue[T any](msg *schema.Message, key string) (T, bool) {

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -61,12 +61,12 @@ func (cm *responsesAPIChatModel) Generate(ctx context.Context, input []*schema.M
 		return nil, err
 	}
 
-	req, reqOpts, err := cm.genRequestAndOptions(input, options, specOptions)
+	reqParams, err := cm.genRequestAndOptions(input, options, specOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create generate request: %w", err)
 	}
 
-	config := cm.toCallbackConfig(req)
+	config := cm.toCallbackConfig(reqParams.req)
 
 	tools := cm.rawTools
 	if options.Tools != nil {
@@ -86,12 +86,12 @@ func (cm *responsesAPIChatModel) Generate(ctx context.Context, input []*schema.M
 		}
 	}()
 
-	resp, err := cm.client.New(ctx, req, reqOpts...)
+	resp, err := cm.client.New(ctx, *reqParams.req, reqParams.opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create generate request: %w", err)
 	}
 
-	outMsg, err = cm.toOutputMessage(resp, req.Store.Value)
+	outMsg, err = cm.toOutputMessage(resp, reqParams.cache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert output to schema.Message: %w", err)
 	}
@@ -114,12 +114,12 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 		return nil, err
 	}
 
-	req, reqOpts, err := cm.genRequestAndOptions(input, options, specOptions)
+	reqParams, err := cm.genRequestAndOptions(input, options, specOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create stream request: %w", err)
 	}
 
-	config := cm.toCallbackConfig(req)
+	config := cm.toCallbackConfig(reqParams.req)
 
 	tools := cm.rawTools
 	if options.Tools != nil {
@@ -139,7 +139,7 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 		}
 	}()
 
-	streamResp := cm.client.NewStreaming(ctx, req, reqOpts...)
+	streamResp := cm.client.NewStreaming(ctx, *reqParams.req, reqParams.opts...)
 	if streamResp.Err() != nil {
 		return nil, fmt.Errorf("failed to create stream request: %w", streamResp.Err())
 	}
@@ -157,7 +157,7 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 			sw.Close()
 		}()
 
-		cm.receivedStreamResponse(streamResp, config, req.Store.Value, sw)
+		cm.receivedStreamResponse(streamResp, config, reqParams.cache, sw)
 
 	}()
 
@@ -183,17 +183,24 @@ func (cm *responsesAPIChatModel) Stream(ctx context.Context, input []*schema.Mes
 	return outStream, nil
 }
 
-func (cm *responsesAPIChatModel) setStreamChunkDefaultExtra(msg *schema.Message, response responses.Response, enableCache bool) {
-	if enableCache {
-		setResponseCaching(msg, cachingEnabled)
+func (cm *responsesAPIChatModel) setStreamChunkDefaultExtra(msg *schema.Message, response responses.Response,
+	cacheConfig *cacheConfig) {
+
+	if cacheConfig.Enabled {
+		setResponseCacheExpireAt(msg, arkResponseCacheExpireAt(ptrFromOrZero(cacheConfig.ExpireAt)))
 	}
 	setContextID(msg, response.ID)
 	setResponseID(msg, response.ID)
 	setServiceTier(msg, string(response.ServiceTier))
 }
 
+type cacheConfig struct {
+	Enabled  bool
+	ExpireAt *int64
+}
+
 func (cm *responsesAPIChatModel) receivedStreamResponse(streamResp *ssestream.Stream[responses.ResponseStreamEventUnion],
-	config *model.Config, enableCache bool, sw *schema.StreamWriter[*model.CallbackOutput]) {
+	config *model.Config, cache *cacheConfig, sw *schema.StreamWriter[*model.CallbackOutput]) {
 
 	var toolCallMetaMsg *schema.Message
 
@@ -220,7 +227,7 @@ Outer:
 				Role: schema.Assistant,
 			}
 
-			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, enableCache)
+			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
 			continue
@@ -228,7 +235,7 @@ Outer:
 		case responses.ResponseCompletedEvent:
 			msg := cm.handleCompletedStreamEvent(asEvent)
 
-			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, enableCache)
+			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
 			break Outer
@@ -240,14 +247,14 @@ Outer:
 		case responses.ResponseIncompleteEvent:
 			msg := cm.handleIncompleteStreamEvent(asEvent)
 
-			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, enableCache)
+			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
 			break Outer
 
 		case responses.ResponseFailedEvent:
 			msg := cm.handleFailedStreamEvent(asEvent)
-			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, enableCache)
+			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
 			break Outer
@@ -433,8 +440,14 @@ func (cm *responsesAPIChatModel) toTools(tis []*schema.ToolInfo) ([]responses.To
 	return tools, nil
 }
 
-func (cm *responsesAPIChatModel) genRequestAndOptions(in []*schema.Message, options *model.Options, specOptions *arkOptions) (req responses.ResponseNewParams,
-	reqOpts []option.RequestOption, err error) {
+type responsesAPIRequestParams struct {
+	req   *responses.ResponseNewParams
+	opts  []option.RequestOption
+	cache *cacheConfig
+}
+
+func (cm *responsesAPIChatModel) genRequestAndOptions(in []*schema.Message, options *model.Options,
+	specOptions *arkOptions) (reqParams *responsesAPIRequestParams, err error) {
 
 	var text *responses.ResponseTextConfigParam
 	if cm.responseFormat != nil {
@@ -450,37 +463,39 @@ func (cm *responsesAPIChatModel) genRequestAndOptions(in []*schema.Message, opti
 		}
 	}
 
-	req = responses.ResponseNewParams{
-		Text:            ptrFromOrZero(text),
-		Model:           ptrFromOrZero(options.Model),
-		MaxOutputTokens: newOpenaiIntOpt(options.MaxTokens),
-		Temperature:     newOpenaiFloatOpt(options.Temperature),
-		TopP:            newOpenaiFloatOpt(options.TopP),
-		ServiceTier:     responses.ResponseNewParamsServiceTier(ptrFromOrZero(cm.serviceTier)),
+	reqParams = &responsesAPIRequestParams{
+		req: &responses.ResponseNewParams{
+			Text:            ptrFromOrZero(text),
+			Model:           ptrFromOrZero(options.Model),
+			MaxOutputTokens: newOpenaiIntOpt(options.MaxTokens),
+			Temperature:     newOpenaiFloatOpt(options.Temperature),
+			TopP:            newOpenaiFloatOpt(options.TopP),
+			ServiceTier:     responses.ResponseNewParamsServiceTier(ptrFromOrZero(cm.serviceTier)),
+		},
 	}
 
-	var in_ []*schema.Message
-	if in_, req, reqOpts, err = cm.populateCache(in, req, specOptions, reqOpts); err != nil {
-		return req, nil, err
+	in_ := in
+	if in_, reqParams, err = cm.populateCache(in, reqParams, specOptions); err != nil {
+		return nil, err
 	}
 
-	if err = cm.populateInput(&req, in_); err != nil {
-		return req, nil, err
+	if err = cm.populateInput(reqParams.req, in_); err != nil {
+		return nil, err
 	}
 
-	if err = cm.populateTools(&req, options.Tools); err != nil {
-		return req, nil, err
+	if err = cm.populateTools(reqParams.req, options.Tools); err != nil {
+		return nil, err
 	}
 
 	for k, v := range specOptions.customHeaders {
-		reqOpts = append(reqOpts, option.WithHeaderAdd(k, v))
+		reqParams.opts = append(reqParams.opts, option.WithHeaderAdd(k, v))
 	}
 
 	if specOptions.thinking != nil {
-		reqOpts = append(reqOpts, option.WithJSONSet("thinking", specOptions.thinking))
+		reqParams.opts = append(reqParams.opts, option.WithJSONSet("thinking", specOptions.thinking))
 	}
 
-	return req, reqOpts, nil
+	return reqParams, nil
 }
 
 func (cm *responsesAPIChatModel) checkOptions(mOpts *model.Options, _ *arkOptions) error {
@@ -490,8 +505,8 @@ func (cm *responsesAPIChatModel) checkOptions(mOpts *model.Options, _ *arkOption
 	return nil
 }
 
-func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, req responses.ResponseNewParams, arkOpts *arkOptions,
-	reqOpts []option.RequestOption) ([]*schema.Message, responses.ResponseNewParams, []option.RequestOption, error) {
+func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, reqParams *responsesAPIRequestParams, arkOpts *arkOptions,
+) ([]*schema.Message, *responsesAPIRequestParams, error) {
 
 	var (
 		store       = param.NewOpt(false)
@@ -534,6 +549,8 @@ func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, req respons
 		inputIdx  int
 	)
 
+	now := time.Now().Unix()
+
 	// If the user implements session caching with ContextID,
 	// ContextID and ResponseID will exist at the same time.
 	// Using ContextID is prioritized to maintain compatibility with the old logic.
@@ -542,7 +559,7 @@ func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, req respons
 		for i := len(in) - 1; i >= 0; i-- {
 			msg := in[i]
 			inputIdx = i
-			if caching_, _ := getResponseCaching(msg); caching_ != string(cachingEnabled) {
+			if expireAtSec, ok := getCacheExpiration(msg); !ok || expireAtSec < now {
 				continue
 			}
 			if id, ok := GetResponseID(msg); ok {
@@ -554,7 +571,7 @@ func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, req respons
 
 	if preRespID != nil {
 		if inputIdx+1 >= len(in) {
-			return in, req, reqOpts, fmt.Errorf("not found incremental input after ResponseID")
+			return in, nil, fmt.Errorf("not found incremental input after ResponseID")
 		}
 		in = in[inputIdx+1:]
 	}
@@ -567,18 +584,29 @@ func (cm *responsesAPIChatModel) populateCache(in []*schema.Message, req respons
 		}
 	}
 
-	req.PreviousResponseID = newOpenaiStringOpt(preRespID)
-	req.Store = store
+	reqParams.req.PreviousResponseID = newOpenaiStringOpt(preRespID)
+	reqParams.req.Store = store
 
 	if cacheTTL != nil {
-		reqOpts = append(reqOpts, option.WithJSONSet("expire_at", time.Now().Unix()+int64(*cacheTTL)))
+		reqParams.opts = append(reqParams.opts, option.WithJSONSet("expire_at", now+int64(*cacheTTL)))
 	}
 
-	reqOpts = append(reqOpts, option.WithJSONSet("caching", map[string]any{
+	reqParams.opts = append(reqParams.opts, option.WithJSONSet("caching", map[string]any{
 		"type": cacheStatus,
 	}))
 
-	return in, req, reqOpts, nil
+	reqParams.cache = &cacheConfig{
+		Enabled: cacheStatus == cachingEnabled,
+		ExpireAt: func() *int64 {
+			// TODO: After changing to using ARK responses sdk, use the `expire_at` returned by the response
+			if cacheTTL == nil { // Default TTL is 3 days
+				return ptrOf(now + 259200)
+			}
+			return ptrOf(now + int64(*cacheTTL))
+		}(),
+	}
+
+	return in, reqParams, nil
 }
 
 func (cm *responsesAPIChatModel) populateInput(req *responses.ResponseNewParams, in []*schema.Message) error {
@@ -800,7 +828,7 @@ func (cm *responsesAPIChatModel) populateTools(req *responses.ResponseNewParams,
 	return nil
 }
 
-func (cm *responsesAPIChatModel) toCallbackConfig(req responses.ResponseNewParams) *model.Config {
+func (cm *responsesAPIChatModel) toCallbackConfig(req *responses.ResponseNewParams) *model.Config {
 	return &model.Config{
 		Model:       req.Model,
 		MaxTokens:   int(req.MaxOutputTokens.Value),
@@ -809,7 +837,7 @@ func (cm *responsesAPIChatModel) toCallbackConfig(req responses.ResponseNewParam
 	}
 }
 
-func (cm *responsesAPIChatModel) toOutputMessage(resp *responses.Response, enableCache bool) (*schema.Message, error) {
+func (cm *responsesAPIChatModel) toOutputMessage(resp *responses.Response, cache *cacheConfig) (*schema.Message, error) {
 	msg := &schema.Message{
 		Role: schema.Assistant,
 		ResponseMeta: &schema.ResponseMeta{
@@ -818,8 +846,8 @@ func (cm *responsesAPIChatModel) toOutputMessage(resp *responses.Response, enabl
 		},
 	}
 
-	if enableCache {
-		setResponseCaching(msg, cachingEnabled)
+	if cache != nil && cache.Enabled {
+		setResponseCacheExpireAt(msg, arkResponseCacheExpireAt(ptrFromOrZero(cache.ExpireAt)))
 	}
 	setContextID(msg, resp.ID)
 	setResponseID(msg, resp.ID)
@@ -845,17 +873,41 @@ func (cm *responsesAPIChatModel) toOutputMessage(resp *responses.Response, enabl
 	for _, item := range resp.Output {
 		switch asItem := item.AsAny().(type) {
 		case responses.ResponseOutputMessage:
-			if len(asItem.Content) == 0 {
-				return nil, fmt.Errorf("received empty message content from ARK")
+			isMultiContent := len(asItem.Content) > 1
+
+			for _, content := range asItem.Content {
+				text := ""
+
+				switch asContent := content.AsAny().(type) {
+				case responses.ResponseOutputText:
+					text = asContent.Text
+				case responses.ResponseOutputRefusal:
+					text = asContent.Refusal
+				default:
+					return nil, fmt.Errorf("unsupported content type: %T", asContent)
+				}
+
+				if !isMultiContent {
+					msg.Content = text
+				} else {
+					msg.AssistantGenMultiContent = append(msg.AssistantGenMultiContent, schema.MessageOutputPart{
+						Type: schema.ChatMessagePartTypeText,
+						Text: text,
+					})
+				}
 			}
-			msg.Content = asItem.Content[0].Text
 
 		case responses.ResponseReasoningItem:
-			if len(asItem.Summary) == 0 {
-				continue
+			for _, s := range asItem.Summary {
+				if s.Text == "" {
+					continue
+				}
+				if msg.ReasoningContent == "" {
+					msg.ReasoningContent = s.Text
+					continue
+				}
+				msg.ReasoningContent = fmt.Sprintf("%s\n\n%s", msg.ReasoningContent, s.Text)
 			}
-			msg.ReasoningContent = asItem.Summary[0].Text
-			setReasoningContent(msg, msg.ReasoningContent)
 
 		case responses.ResponseFunctionToolCall:
 			msg.ToolCalls = append(msg.ToolCalls, schema.ToolCall{


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Added `InvalidateMessageCaches` method to allow users to invalidate message caches.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixed the issue of cache expiration not being processed during automatic response caching.

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
