### PR TITLE
feat(model/ark): Refactor callback handling for Responses API

### DIFF
--- a/components/model/ark/chatmodel.go
+++ b/components/model/ark/chatmodel.go
@@ -27,8 +27,6 @@ import (
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model"
 
-	"github.com/cloudwego/eino/callbacks"
-	"github.com/cloudwego/eino/components"
 	fmodel "github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 )
@@ -389,9 +387,6 @@ type CacheInfo struct {
 
 func (cm *ChatModel) Generate(ctx context.Context, in []*schema.Message, opts ...fmodel.Option) (
 	outMsg *schema.Message, err error) {
-
-	ctx = callbacks.EnsureRunInfo(ctx, cm.GetType(), components.ComponentOfChatModel)
-
 	ok, err := cm.callByResponsesAPI(opts...)
 	if err != nil {
 		return nil, err
@@ -405,8 +400,6 @@ func (cm *ChatModel) Generate(ctx context.Context, in []*schema.Message, opts ..
 
 func (cm *ChatModel) Stream(ctx context.Context, in []*schema.Message, opts ...fmodel.Option) (
 	outStream *schema.StreamReader[*schema.Message], err error) {
-
-	ctx = callbacks.EnsureRunInfo(ctx, cm.GetType(), components.ComponentOfChatModel)
 
 	ok, err := cm.callByResponsesAPI(opts...)
 	if err != nil {

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
@@ -219,8 +220,14 @@ type cacheConfig struct {
 	ExpireAt *int64
 }
 
+func (cm *ResponsesAPIChatModel) GetType() string {
+	return "ResponsesAPI"
+}
+
 func (cm *ResponsesAPIChatModel) Generate(ctx context.Context, input []*schema.Message,
 	opts ...model.Option) (outMsg *schema.Message, err error) {
+	ctx = callbacks.EnsureRunInfo(ctx, cm.GetType(), components.ComponentOfChatModel)
+
 	options, specOptions, err := cm.getOptions(opts)
 	if err != nil {
 		return nil, err
@@ -288,7 +295,7 @@ func (cm *ResponsesAPIChatModel) Generate(ctx context.Context, input []*schema.M
 
 func (cm *ResponsesAPIChatModel) Stream(ctx context.Context, input []*schema.Message,
 	opts ...model.Option) (outStream *schema.StreamReader[*schema.Message], err error) {
-
+	ctx = callbacks.EnsureRunInfo(ctx, cm.GetType(), components.ComponentOfChatModel)
 	options, specOptions, err := cm.getOptions(opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Moves the callback initialization logic from the generic ChatModel to the specific ResponsesAPIChatModel.

This change ensures that EnsureRunInfo is only called for the Responses API flow, where it is actually needed. The GetType method was also added to ResponsesAPIChatModel to support this.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->

Moves the callback initialization logic from the generic ChatModel to the specific ResponsesAPIChatModel.

This change ensures that EnsureRunInfo is only called for the Responses API flow, where it is actually needed. The GetType method was also added to ResponsesAPIChatModel to support this.


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
