### PR TITLE
feat: openai add responseFormat option

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -732,11 +732,18 @@ func (c *Client) genRequest(ctx context.Context, in []*schema.Message, opts ...m
 
 	req.Messages = msgs
 
+	var responseFormat *ChatCompletionResponseFormat
 	if c.config.ResponseFormat != nil {
+		responseFormat = c.config.ResponseFormat
+	}
+	if specOptions.ResponseFormat != nil {
+		responseFormat = specOptions.ResponseFormat
+	}
+	if responseFormat != nil {
 		req.ResponseFormat = &openai.ChatCompletionResponseFormat{
-			Type: openai.ChatCompletionResponseFormatType(c.config.ResponseFormat.Type),
+			Type: openai.ChatCompletionResponseFormatType(responseFormat.Type),
 		}
-		if js := c.config.ResponseFormat.JSONSchema; js != nil {
+		if js := responseFormat.JSONSchema; js != nil {
 			req.ResponseFormat.JSONSchema = &openai.ChatCompletionResponseFormatJSONSchema{
 				Name:        js.Name,
 				Schema:      js.JSONSchema,

--- a/libs/acl/openai/option.go
+++ b/libs/acl/openai/option.go
@@ -54,6 +54,7 @@ type openaiOptions struct {
 	ResponseMessageModifier      ResponseMessageModifier
 	ResponseChunkMessageModifier ResponseChunkMessageModifier
 	MaxCompletionTokens          *int
+	ResponseFormat               *ChatCompletionResponseFormat
 }
 
 func WithExtraFields(extraFields map[string]any) model.Option {
@@ -110,5 +111,11 @@ func WithExtraHeader(header map[string]string) model.Option {
 func WithMaxCompletionTokens(maxCompletionTokens int) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *openaiOptions) {
 		o.MaxCompletionTokens = &maxCompletionTokens
+	})
+}
+
+func WithResponseFormat(responseFormat *ChatCompletionResponseFormat) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *openaiOptions) {
+		o.ResponseFormat = responseFormat
 	})
 }

--- a/libs/acl/openai/option_test.go
+++ b/libs/acl/openai/option_test.go
@@ -111,4 +111,12 @@ func Test_OpenAIOptions_Setters(t *testing.T) {
 			assert.Equal(t, 123, *spec.MaxCompletionTokens)
 		}
 	})
+
+	t.Run("WithResponseFormat", func(t *testing.T) {
+		opts := []model.Option{WithResponseFormat(&ChatCompletionResponseFormat{Type: ChatCompletionResponseFormatTypeText})}
+		spec := model.GetImplSpecificOptions(&openaiOptions{}, opts...)
+		if assert.NotNil(t, spec.ResponseFormat) {
+			assert.Equal(t, ChatCompletionResponseFormatTypeText, spec.ResponseFormat.Type)
+		}
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
