### PR TITLE
fix(callbacks): replace sonic JSON path for Go 1.24 compatibility

### DIFF
--- a/callbacks/langfuse/go.mod
+++ b/callbacks/langfuse/go.mod
@@ -4,7 +4,6 @@ go 1.23.0
 
 require (
 	github.com/bytedance/mockey v1.2.13
-	github.com/bytedance/sonic v1.14.1
 	github.com/cloudwego/eino v0.6.0
 	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20251124083837-ce2e7e196f9f
 	github.com/golang/mock v1.6.0
@@ -15,6 +14,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
@@ -42,8 +42,8 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
 	golang.org/x/arch v0.12.0 // indirect
-	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/term v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/callbacks/langfuse/go.sum
+++ b/callbacks/langfuse/go.sum
@@ -22,8 +22,6 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.6.0 h1:pobGKMOfcQHVNhD9UT/HrvO0eYG6FC2ML/NKY2Eb9+Q=
 github.com/cloudwego/eino v0.6.0/go.mod h1:JNapfU+QUrFFpboNDrNOFvmz0m9wjBFHHCr77RH6a50=
-github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20250409060521-ba8646352e4b h1:QGOp1e7tmQEUtznQ8fD8xUam2d/RECA8oJuPam2212s=
-github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20250409060521-ba8646352e4b/go.mod h1:3U4sve/4FGASns5zXHUfBX4ZTruQEhT1t9F1cNb5czM=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20251124083837-ce2e7e196f9f h1:i8DgDklrNznB1/e/HUpM8i/mfOL/E+Hsug5166f/mec=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20251124083837-ce2e7e196f9f/go.mod h1:P3zzJTRexY0QKaE9Vn2CmOnCorIMgNzNtler8mw9IQM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -18,12 +18,12 @@ package langfuse
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log"
 	"runtime/debug"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino-ext/libs/acl/langfuse"
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components"
@@ -225,11 +225,12 @@ func (c *CallbackHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, 
 		})
 	}
 
-	in, err := sonic.MarshalString(input)
+	inBytes, err := json.Marshal(input)
 	if err != nil {
 		log.Printf("marshal input error: %v, runinfo: %+v", err, info)
 		return ctx
 	}
+	in := string(inBytes)
 	spanID, err := c.cli.CreateSpan(&langfuse.SpanEventBody{
 		BaseObservationEventBody: langfuse.BaseObservationEventBody{
 			BaseEventBody: langfuse.BaseEventBody{
@@ -290,11 +291,12 @@ func (c *CallbackHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo, ou
 		return ctx
 	}
 
-	out, err := sonic.MarshalString(output)
+	outBytes, err := json.Marshal(output)
 	if err != nil {
 		log.Printf("marshal output error: %v, runinfo: %+v", err, info)
 		return ctx
 	}
+	out := string(outBytes)
 	err = c.cli.EndSpan(&langfuse.SpanEventBody{
 		BaseObservationEventBody: langfuse.BaseObservationEventBody{
 			BaseEventBody: langfuse.BaseEventBody{
@@ -468,11 +470,12 @@ func (c *CallbackHandler) OnStartWithStreamInput(ctx context.Context, info *call
 			ins = append(ins, chunk)
 		}
 
-		in, err_ := sonic.MarshalString(ins)
+		inBytes, err_ := json.Marshal(ins)
 		if err_ != nil {
 			log.Printf("marshal input error: %v, runinfo: %+v", err_, info)
 			return
 		}
+		in := string(inBytes)
 		err = c.cli.EndSpan(&langfuse.SpanEventBody{
 			BaseObservationEventBody: langfuse.BaseObservationEventBody{
 				BaseEventBody: langfuse.BaseEventBody{
@@ -573,10 +576,11 @@ func (c *CallbackHandler) OnEndWithStreamOutput(ctx context.Context, info *callb
 			outs = append(outs, chunk)
 		}
 
-		out, err := sonic.MarshalString(outs)
+		outBytes, err := json.Marshal(outs)
 		if err != nil {
 			log.Printf("marshal stream output error: %v, runinfo: %+v", err, info)
 		}
+		out := string(outBytes)
 		err = c.cli.EndSpan(&langfuse.SpanEventBody{
 			BaseObservationEventBody: langfuse.BaseObservationEventBody{
 				BaseEventBody: langfuse.BaseEventBody{

--- a/callbacks/langsmith/flow_trace.go
+++ b/callbacks/langsmith/flow_trace.go
@@ -18,12 +18,12 @@ package langsmith
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sync"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 )
 
@@ -116,7 +116,7 @@ func (ft *FlowTrace) SpanToString(ctx context.Context) (string, error) {
 		})
 	}
 	state.MarshalMetadata = tmpMetadata
-	val, err := sonic.Marshal(state)
+	val, err := json.Marshal(state)
 	if err != nil {
 		return "", err
 	}
@@ -129,7 +129,7 @@ func (ft *FlowTrace) StringToSpan(val string) (*LangsmithState, error) {
 		return nil, nil
 	}
 	state := &LangsmithState{}
-	err := sonic.Unmarshal([]byte(val), state)
+	err := json.Unmarshal([]byte(val), state)
 	if err != nil {
 		return nil, err
 	}

--- a/callbacks/langsmith/langsmith.go
+++ b/callbacks/langsmith/langsmith.go
@@ -18,6 +18,7 @@ package langsmith
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -25,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/schema"
 	"github.com/google/uuid"
@@ -84,11 +84,12 @@ func (c *CallbackHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, 
 	if opts == nil {
 		opts = &traceOptions{}
 	}
-	in, err := sonic.MarshalString(input)
+	inBytes, err := json.Marshal(input)
 	if err != nil {
 		log.Printf("marshal input error: %v, runinfo: %+v", err, info)
 		return ctx
 	}
+	in := string(inBytes)
 	var metaData = SafeDeepCopySyncMapMetadata(opts.Metadata)
 	if input != nil {
 		modelConf, _, _, _ := extractModelInput(convModelCallbackInput([]callbacks.CallbackInput{input}))
@@ -158,11 +159,12 @@ func (c *CallbackHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo, ou
 		log.Printf("[langsmith] no state in context on OnEnd, runinfo: %+v", info)
 		return ctx
 	}
-	out, err := sonic.MarshalString(output)
+	outBytes, err := json.Marshal(output)
 	if err != nil {
 		log.Printf("marshal output error: %v, runinfo: %+v", err, info)
 		return ctx
 	}
+	out := string(outBytes)
 
 	endTime := time.Now().UTC()
 	patch := &RunPatch{


### PR DESCRIPTION
## Background\nGo 1.24 environments can hit linker/runtime issues via transitive github.com/bytedance/sonic/loader dependency.\n\n## Changes\n- callbacks/langsmith: replace sonic marshal/unmarshal with encoding/json\n- callbacks/langfuse: replace sonic marshal calls with encoding/json\n- run go mod tidy in both callback submodules\n\n## Scope\nThis PR only updates callback submodules where sonic was directly imported and used for JSON serialization.\n\n## Notes\nMainline behavior is preserved; only JSON codec implementation is changed for compatibility.