### PR TITLE
add docker_sandbox inspect

### DIFF
--- a/components/tool/commandline/sandbox/sandbox.go
+++ b/components/tool/commandline/sandbox/sandbox.go
@@ -450,6 +450,11 @@ func (s *DockerSandbox) safeResolvePath(path string) (string, error) {
 	return resolved, nil
 }
 
+// Inspect retrieves container inspection information
+func (s *DockerSandbox) Inspect() (container.InspectResponse, error) {
+	return s.client.ContainerInspect(context.Background(), s.containerID)
+}
+
 // readFromTar reads file content from tar stream
 func readFromTar(reader io.Reader) ([]byte, error) {
 	tr := tar.NewReader(reader)


### PR DESCRIPTION
#### What type of PR is this?
This PR introduces a new Inspect method in the DockerSandbox struct, which wraps the ContainerInspect API from the Docker client to expose container inspection information. This enables users to retrieve detailed runtime metadata of the sandboxed container, such as network settings, mounted volumes, and process status. 

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
新增了 Inspect 方法，属于为 DockerSandbox 添加新功能
有需要管理沙箱可以获取docker沙箱的信息存储到数据库后使用docker客户端管理


#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
