### PR TITLE
fix(model/gemini): Correctly attach metadata to video input part

### DIFF
--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -880,15 +880,18 @@ func convInputMedia(contents []schema.MessageInputPart) ([]*genai.Part, error) {
 			if content.Video == nil {
 				return nil, fmt.Errorf("video field must not be nil when Type is ChatMessagePartTypeVideoURL in user message")
 			}
-			if content.Video.Extra != nil {
-				if videoMetaData := GetInputVideoMetaData(content.Video); videoMetaData != nil {
-					result = append(result, &genai.Part{VideoMetadata: videoMetaData})
-				}
-			}
+
 			p, err := toGenAIDataPart(content.Video.Base64Data, content.Video.URL, content.Video.MIMEType, schema.ChatMessagePartTypeVideoURL)
 			if err != nil {
 				return nil, err
 			}
+
+			if content.Video.Extra != nil {
+				if videoMetaData := GetInputVideoMetaData(content.Video); videoMetaData != nil {
+					p.VideoMetadata = videoMetaData
+				}
+			}
+
 			result = append(result, p)
 
 		case schema.ChatMessagePartTypeFileURL:

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -440,7 +440,7 @@ func TestChatModel_convMedia(t *testing.T) {
 			}
 			parts, err := convInputMedia(contents)
 			assert.NoError(t, err)
-			assert.Len(t, parts, 2)
+			assert.Len(t, parts, 1)
 			assert.NotNil(t, parts[0].VideoMetadata)
 			assert.Equal(t, time.Second, parts[0].VideoMetadata.StartOffset)
 			assert.Equal(t, time.Second*5, parts[0].VideoMetadata.EndOffset)


### PR DESCRIPTION
The previous implementation incorrectly sent video metadata as a separate `genai.Part` instead of attaching it to the corresponding video data part.

This commit fixes the issue by assigning the `VideoMetadata` to the `VideoMetadata` field of the `genai.Part` that contains the video data. This ensures that the metadata is correctly associated with the video content in the request sent to the Gemini API.