### PR TITLE
feat(backend): allow Write method to overwrite existing files

### DIFF
--- a/adk/backend/agentkit/code_template.go
+++ b/adk/backend/agentkit/code_template.go
@@ -68,15 +68,9 @@ except PermissionError:
 `
 	writePythonCodeTemplate = `
 import os
-import sys
 import base64
 
 file_path = '{file_path}'
-
-# Check if file already exists (atomic with write)
-if os.path.exists(file_path):
-    print(f"Error: File '{{file_path}}' already exists", file=sys.stderr)
-    sys.exit(-1)
 
 # Create parent directory if needed
 parent_dir = os.path.dirname(file_path) or '.'

--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -331,11 +331,8 @@ func (s *Local) Write(ctx context.Context, req *filesystem.WriteRequest) error {
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
-	file, err := os.OpenFile(req.FilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	file, err := os.OpenFile(req.FilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		if os.IsExist(err) {
-			return fmt.Errorf("file '%s' already exists", req.FilePath)
-		}
 		return fmt.Errorf("failed to open file for writing: %w", err)
 	}
 	defer file.Close()

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -176,8 +176,8 @@ func TestWrite(t *testing.T) {
 
 		req := &filesystem.WriteRequest{FilePath: filePath, Content: "new content"}
 		err := s.Write(ctx, req)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "already exists")
+		assert.NoError(t, err)
+
 	})
 }
 


### PR DESCRIPTION
- Change local backend OpenFile flag from O_EXCL to O_TRUNC so that writing to an existing file truncates and overwrites instead of returning an error
- Remove the os.IsExist error check that was no longer needed
- Remove the os.path.exists pre-check in the agentkit Python write template, since Python open('w') already overwrites by default
- Remove unused `import sys` from the write template
- Update test to assert overwrite succeeds instead of expecting an error
