### PR TITLE
feat(model/ark): rename Enable Tool Web Search to Web Search

### DIFF
--- a/components/model/ark/option.go
+++ b/components/model/ark/option.go
@@ -30,7 +30,7 @@ type arkOptions struct {
 
 	cache *CacheOption
 
-	enableWebSearch *EnableToolWebSearch
+	enableWebSearch *ToolWebSearch
 
 	maxToolCalls *int64
 }
@@ -121,9 +121,9 @@ func WithMaxCompletionTokens(maxCompletionTokens int) model.Option {
 // and you do not need to develop your own search engine or maintain data resources.
 // Note: This option is only effective for the Responses API.
 // For more details, see https://www.volcengine.com/docs/82379/1756990?lang=zh
-func WithEnableToolWebSearch(enable *EnableToolWebSearch) model.Option {
+func WithEnableToolWebSearch(toolWebSearch *ToolWebSearch) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
-		o.enableWebSearch = enable
+		o.enableWebSearch = toolWebSearch
 	})
 
 }

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -125,7 +125,7 @@ type ResponsesAPIConfig struct {
 	// Note: This option is only effective for the Responses API.
 	// For more details, see https://www.volcengine.com/docs/82379/1756990?lang=zh
 	// Optional.
-	EnableToolWebSearch *EnableToolWebSearch `json:"enable_tool_web_search,omitempty"`
+	EnableToolWebSearch *ToolWebSearch `json:"enable_tool_web_search,omitempty"`
 
 	// MaxToolCalls specifies the maximum number of tool-calling rounds.
 	// The value must be in the range [1, 10].
@@ -210,7 +210,7 @@ type ResponsesAPIChatModel struct {
 	serviceTier     *string
 	reasoningEffort *arkModel.ReasoningEffort
 
-	enableToolWebSearch *EnableToolWebSearch
+	enableToolWebSearch *ToolWebSearch
 
 	maxToolCalls *int64
 }
@@ -660,7 +660,7 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 	return nil
 }
 
-func (cm *ResponsesAPIChatModel) populateTools(responseReq *responses.ResponsesRequest, options *model.Options, enableToolWebSearch *EnableToolWebSearch, maxToolCalls *int64) error {
+func (cm *ResponsesAPIChatModel) populateTools(responseReq *responses.ResponsesRequest, options *model.Options, enableToolWebSearch *ToolWebSearch, maxToolCalls *int64) error {
 
 	if responseReq.PreviousResponseId != nil {
 		return nil
@@ -700,7 +700,7 @@ func (cm *ResponsesAPIChatModel) populateTools(responseReq *responses.ResponsesR
 	return nil
 }
 
-func convToolWebSearch(enableToolWebSearch *EnableToolWebSearch) (*responses.ToolWebSearch, error) {
+func convToolWebSearch(enableToolWebSearch *ToolWebSearch) (*responses.ToolWebSearch, error) {
 	tl := &responses.ToolWebSearch{
 		Type:       responses.ToolType_web_search,
 		Limit:      enableToolWebSearch.Limit,

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -884,7 +884,7 @@ func TestResponsesAPIChatModel_populateToolChoice(t *testing.T) {
 					},
 				},
 			}
-			err := cm.populateTools(req, options, &EnableToolWebSearch{
+			err := cm.populateTools(req, options, &ToolWebSearch{
 				Limit:   ptrOf(int64(2)),
 				Sources: []Source{SourceOfToutiao},
 			}, nil)
@@ -1014,7 +1014,7 @@ func TestNewResponsesAPIChatModel(t *testing.T) {
 				SessionCache: &SessionCacheConfig{
 					EnableCache: true,
 				},
-				EnableToolWebSearch: &EnableToolWebSearch{},
+				EnableToolWebSearch: &ToolWebSearch{},
 				MaxToolCalls:        ptrOf(int64(5)),
 			}
 			m, err := NewResponsesAPIChatModel(ctx, config)

--- a/components/model/ark/types.go
+++ b/components/model/ark/types.go
@@ -85,8 +85,8 @@ const (
 	SourceOfMoji    = "moji"
 )
 
-// EnableToolWebSearch holds the configuration for the web search tool.
-type EnableToolWebSearch struct {
+// ToolWebSearch holds the configuration for the web search tool.
+type ToolWebSearch struct {
 	// Limit is the maximum number of results to retrieve per search in a single round.
 	// It affects input size and performance. The value must be in the range [1, 50].
 	// Optional. Default 10


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: rename Enable Tool Web Search to Web Search


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
