### PR TITLE
fix(gemini): prevent duplicate tool call IDs for same function calls

### DIFF
--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -12,6 +12,29 @@ A Google Gemini implementation for [Eino](https://github.com/cloudwego/eino) tha
 - Custom response parsing support
 - Flexible model configuration
 - Caching support for generated responses
+- Automatic handling of duplicate tool call IDs
+
+## Important Notes
+
+### Tool Call ID Handling
+
+When Gemini returns multiple function calls with the same function name but different arguments in a single response, this implementation automatically generates unique IDs for each tool call to prevent conflicts.
+
+**ID Generation Pattern:**
+- First call to a function: ID = `function_name`
+- Second call to same function: ID = `function_name-2`
+- Third call to same function: ID = `function_name-3`
+- And so on...
+
+**Example:**
+```go
+// If Gemini returns multiple calls to "get_weather" for different cities:
+// Tool Call 1: ID = "get_weather", Args = {"city": "Paris"}
+// Tool Call 2: ID = "get_weather-2", Args = {"city": "London"}
+// Tool Call 3: ID = "get_weather-3", Args = {"city": "Tokyo"}
+```
+
+This ensures that each tool call has a unique identifier, which is essential for proper tool execution tracking and response handling in agent workflows.
 
 ## Installation
 

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -12,6 +12,29 @@
 - 支持自定义响应解析
 - 灵活的模型配置
 - 支持对生成的响应进行缓存
+- 自动处理重复的工具调用 ID
+
+## 重要说明
+
+### 工具调用 ID 处理
+
+当 Gemini 在单个响应中返回多个具有相同函数名但不同参数的函数调用时，此实现会自动为每个工具调用生成唯一的 ID 以防止冲突。
+
+**ID 生成模式：**
+- 第一次调用函数：ID = `function_name`
+- 第二次调用相同函数：ID = `function_name-2`
+- 第三次调用相同函数：ID = `function_name-3`
+- 以此类推...
+
+**示例：**
+```go
+// 如果 Gemini 为不同城市返回多次 "get_weather" 调用：
+// 工具调用 1：ID = "get_weather", Args = {"city": "Paris"}
+// 工具调用 2：ID = "get_weather-2", Args = {"city": "London"}
+// 工具调用 3：ID = "get_weather-3", Args = {"city": "Tokyo"}
+```
+
+这确保每个工具调用都有唯一的标识符，这对于 Agent 工作流中的工具执行跟踪和响应处理至关重要。
 
 ## 安装
 

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -215,12 +215,14 @@ func (cm *ChatModel) Generate(ctx context.Context, input []*schema.Message, opts
 		return nil, err
 	}
 
+	// Generate content using the Gemini API
 	result, err := cm.cli.Models.GenerateContent(ctx, modelName, contents, genaiConf)
 	if err != nil {
 		return nil, fmt.Errorf("send message fail: %w", err)
 	}
 
-	message, err = convResponse(result)
+	// Convert the API response to schema.Message format
+	message, err = convResponse(result, make(map[string]int))
 	if err != nil {
 		return nil, fmt.Errorf("convert response fail: %w", err)
 	}
@@ -273,22 +275,24 @@ func (cm *ChatModel) Stream(ctx context.Context, input []*schema.Message, opts .
 				_ = sw.Send(nil, newPanicErr(pe, debug.Stack()))
 			}
 			sw.Close()
-		}()
-		for resp, err_ := range resultIter {
-			if err_ != nil {
-				sw.Send(nil, err_)
-				return
-			}
-			message, err_ := convResponse(resp)
-			if err_ != nil {
-				sw.Send(nil, err_)
-				return
-			}
-			closed := sw.Send(convCallbackOutput(message, cbConf), nil)
-			if closed {
-				return
-			}
+	}()
+	// Track tool call IDs to generate unique identifiers for each tool call
+	toolCallIDs := make(map[string]int)
+	for resp, err_ := range resultIter {
+		if err_ != nil {
+			sw.Send(nil, err_)
+			return
 		}
+		message, err_ := convResponse(resp, toolCallIDs)
+		if err_ != nil {
+			sw.Send(nil, err_)
+			return
+		}
+		closed := sw.Send(convCallbackOutput(message, cbConf), nil)
+		if closed {
+			return
+		}
+	}
 	}()
 	srList := sr.Copy(2)
 	callbacks.OnEndWithStreamOutput(ctx, srList[0])
@@ -1115,12 +1119,12 @@ func decodeBase64Data(dataURL string) ([]byte, error) {
 	return decoded, nil
 }
 
-func convResponse(resp *genai.GenerateContentResponse) (*schema.Message, error) {
+func convResponse(resp *genai.GenerateContentResponse, toolCallIDs map[string]int) (*schema.Message, error) {
 	if len(resp.Candidates) == 0 {
 		return nil, fmt.Errorf("gemini result is empty")
 	}
 
-	message, err := convCandidate(resp.Candidates[0])
+	message, err := convCandidate(resp.Candidates[0], toolCallIDs)
 	if err != nil {
 		return nil, fmt.Errorf("convert candidate fail: %w", err)
 	}
@@ -1144,7 +1148,7 @@ func convResponse(resp *genai.GenerateContentResponse) (*schema.Message, error) 
 	return message, nil
 }
 
-func convCandidate(candidate *genai.Candidate) (*schema.Message, error) {
+func convCandidate(candidate *genai.Candidate, toolCallIDs map[string]int) (*schema.Message, error) {
 	result := &schema.Message{
 		ResponseMeta: &schema.ResponseMeta{
 			FinishReason: string(candidate.FinishReason),
@@ -1193,7 +1197,7 @@ func convCandidate(candidate *genai.Candidate) (*schema.Message, error) {
 				outParts = append(outParts, outPart)
 			}
 			if part.FunctionCall != nil {
-				fc, err := convFC(part)
+				fc, err := convFC(part, toolCallIDs)
 				if err != nil {
 					return nil, err
 				}
@@ -1284,7 +1288,7 @@ func toMultiOutPart(part *genai.Part) (schema.MessageOutputPart, error) {
 	return res, nil
 }
 
-func convFC(part *genai.Part) (*schema.ToolCall, error) {
+func convFC(part *genai.Part, toolCallIDs map[string]int) (*schema.ToolCall, error) {
 	if part == nil || part.FunctionCall == nil {
 		return nil, fmt.Errorf("part or function call is nil")
 	}
@@ -1295,8 +1299,19 @@ func convFC(part *genai.Part) (*schema.ToolCall, error) {
 		return nil, fmt.Errorf("marshal gemini tool call arguments fail: %w", err)
 	}
 
+	// Generate a unique call ID for the tool call
+	// For the first call to a tool, use the tool name as the ID
+	// For subsequent calls, append a counter to make it unique
+	callID := tp.Name
+	if count, ok := toolCallIDs[tp.Name]; !ok {
+		toolCallIDs[tp.Name] = 1
+	} else {
+		callID = fmt.Sprintf("%s-%d", tp.Name, count+1)
+		toolCallIDs[tp.Name] = count + 1
+	}
+
 	toolCall := &schema.ToolCall{
-		ID: tp.Name,
+		ID: callID,
 		Function: schema.FunctionCall{
 			Name:      tp.Name,
 			Arguments: args,


### PR DESCRIPTION
## Review Summary

The changes fix a critical bug where Gemini's ChatModel could output multiple function calls with the same function name but different arguments in one candidate. The previous implementation used the tool name directly as the tool call ID, causing duplicate IDs.

### Key Changes
1. **Added `toolCallIDs` map tracking**: Maintains a counter for each tool name across the response lifecycle
2. **Modified `convFC` function**: Generates unique IDs by appending `-N` suffix for duplicate tool names
3. **Updated function signatures**: `convResponse`, `convCandidate`, and `convFC` now accept `toolCallIDs map[string]int`
4. **Preserved state across streaming**: In `Stream()`, the map persists across iterations to maintain unique IDs

### ID Generation Logic
- First call: `tool_name` → ID: `tool_name`
- Second call: `tool_name` → ID: `tool_name-2`
- Third call: `tool_name` → ID: `tool_name-3`