### PR TITLE
feat(model/qwen): Add support for custom request headers and fields

### DIFF
--- a/components/model/qwen/option.go
+++ b/components/model/qwen/option.go
@@ -17,6 +17,7 @@
 package qwen
 
 import (
+	"github.com/cloudwego/eino-ext/libs/acl/openai"
 	"github.com/cloudwego/eino/components/model"
 )
 
@@ -33,4 +34,14 @@ func WithEnableThinking(enableThinking bool) model.Option {
 	return model.WrapImplSpecificOptFn(func(opt *options) {
 		opt.EnableThinking = &enableThinking
 	})
+}
+
+// WithExtraHeader is used to set extra headers for the request.
+func WithExtraHeader(header map[string]string) model.Option {
+	return openai.WithExtraHeader(header)
+}
+
+// WithExtraFields is used to set extra body fields for the request.
+func WithExtraFields(extraFields map[string]any) model.Option {
+	return openai.WithExtraFields(extraFields)
 }


### PR DESCRIPTION
This commit enhances the Qwen model component by introducing options to add custom HTTP headers and extra body fields to the API requests.

The new `WithExtraHeader` and `WithExtraFields` functions are added, which wrap the existing functionalities from the `eino-ext/libs/acl/openai` package. This approach promotes code reuse and provides users with greater flexibility to pass specific metadata or custom parameters required by their service endpoints.
