### PR TITLE
fix(adk): ensure streaming shell response is sent even when command produces no output

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -464,9 +464,10 @@ func (s *backend) ExecuteStreaming(ctx context.Context, input *filesystem.Execut
 		}()
 
 		scanner := bufio.NewScanner(stdout)
+		hasOutput := false
 		for scanner.Scan() {
+			hasOutput = true
 			line := scanner.Text() + "\n"
-
 			select {
 			case <-ctx.Done():
 				_ = cmd.Process.Kill()
@@ -500,6 +501,11 @@ func (s *backend) ExecuteStreaming(ctx context.Context, input *filesystem.Execut
 			}
 			return
 		}
+
+		if !hasOutput {
+			w.Send(&filesystem.ExecuteResponse{ExitCode: new(int)}, nil)
+		}
+
 	}()
 
 	return sr, nil

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -662,6 +662,31 @@ func TestExecuteStreaming(t *testing.T) {
 
 		assert.Error(t, lastErr, "should receive error for invalid command")
 	})
+
+	t.Run("ExecuteStreaming with no stdout output", func(t *testing.T) {
+		req := &filesystem.ExecuteRequest{Command: "true"}
+		sr, err := s.(*backend).ExecuteStreaming(ctx, req)
+		assert.NoError(t, err)
+
+		var receivedResponse bool
+		var exitCode *int
+		for {
+			resp, err := sr.Recv()
+			if err != nil {
+				break
+			}
+			if resp != nil {
+				receivedResponse = true
+				if resp.ExitCode != nil {
+					exitCode = resp.ExitCode
+				}
+			}
+		}
+
+		assert.True(t, receivedResponse, "should receive at least one response even with no stdout")
+		assert.NotNil(t, exitCode, "should receive exit code in response")
+		assert.Equal(t, 0, *exitCode, "exit code should be 0 for successful command")
+	})
 }
 
 func TestExecute1(t *testing.T) {


### PR DESCRIPTION
…roduces no output

Fixed an edge case in ExecuteStreaming where no response was sent when the executed command produced no stdout output.

Main changes:
- Added `hasOutput` flag to track whether any output was received from stdout
- When scanner completes without any output, send an empty ExecuteResponse with default exit code (0) to ensure the stream properly terminates

Impact:
- Fixes potential client-side hanging when executing commands that produce no stdout (e.g., commands that only write to stderr or have no output at all)
- Ensures consistent streaming behavior regardless of command output

