### PR TITLE
fix(model_ark): stream reception was terminated prematurely when using caching

### DIFF
--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -214,7 +214,6 @@ func (cm *responsesAPIChatModel) receivedStreamResponse(streamResp *ssestream.St
 		}
 	}()
 
-Outer:
 	for streamResp.Next() {
 		cur := streamResp.Current()
 
@@ -242,11 +241,8 @@ Outer:
 			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
-			break Outer
-
 		case responses.ResponseErrorEvent:
 			sw.Send(nil, fmt.Errorf("received error: %s", asEvent.Message))
-			break Outer
 
 		case responses.ResponseIncompleteEvent:
 			msg := cm.handleIncompleteStreamEvent(asEvent)
@@ -254,14 +250,10 @@ Outer:
 			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
 
-			break Outer
-
 		case responses.ResponseFailedEvent:
 			msg := cm.handleFailedStreamEvent(asEvent)
 			cm.setStreamChunkDefaultExtra(msg, asEvent.Response, cache)
 			cm.sendCallbackOutput(sw, config, msg)
-
-			break Outer
 
 		default:
 			msg := cm.handleDeltaStreamEvent(event)

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -437,7 +437,7 @@ func TestResponsesAPIChatModelReceivedStreamResponse_ResponseCompletedEvent(t *t
 	streamResp := &ssestream.Stream[responses.ResponseStreamEventUnion]{}
 	PatchConvey("ResponseCompletedEvent", t, func() {
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Next).
-			Return(true).Build()
+			Return(Sequence(true).Then(false)).Build()
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Current).
 			Return(responses.ResponseStreamEventUnion{}).Build()
 		Mock((*responsesAPIChatModel).isAddedToolCall).Return(nil, false).Build()
@@ -456,7 +456,7 @@ func TestResponsesAPIChatModelReceivedStreamResponse_ResponseErrorEvent(t *testi
 	streamResp := &ssestream.Stream[responses.ResponseStreamEventUnion]{}
 	PatchConvey("ResponseErrorEvent", t, func() {
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Next).
-			Return(true).Build()
+			Return(Sequence(true).Then(false)).Build()
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Current).
 			Return(responses.ResponseStreamEventUnion{}).Build()
 		Mock((*responsesAPIChatModel).isAddedToolCall).Return(nil, false).Build()
@@ -497,7 +497,7 @@ func TestResponsesAPIChatModelReceivedStreamResponse_ResponseFailedEvent(t *test
 	streamResp := &ssestream.Stream[responses.ResponseStreamEventUnion]{}
 	PatchConvey("ResponseFailedEvent", t, func() {
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Next).
-			Return(true).Build()
+			Return(Sequence(true).Then(false)).Build()
 		MockGeneric((*ssestream.Stream[responses.ResponseStreamEventUnion]).Current).
 			Return(responses.ResponseStreamEventUnion{}).Build()
 		Mock((*responsesAPIChatModel).isAddedToolCall).Return(nil, false).Build()


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
