### PR TITLE
fix(a2a): support client concurrency

### DIFF
--- a/a2a/transport/jsonrpc/core/rpc_call.go
+++ b/a2a/transport/jsonrpc/core/rpc_call.go
@@ -56,8 +56,6 @@ func (conn *connection) roundLoop() error {
 }
 
 func (conn *connection) sendRequest(ctx context.Context, msg Message) (MessageReader, error) {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
 	reader, err := conn.cliTrans.Round(ctx, msg)
 	if err != nil {
 		return nil, err
@@ -66,8 +64,6 @@ func (conn *connection) sendRequest(ctx context.Context, msg Message) (MessageRe
 }
 
 func (conn *connection) sendNotification(ctx context.Context, msg Message) error {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
 	// there is no need to care about reader
 	if _, err := conn.cliTrans.Round(ctx, msg); err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
