### PR TITLE
fix(sandbox): use test -d to check directories in IsDirectory

### DIFF
--- a/components/tool/commandline/sandbox/sandbox.go
+++ b/components/tool/commandline/sandbox/sandbox.go
@@ -322,7 +322,7 @@ func (s *DockerSandbox) IsDirectory(ctx context.Context, path string) (bool, err
 	}
 
 	// Use stat command to check path type
-	cmd := []string{"test", "-e", resolvedPath}
+	cmd := []string{"test", "-d", resolvedPath}
 	cmdOutput, err := s.RunCommand(ctx, cmd)
 	if err != nil {
 		return false, fmt.Errorf("failed to check path existence: %w", err)


### PR DESCRIPTION
Use `test -d` instead of `test -e` to ensure IsDirectory returns true only for directories. This fixes a bug where regular files were treated as directories.