### PR TITLE
fix(gemini): gemini tool_call part position

### DIFF
--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -784,25 +784,28 @@ func convSchemaMessage(message *schema.Message) (*genai.Content, error) {
 		content.Parts = append(content.Parts, thoughtPart)
 	}
 
-	for i := range message.ToolCalls {
-		call := &message.ToolCalls[i]
-		args := make(map[string]any)
-		err := sonic.UnmarshalString(call.Function.Arguments, &args)
-		if err != nil {
-			return nil, fmt.Errorf("unmarshal schema tool call arguments to map[string]any fail: %w", err)
-		}
+	addToolCallPart := func() error {
+		for i := range message.ToolCalls {
+			call := &message.ToolCalls[i]
+			args := make(map[string]any)
+			err := sonic.UnmarshalString(call.Function.Arguments, &args)
+			if err != nil {
+				return fmt.Errorf("unmarshal schema tool call arguments to map[string]any fail: %w", err)
+			}
 
-		part := genai.NewPartFromFunctionCall(call.Function.Name, args)
-		// Restore thought signature on the functionCall part if present.
-		// Per Gemini docs (https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures):
-		// - Signatures must be returned exactly as received on functionCall parts
-		// - For parallel calls: only first functionCall has signature
-		// - For sequential calls: each functionCall has its own signature
-		// - Omitting required signature causes 400 error on Gemini 3 Pro
-		if sig := getToolCallThoughtSignature(call); len(sig) > 0 {
-			part.ThoughtSignature = sig
+			part := genai.NewPartFromFunctionCall(call.Function.Name, args)
+			// Restore thought signature on the functionCall part if present.
+			// Per Gemini docs (https://cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures):
+			// - Signatures must be returned exactly as received on functionCall parts
+			// - For parallel calls: only first functionCall has signature
+			// - For sequential calls: each functionCall has its own signature
+			// - Omitting required signature causes 400 error on Gemini 3 Pro
+			if sig := getToolCallThoughtSignature(call); len(sig) > 0 {
+				part.ThoughtSignature = sig
+			}
+			content.Parts = append(content.Parts, part)
 		}
-		content.Parts = append(content.Parts, part)
+		return nil
 	}
 
 	if len(message.UserInputMultiContent) > 0 && len(message.AssistantGenMultiContent) > 0 {
@@ -827,6 +830,9 @@ func convSchemaMessage(message *schema.Message) (*genai.Content, error) {
 			return nil, err
 		}
 		content.Parts = append(content.Parts, parts...)
+		if err = addToolCallPart(); err != nil {
+			return nil, err
+		}
 		return content, nil
 	}
 	if message.Content != "" {
@@ -841,6 +847,9 @@ func convSchemaMessage(message *schema.Message) (*genai.Content, error) {
 			}
 		}
 		content.Parts = append(content.Parts, textPart)
+	}
+	if err := addToolCallPart(); err != nil {
+		return nil, err
 	}
 	if len(message.MultiContent) > 0 {
 		log.Printf("MultiContent field is deprecated, please use UserInputMultiContent or AssistantGenMultiContent instead")

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1309,12 +1309,12 @@ func TestUniqueToolCallIDs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, message)
 		assert.Len(t, message.ToolCalls, 3)
-		
+
 		// Verify all IDs are valid UUIDs
 		assert.True(t, isValidUUID(message.ToolCalls[0].ID), "ID 0 should be a valid UUID")
 		assert.True(t, isValidUUID(message.ToolCalls[1].ID), "ID 1 should be a valid UUID")
 		assert.True(t, isValidUUID(message.ToolCalls[2].ID), "ID 2 should be a valid UUID")
-		
+
 		// Verify all IDs are unique
 		assert.NotEqual(t, message.ToolCalls[0].ID, message.ToolCalls[1].ID, "IDs should be unique")
 		assert.NotEqual(t, message.ToolCalls[0].ID, message.ToolCalls[2].ID, "IDs should be unique")
@@ -1366,12 +1366,12 @@ func TestUniqueToolCallIDs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, message)
 		assert.Len(t, message.ToolCalls, 3)
-		
+
 		// Verify all IDs are valid UUIDs
 		for i, tc := range message.ToolCalls {
 			assert.True(t, isValidUUID(tc.ID), "ID %d should be a valid UUID", i)
 		}
-		
+
 		// Verify all IDs are unique
 		ids := make(map[string]bool)
 		for _, tc := range message.ToolCalls {
@@ -1423,7 +1423,7 @@ func TestUniqueToolCallIDs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, message)
 		assert.Len(t, message.ToolCalls, 5)
-		
+
 		// Verify all IDs are valid UUIDs and unique
 		ids := make(map[string]bool)
 		for i, tc := range message.ToolCalls {
@@ -1489,9 +1489,104 @@ func TestUniqueToolCallIDs(t *testing.T) {
 		assert.NotNil(t, message2)
 		assert.Len(t, message2.ToolCalls, 1)
 		assert.True(t, isValidUUID(message2.ToolCalls[0].ID))
-		
+
 		// Verify IDs across responses are unique
 		assert.NotEqual(t, message1.ToolCalls[0].ID, message2.ToolCalls[0].ID)
 		assert.NotEqual(t, message1.ToolCalls[1].ID, message2.ToolCalls[0].ID)
+	})
+}
+
+func TestConvSchemaMessageToolCallOrder(t *testing.T) {
+	t.Run("AssistantGenMultiContent with tool calls - tool calls come after media parts", func(t *testing.T) {
+		base64Data := base64.StdEncoding.EncodeToString([]byte("123"))
+		message := &schema.Message{
+			Role: schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{
+				{Type: schema.ChatMessagePartTypeText, Text: "Here's the image:"},
+				{Type: schema.ChatMessagePartTypeImageURL, Image: &schema.MessageOutputImage{MessagePartCommon: schema.MessagePartCommon{Base64Data: &base64Data, MIMEType: "image/png"}}},
+			},
+			ToolCalls: []schema.ToolCall{
+				{
+					ID: "call_1",
+					Function: schema.FunctionCall{
+						Name:      "analyze_image",
+						Arguments: `{"image_id":"123"}`,
+					},
+				},
+			},
+		}
+
+		content, err := convSchemaMessage(message)
+		assert.NoError(t, err)
+		assert.NotNil(t, content)
+		assert.Len(t, content.Parts, 3)
+
+		assert.Equal(t, "Here's the image:", content.Parts[0].Text)
+		assert.NotNil(t, content.Parts[1].InlineData)
+		assert.Equal(t, "image/png", content.Parts[1].InlineData.MIMEType)
+		assert.NotNil(t, content.Parts[2].FunctionCall)
+		assert.Equal(t, "analyze_image", content.Parts[2].FunctionCall.Name)
+	})
+
+	t.Run("Content with reasoning and tool calls - correct order", func(t *testing.T) {
+		message := &schema.Message{
+			Role:             schema.Assistant,
+			Content:          "Final answer",
+			ReasoningContent: "Thinking process",
+			ToolCalls: []schema.ToolCall{
+				{
+					ID: "call_1",
+					Function: schema.FunctionCall{
+						Name:      "tool",
+						Arguments: `{}`,
+					},
+				},
+			},
+		}
+
+		content, err := convSchemaMessage(message)
+		assert.NoError(t, err)
+		assert.NotNil(t, content)
+		assert.Len(t, content.Parts, 3)
+
+		assert.True(t, content.Parts[0].Thought)
+		assert.Equal(t, "Thinking process", content.Parts[0].Text)
+		assert.Equal(t, "Final answer", content.Parts[1].Text)
+		assert.NotNil(t, content.Parts[2].FunctionCall)
+		assert.Equal(t, "tool", content.Parts[2].FunctionCall.Name)
+	})
+
+	t.Run("Multiple tool calls with content - all tool calls come after text", func(t *testing.T) {
+		message := &schema.Message{
+			Role:    schema.Assistant,
+			Content: "I need to check several things:",
+			ToolCalls: []schema.ToolCall{
+				{
+					ID: "call_1",
+					Function: schema.FunctionCall{
+						Name:      "tool1",
+						Arguments: `{"a":1}`,
+					},
+				},
+				{
+					ID: "call_2",
+					Function: schema.FunctionCall{
+						Name:      "tool2",
+						Arguments: `{"b":2}`,
+					},
+				},
+			},
+		}
+
+		content, err := convSchemaMessage(message)
+		assert.NoError(t, err)
+		assert.NotNil(t, content)
+		assert.Len(t, content.Parts, 3)
+
+		assert.Equal(t, "I need to check several things:", content.Parts[0].Text)
+		assert.NotNil(t, content.Parts[1].FunctionCall)
+		assert.Equal(t, "tool1", content.Parts[1].FunctionCall.Name)
+		assert.NotNil(t, content.Parts[2].FunctionCall)
+		assert.Equal(t, "tool2", content.Parts[2].FunctionCall.Name)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(gemini): assistant message 通过 convSchemaMessage 还原为 candidate parts 时，tool call part 所在位置问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
- en: This PR fixes the order of tool call parts in the convSchemaMessage function. Previously, tool call parts were added at the beginning of the content parts list, which could cause issues with Gemini API expectations. Now tool call parts are properly placed after media parts (when using AssistantGenMultiContent ) or after text parts (when using Content ). This ensures compatibility with Gemini's expected message format.

- zh(optional): 此 PR 修复了 convSchemaMessage 函数中 tool call 部分的顺序问题。之前，tool call 部分被添加到 content parts 列表的开头，这可能导致与 Gemini API 期望不兼容的问题。现在，tool call 部分被正确地放置在 media 部分之后（当使用 AssistantGenMultiContent 时）或 text 部分之后（当使用 Content 时）。这确保了与 Gemini 期望的消息格式的兼容性。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
