### PR TITLE
feat(ark): export SetResponseID

### DIFF
--- a/components/model/ark/message_extra.go
+++ b/components/model/ark/message_extra.go
@@ -190,7 +190,9 @@ func GetResponseID(msg *schema.Message) (string, bool) {
 	return responseIDStr, true
 }
 
-func setResponseID(msg *schema.Message, responseID string) {
+// SetResponseID set the response ID to the message.
+// Available only for ResponsesAPI responses.
+func SetResponseID(msg *schema.Message, responseID string) {
 	setMsgExtra(msg, keyOfResponseID, arkResponseID(responseID))
 }
 

--- a/components/model/ark/message_extra_test.go
+++ b/components/model/ark/message_extra_test.go
@@ -41,8 +41,8 @@ func TestConcatMessages(t *testing.T) {
 
 	setResponseCacheExpireAt(msgs[0], arkResponseCacheExpireAt(10))
 	setResponseCacheExpireAt(msgs[1], arkResponseCacheExpireAt(10))
-	setResponseID(msgs[0], "resp id")
-	setResponseID(msgs[1], "resp id")
+	SetResponseID(msgs[0], "resp id")
+	SetResponseID(msgs[1], "resp id")
 	setContextID(msgs[0], "context id")
 	setContextID(msgs[1], "context id")
 

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -955,7 +955,7 @@ func (cm *ResponsesAPIChatModel) toOutputMessage(resp *responses.ResponseObject,
 		setResponseCacheExpireAt(msg, arkResponseCacheExpireAt(ptrFromOrZero(cache.ExpireAt)))
 	}
 	setContextID(msg, resp.Id)
-	setResponseID(msg, resp.Id)
+	SetResponseID(msg, resp.Id)
 
 	if resp.ServiceTier != nil {
 		setServiceTier(msg, resp.ServiceTier.String())
@@ -1214,7 +1214,7 @@ func (cm *ResponsesAPIChatModel) setStreamChunkDefaultExtra(msg *schema.Message,
 		setResponseCacheExpireAt(msg, arkResponseCacheExpireAt(ptrFromOrZero(cacheConfig.ExpireAt)))
 	}
 	setContextID(msg, object.Id)
-	setResponseID(msg, object.Id)
+	SetResponseID(msg, object.Id)
 	if object.ServiceTier != nil {
 		setServiceTier(msg, object.ServiceTier.String())
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
