### PR TITLE
feat(gemini): add ImageConfig support

### DIFF
--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -73,6 +73,7 @@ func NewChatModel(_ context.Context, cfg *Config) (*ChatModel, error) {
 		enableGoogleMaps:            cfg.EnableGoogleMaps,
 		safetySettings:              cfg.SafetySettings,
 		thinkingConfig:              cfg.ThinkingConfig,
+		imageConfig:                 cfg.ImageConfig,
 		responseModalities:          cfg.ResponseModalities,
 		mediaResolution:             cfg.MediaResolution,
 		cache:                       cfg.Cache,
@@ -130,6 +131,8 @@ type Config struct {
 
 	ThinkingConfig *genai.ThinkingConfig
 
+	ImageConfig *genai.ImageConfig
+
 	// ResponseModalities specifies the modalities the model can return.
 	// Optional.
 	ResponseModalities []GeminiResponseModality
@@ -170,6 +173,7 @@ type ChatModel struct {
 	enableGoogleMaps            *genai.GoogleMaps
 	safetySettings              []*genai.SafetySetting
 	thinkingConfig              *genai.ThinkingConfig
+	imageConfig                 *genai.ImageConfig
 	responseModalities          []GeminiResponseModality
 	mediaResolution             genai.MediaResolution
 	cache                       *CacheConfig
@@ -522,6 +526,11 @@ func (cm *ChatModel) genInputAndConf(input []*schema.Message, opts ...model.Opti
 	m.ThinkingConfig = cm.thinkingConfig
 	if geminiOptions.ThinkingConfig != nil {
 		m.ThinkingConfig = geminiOptions.ThinkingConfig
+	}
+
+	m.ImageConfig = cm.imageConfig
+	if geminiOptions.ImageConfig != nil {
+		m.ImageConfig = geminiOptions.ImageConfig
 	}
 
 	if len(geminiOptions.CachedContentName) > 0 {

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -27,6 +27,7 @@ type options struct {
 	TopK               *int32
 	ResponseJSONSchema *jsonschema.Schema
 	ThinkingConfig     *genai.ThinkingConfig
+	ImageConfig        *genai.ImageConfig
 	ResponseModalities []GeminiResponseModality
 
 	CachedContentName string
@@ -47,6 +48,12 @@ func WithResponseJSONSchema(s *jsonschema.Schema) model.Option {
 func WithThinkingConfig(t *genai.ThinkingConfig) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.ThinkingConfig = t
+	})
+}
+
+func WithImageConfig(i *genai.ImageConfig) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.ImageConfig = i
 	})
 }
 


### PR DESCRIPTION
## Summary

  This PR adds comprehensive `ImageConfig` support to the Gemini model component, allowing users to configure image generation parameters.

  ## Changes

  - ✅ Add `ImageConfig` field to `Config` struct for default configuration
  - ✅ Add `imageConfig` field to `ChatModel` struct for runtime storage
  - ✅ Initialize `imageConfig` in `NewChatModel` from `Config`
  - ✅ Add `WithImageConfig` option function in `option.go`
  - ✅ Update `genInputAndConf` to support both default and per-call `ImageConfig`

  ## Implementation Details

  This implementation follows the same pattern as `ThinkingConfig`, supporting both:
  1. Default configuration during model creation via `Config.ImageConfig`
  2. Dynamic override during `Generate`/`Stream` calls via `WithImageConfig()`

  ## Usage Example

  ```go
  // Set default ImageConfig during model creation
  model, _ := gemini.NewChatModel(ctx, &gemini.Config{
      Client: client,
      Model:  "gemini-2.0-flash-exp",
      ImageConfig: &genai.ImageConfig{
          // Image generation configuration
      },
  })

  // Override ImageConfig per call
  model.Generate(ctx, messages, gemini.WithImageConfig(&genai.ImageConfig{
      // Custom configuration for this call
  }))

  Testing

  - ✅ Code compiles successfully
  - ✅ Implementation is consistent with existing patterns (ThinkingConfig, ResponseModalities)