### PR TITLE
fix(langfuse): fix latency display showing incorrect huge hours value

### DIFF
--- a/callbacks/langfuse/go.mod
+++ b/callbacks/langfuse/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
+replace github.com/cloudwego/eino-ext/libs/acl/langfuse => ../../libs/acl/langfuse
+
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -181,10 +181,11 @@ type CallbackHandler struct {
 }
 
 type langfuseStateKey struct{}
+
 type langfuseState struct {
 	traceID       string
 	observationID string
-	startTime     time.Time // 用于计算 duration
+	startTime     time.Time // startTime is used to calculate duration in milliseconds
 }
 
 func (c *CallbackHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
@@ -290,7 +291,7 @@ func (c *CallbackHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo, ou
 			}
 		}
 
-		// 计算 duration（毫秒）
+		// Calculate duration in milliseconds
 		if !state.startTime.IsZero() {
 			duration := int64(endTime.Sub(state.startTime).Milliseconds())
 			body.Duration = &duration
@@ -314,12 +315,12 @@ func (c *CallbackHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo, ou
 			BaseEventBody: langfuse.BaseEventBody{
 				ID: state.observationID,
 			},
-			Output:   out,
-			StartTime: state.startTime, // ← 必须保留原始 startTime
+			Output:    out,
+			StartTime: state.startTime, // Must preserve the original startTime for correct latency calculation
 		},
 		EndTime: endTime,
 	}
-	// 计算 duration（毫秒）
+	// Calculate duration in milliseconds
 	if !state.startTime.IsZero() {
 		duration := int64(endTime.Sub(state.startTime).Milliseconds())
 		spanBody.Duration = &duration

--- a/libs/acl/langfuse/event.go
+++ b/libs/acl/langfuse/event.go
@@ -227,7 +227,7 @@ type SpanEventBody struct {
 	BaseObservationEventBody
 
 	EndTime  time.Time `json:"endTime,omitempty"`
-	Duration *int64    `json:"duration,omitempty"` // 毫秒
+	Duration *int64    `json:"duration,omitempty"` // Duration in milliseconds
 }
 
 type Usage struct {
@@ -248,7 +248,7 @@ type GenerationEventBody struct {
 	PromptVersion       int               `json:"promptVersion,omitempty"`
 	ModelParameters     any               `json:"modelParameters,omitempty"`
 	Usage               *Usage            `json:"usage,omitempty"`
-	Duration            *int64            `json:"duration,omitempty"` // 毫秒
+	Duration            *int64            `json:"duration,omitempty"` // Duration in milliseconds
 }
 
 type EventEventBody struct {

--- a/libs/acl/langfuse/event.go
+++ b/libs/acl/langfuse/event.go
@@ -226,7 +226,8 @@ type BaseObservationEventBody struct {
 type SpanEventBody struct {
 	BaseObservationEventBody
 
-	EndTime time.Time `json:"endTime,omitempty"`
+	EndTime  time.Time `json:"endTime,omitempty"`
+	Duration *int64    `json:"duration,omitempty"` // 毫秒
 }
 
 type Usage struct {
@@ -247,6 +248,7 @@ type GenerationEventBody struct {
 	PromptVersion       int               `json:"promptVersion,omitempty"`
 	ModelParameters     any               `json:"modelParameters,omitempty"`
 	Usage               *Usage            `json:"usage,omitempty"`
+	Duration            *int64            `json:"duration,omitempty"` // 毫秒
 }
 
 type EventEventBody struct {


### PR DESCRIPTION
## Problem
Langfuse UI was displaying incorrect latency values like **"17751749h 37m 57s"** 
instead of the actual duration in milliseconds (e.g., "854ms").

## Root Cause
The callback handler was not preserving the original `startTime` when 
updating spans/generations in `OnEnd`. This caused the `startTime` to be 
reset to zero value (`"0001-01-01T00:00:00Z"`), which Langfuse backend 
uses to calculate latency as `endTime - startTime`, resulting in a 
massive time difference.

## Solution
1. Add `Duration` field (milliseconds) to `SpanEventBody` and 
   `GenerationEventBody` in event data model
2. Store `startTime` in callback state during `OnStart`
3. Preserve original `startTime` and calculate `duration` in `OnEnd`

## Changes
- `libs/acl/langfuse/event.go`: Add `Duration *int64` field (milliseconds)
- `callbacks/langfuse/langfuse.go`: Track startTime and compute duration

## Testing
Before fix: `Latency: 17751749h 37m 57s` ❌
After fix: `Latency: 854ms` ✅

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>