### PR TITLE
fix(claude): pass HTTPClient to Anthropic SDK for Bedrock

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -102,7 +102,14 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 		if config.HTTPClient != nil {
 			opts = append(opts, awsConfig.WithHTTPClient(config.HTTPClient))
 		}
-		cli = anthropic.NewClient(bedrock.WithLoadDefaultConfig(ctx, opts...))
+
+		// AWS config HTTP client is used for credential/signing requests;
+		// option.WithHTTPClient is used for actual Anthropic API calls via Bedrock.
+		clientOpts := []option.RequestOption{bedrock.WithLoadDefaultConfig(ctx, opts...)}
+		if config.HTTPClient != nil {
+			clientOpts = append(clientOpts, option.WithHTTPClient(config.HTTPClient))
+		}
+		cli = anthropic.NewClient(clientOpts...)
 	} else {
 		// Use direct Anthropic API
 		var opts []option.RequestOption


### PR DESCRIPTION
## Summary

Fixes https://github.com/cloudwego/eino-ext/issues/712

- The Anthropic SDK's HTTP calls were not using the custom `HTTPClient` when configured with Bedrock — only AWS credential/signing requests used it
- Adds `option.WithHTTPClient` so the user's client is used for both AWS and Anthropic SDK layers
- Removes unnecessary `BuildableClient` workaround that partially copied transport fields, silently dropping settings like connection pool limits, timeouts, and failing entirely for custom `RoundTripper` implementations

## Test plan
- [ ] Verify Bedrock requests use the custom HTTPClient for both credential and API calls
- [ ] Verify non-Bedrock (direct API / Vertex) paths are unaffected
- [ ] Verify with custom proxy/TLS settings that they are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)