### PR TITLE
feat(gemini): Use default value for GEMINI_MODEL in example/generate

### DIFF
--- a/components/model/gemini/examples/generate/generate.go
+++ b/components/model/gemini/examples/generate/generate.go
@@ -30,7 +30,10 @@ import (
 
 func main() {
 	apiKey := os.Getenv("GEMINI_API_KEY")
-	modelName := os.Getenv("GEMINI_MODEL")
+	modelName, ok := os.LookupEnv("GEMINI_MODEL")
+	if !ok {
+		modelName = "gemini-2.5-flash"
+	}
 
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{


### PR DESCRIPTION
When the GEMINI_MODEL environment variable is not set in the generate example, it now defaults to gemini-2.5-flash. This prevents errors when running the example without this environment variable configured.