### PR TITLE
feat(a2a): add jsonrpc id gen config

### DIFF
--- a/a2a/transport/jsonrpc/client/option.go
+++ b/a2a/transport/jsonrpc/client/option.go
@@ -17,13 +17,15 @@
 package client
 
 import (
+	"github.com/cloudwego/eino-ext/a2a/transport/jsonrpc/core"
 	"github.com/cloudwego/eino-ext/a2a/transport/jsonrpc/pkg/transport"
 	"github.com/cloudwego/eino-ext/a2a/transport/jsonrpc/pkg/transport/http"
 )
 
 type Options struct {
-	url string
-	hdl transport.ClientTransportHandler
+	url   string
+	hdl   transport.ClientTransportHandler
+	idGen core.IDGenerator
 }
 
 func defaultOptions() Options {
@@ -43,5 +45,11 @@ func WithURL(url string) Option {
 func WithTransportHandler(hdl transport.ClientTransportHandler) Option {
 	return func(options *Options) {
 		options.hdl = hdl
+	}
+}
+
+func WithJSONRPCIDGenerator(gen core.IDGenerator) Option {
+	return func(options *Options) {
+		options.idGen = gen
 	}
 }

--- a/a2a/transport/jsonrpc/client/option_test.go
+++ b/a2a/transport/jsonrpc/client/option_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +47,104 @@ func TestWithOptions(t *testing.T) {
 	}
 	assert.Equal(t, testURL, defOptions.url)
 	assert.Equal(t, testHdl, defOptions.hdl)
+}
+
+func TestWithJSONRPCIDGenerator(t *testing.T) {
+	ctx := context.Background()
+	// default
+	cth := &mockClientTransportHandler{func(_ context.Context, _ conninfo.Peer) (core.Transport, error) {
+		return &mockTransport{
+			cr: &mockClientRounder{func(_ context.Context, m core.Message) (core.MessageReader, error) {
+				req := m.(*core.Request)
+				assert.NotNil(t, req.ID.Str)
+				return &mockMessageReader{func(ctx context.Context) (core.Message, error) {
+					return &core.Response{
+						Version: req.Version,
+						ID:      req.ID,
+						Result:  []byte("{}"),
+					}, nil
+				}}, nil
+			}},
+		}, nil
+	}}
+	cli, err := NewClient(WithTransportHandler(cth), WithURL("123"))
+	assert.NoError(t, err)
+	conn, err := cli.NewConnection(ctx)
+	assert.NoError(t, err)
+	var resp json.RawMessage
+	err = conn.Call(ctx, "", "", &resp)
+	assert.NoError(t, err)
+
+	// with id gen
+	cth = &mockClientTransportHandler{func(_ context.Context, _ conninfo.Peer) (core.Transport, error) {
+		return &mockTransport{
+			cr: &mockClientRounder{func(_ context.Context, m core.Message) (core.MessageReader, error) {
+				req := m.(*core.Request)
+				assert.NotNil(t, req.ID.Num)
+				return &mockMessageReader{func(ctx context.Context) (core.Message, error) {
+					return &core.Response{
+						Version: req.Version,
+						ID:      req.ID,
+						Result:  []byte("{}"),
+					}, nil
+				}}, nil
+			}},
+		}, nil
+	}}
+	cli, err = NewClient(WithTransportHandler(cth), WithURL("123"), WithJSONRPCIDGenerator(func(ctx context.Context) core.ID {
+		var num = 1.0
+		return core.ID{Num: &num}
+	}))
+	assert.NoError(t, err)
+	conn, err = cli.NewConnection(ctx)
+	assert.NoError(t, err)
+	err = conn.Call(ctx, "", "", &resp)
+	assert.NoError(t, err)
+}
+
+type mockClientTransportHandler struct {
+	f func(ctx context.Context, peer conninfo.Peer) (core.Transport, error)
+}
+
+func (m *mockClientTransportHandler) NewTransport(ctx context.Context, peer conninfo.Peer) (core.Transport, error) {
+	return m.f(ctx, peer)
+}
+
+type mockTransport struct {
+	cr core.ClientRounder
+	sr core.ServerRounder
+}
+
+func (m *mockTransport) ClientCapability() (core.ClientRounder, bool) {
+	if m.cr == nil {
+		return nil, false
+	}
+	return m.cr, true
+}
+
+func (m *mockTransport) ServerCapability() (core.ServerRounder, bool) {
+	if m.sr == nil {
+		return nil, false
+	}
+	return m.sr, true
+}
+
+type mockClientRounder struct {
+	f func(ctx context.Context, msg core.Message) (core.MessageReader, error)
+}
+
+func (m *mockClientRounder) Round(ctx context.Context, msg core.Message) (core.MessageReader, error) {
+	return m.f(ctx, msg)
+}
+
+type mockMessageReader struct {
+	f func(ctx context.Context) (core.Message, error)
+}
+
+func (m *mockMessageReader) Read(ctx context.Context) (core.Message, error) {
+	return m.f(ctx)
+}
+
+func (m *mockMessageReader) Close() error {
+	return nil
 }

--- a/a2a/transport/jsonrpc/core/option.go
+++ b/a2a/transport/jsonrpc/core/option.go
@@ -43,6 +43,8 @@ type Options struct {
 	tracer   tracer.Tracer
 	cliTrans ClientRounder
 	srvTrans ServerRounder
+
+	idGen IDGenerator
 }
 
 func defaultOptions() Options {
@@ -109,5 +111,11 @@ func WithCallMiddleware(mw CallMiddleware) Option {
 func WithHandleMiddleware(mw HandleMiddleware) Option {
 	return func(options *Options) {
 		options.hdlMWs = append(options.hdlMWs, mw)
+	}
+}
+
+func WithJSONRPCIDGenerator(gen IDGenerator) Option {
+	return func(options *Options) {
+		options.idGen = gen
 	}
 }

--- a/a2a/transport/jsonrpc/core/rpc_call.go
+++ b/a2a/transport/jsonrpc/core/rpc_call.go
@@ -81,7 +81,7 @@ func (conn *connection) deleteOutBound(id ID) {
 	delete(conn.outbounds, id.String())
 }
 
-func allocateId() ID {
+func allocateId(_ context.Context) ID {
 	return NewIDFromString(uuid.New().String())
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
