### PR TITLE
feat(ark): extend generate_with_image example to use chat template

### DIFF
--- a/components/model/ark/README.md
+++ b/components/model/ark/README.md
@@ -463,6 +463,45 @@ func main() {
 	}
 
 	log.Printf("Ark ChatModel output: \n%v", resp)
+	
+	// demonstrate how to use ChatTemplate to generate with image
+	imgPlaceholder := "{img}"
+	ctx = context.Background()
+	chain := compose.NewChain[map[string]any, *schema.Message]()
+	_ = chain.AppendChatTemplate(prompt.FromMessages(schema.FString,
+		&schema.Message{
+			Role: schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{
+				{
+					Type: schema.ChatMessagePartTypeText,
+					Text: "What do you see in this image?",
+				},
+				{
+					Type: schema.ChatMessagePartTypeImageURL,
+					Image: &schema.MessageInputImage{
+						MessagePartCommon: schema.MessagePartCommon{
+							Base64Data: &imgPlaceholder,
+							MIMEType:   "image/png",
+						},
+						Detail: schema.ImageURLDetailAuto,
+					},
+				},
+			},
+		}))
+	_ = chain.AppendChatModel(chatModel)
+	r, err := chain.Compile(ctx)
+	if err != nil {
+		log.Fatalf("Compile failed, err=%v", err)
+	}
+
+	resp, err = r.Invoke(ctx, map[string]any{
+		"img": imageStr,
+	})
+	if err != nil {
+		log.Fatalf("Run failed, err=%v", err)
+	}
+
+	log.Printf("Ark ChatModel output with ChatTemplate: \n%v", resp)
 }
 
 ```

--- a/components/model/ark/examples/generate_with_image/generate_with_image.go
+++ b/components/model/ark/examples/generate_with_image/generate_with_image.go
@@ -22,8 +22,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/cloudwego/eino-ext/components/model/ark"
+	"github.com/cloudwego/eino/components/prompt"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
+
+	"github.com/cloudwego/eino-ext/components/model/ark"
 )
 
 func main() {
@@ -71,4 +74,43 @@ func main() {
 	}
 
 	log.Printf("Ark ChatModel output: \n%v", resp)
+
+	// demonstrate how to use ChatTemplate to generate with image
+	imgPlaceholder := "{img}"
+	ctx = context.Background()
+	chain := compose.NewChain[map[string]any, *schema.Message]()
+	_ = chain.AppendChatTemplate(prompt.FromMessages(schema.FString,
+		&schema.Message{
+			Role: schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{
+				{
+					Type: schema.ChatMessagePartTypeText,
+					Text: "What do you see in this image?",
+				},
+				{
+					Type: schema.ChatMessagePartTypeImageURL,
+					Image: &schema.MessageInputImage{
+						MessagePartCommon: schema.MessagePartCommon{
+							Base64Data: &imgPlaceholder,
+							MIMEType:   "image/png",
+						},
+						Detail: schema.ImageURLDetailAuto,
+					},
+				},
+			},
+		}))
+	_ = chain.AppendChatModel(chatModel)
+	r, err := chain.Compile(ctx)
+	if err != nil {
+		log.Fatalf("Compile failed, err=%v", err)
+	}
+
+	resp, err = r.Invoke(ctx, map[string]any{
+		"img": imageStr,
+	})
+	if err != nil {
+		log.Fatalf("Run failed, err=%v", err)
+	}
+
+	log.Printf("Ark ChatModel output with ChatTemplate: \n%v", resp)
 }


### PR DESCRIPTION
extend generate_with_image example to use chat template:

1. base64 field of UserInputMultiContent is a placeholder
2. the ChatTemplate node uses the passed-in `map[string]any` to render the actual base64 field
3. pass the message to ChatModel