### PR TITLE
fix(es8): correct dense vector similarity parameter name

### DIFF
--- a/components/retriever/es8/search_mode/dense_vector_similarity.go
+++ b/components/retriever/es8/search_mode/dense_vector_similarity.go
@@ -107,7 +107,7 @@ const (
 var denseVectorScriptMap = map[DenseVectorSimilarityType]string{
 	DenseVectorSimilarityTypeCosineSimilarity: `cosineSimilarity(params.embedding, '%s') + 1.0`,
 	DenseVectorSimilarityTypeDotProduct: `
-    double value = dotProduct(params.query_vector, '%s');
+    double value = dotProduct(params.embedding, '%s');
     return sigmoid(1, Math.E, -value);
     `,
 	DenseVectorSimilarityTypeL1Norm: `1 / (1 + l1norm(params.embedding, '%s'))`,

--- a/components/retriever/es8/search_mode/dense_vector_similarity_test.go
+++ b/components/retriever/es8/search_mode/dense_vector_similarity_test.go
@@ -54,7 +54,7 @@ func TestSearchModeDenseVectorSimilarity(t *testing.T) {
 			PatchConvey("test success", func() {
 				typ2Exp := map[DenseVectorSimilarityType]string{
 					DenseVectorSimilarityTypeCosineSimilarity: `{"min_score":1.1,"query":{"script_score":{"query":{"bool":{"filter":[{"match":{"label":{"query":"good"}}}]}},"script":{"params":{"embedding":[1.1,1.2]},"source":"cosineSimilarity(params.embedding, 'vector_eino_doc_content') + 1.0"}}},"size":10}`,
-					DenseVectorSimilarityTypeDotProduct:       `{"min_score":1.1,"query":{"script_score":{"query":{"bool":{"filter":[{"match":{"label":{"query":"good"}}}]}},"script":{"params":{"embedding":[1.1,1.2]},"source":"\n    double value = dotProduct(params.query_vector, 'vector_eino_doc_content');\n    return sigmoid(1, Math.E, -value);\n    "}}},"size":10}`,
+					DenseVectorSimilarityTypeDotProduct:       `{"min_score":1.1,"query":{"script_score":{"query":{"bool":{"filter":[{"match":{"label":{"query":"good"}}}]}},"script":{"params":{"embedding":[1.1,1.2]},"source":"\n    double value = dotProduct(params.embedding, 'vector_eino_doc_content');\n    return sigmoid(1, Math.E, -value);\n    "}}},"size":10}`,
 					DenseVectorSimilarityTypeL1Norm:           `{"min_score":1.1,"query":{"script_score":{"query":{"bool":{"filter":[{"match":{"label":{"query":"good"}}}]}},"script":{"params":{"embedding":[1.1,1.2]},"source":"1 / (1 + l1norm(params.embedding, 'vector_eino_doc_content'))"}}},"size":10}`,
 					DenseVectorSimilarityTypeL2Norm:           `{"min_score":1.1,"query":{"script_score":{"query":{"bool":{"filter":[{"match":{"label":{"query":"good"}}}]}},"script":{"params":{"embedding":[1.1,1.2]},"source":"1 / (1 + l2norm(params.embedding, 'vector_eino_doc_content'))"}}},"size":10}`,
 				}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
fix(es8): 修正 dense vector similarity 参数名称

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
Fixes a parameter mismatch in ES8 `dense_vector_similarity` (DotProduct) where the Painless script used `params.query_vector` but the client sent `params.embedding`.

This mismatch caused the following runtime error:

```
Retrieve of es8 failed, err=status: 400, failed: [search_phase_execution_exception], reason: all shards failed
```

zh:
修复 ES8 `dense_vector_similarity` (DotProduct) 中 Painless 脚本使用 `params.query_vector` 但客户端发送 `params.embedding` 导致的参数不匹配问题。
该问题会导致以下运行时错误：

```
Retrieve of es8 failed, err=status: 400, failed: [search_phase_execution_exception], reason: all shards failed
```

#### (Optional) Which issue(s) this PR fixes: