### PR TITLE
fix(openrouter): register []*reasoningDetails with gob for checkpoint serialization

### DIFF
--- a/components/model/openrouter/message_extra.go
+++ b/components/model/openrouter/message_extra.go
@@ -39,6 +39,7 @@ func init() {
 		return final, nil
 	})
 	schema.RegisterName[*reasoningDetails]("_eino_ext_openrouter_reasoning_details")
+	schema.RegisterName[[]*reasoningDetails]("_eino_ext_openrouter_reasoning_details_slice")
 
 	compose.RegisterStreamChunkConcatFunc(func(chunks []*StreamTerminatedError) (final *StreamTerminatedError, err error) {
 		if len(chunks) == 0 {


### PR DESCRIPTION
## Summary

`setReasoningDetails` stores `[]*reasoningDetails` in `msg.Extra`, but only `*reasoningDetails` was registered via `schema.RegisterName` (and thus `gob.RegisterName`). When the ADK framework gob-encodes a checkpoint that contains messages from the openrouter model, it fails with:

```
gob: type not registered for interface: []*openrouter.reasoningDetails
```

This PR adds the missing `schema.RegisterName[[]*reasoningDetails](...)` call so the slice type is also registered with gob, fixing checkpoint serialization.

## Changes

- `components/model/openrouter/message_extra.go`: added `schema.RegisterName[[]*reasoningDetails]("_eino_ext_openrouter_reasoning_details_slice")` in `init()`.

## How to reproduce

1. Use the openrouter model with reasoning enabled in an ADK agent.
2. Configure a `CheckPointStore` on the runner.
3. Trigger an interrupt (e.g. via `StatefulInterrupt`).
4. The checkpoint save fails with the gob error above because the agent state includes model response messages whose `Extra` map contains `[]*reasoningDetails`.

Made with [Cursor](https://cursor.com)