### PR TITLE
fix(agentkit): fix glob output parsing to use JSON array

### DIFF
--- a/adk/backend/agentkit/code_template.go
+++ b/adk/backend/agentkit/code_template.go
@@ -220,6 +220,7 @@ pattern = base64.b64decode('{pattern_b64}').decode('utf-8')
 
 os.chdir(path)
 matches = sorted(glob.glob(pattern, recursive=True))
+results = []
 for m in matches:
     stat = os.stat(m)
     result = {{
@@ -228,7 +229,8 @@ for m in matches:
         'mtime': stat.st_mtime,
         'is_dir': os.path.isdir(m)
     }}
-    print(json.dumps(result), end="")
+    results.append(result)
+print(json.dumps(results), end="")
 `
 	executePythonCodeTemplate = `
 import sys

--- a/adk/backend/agentkit/sandbox.go
+++ b/adk/backend/agentkit/sandbox.go
@@ -323,16 +323,12 @@ func (s *SandboxTool) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequ
 		return files, nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	for _, line := range lines {
-		var fi filesystem.FileInfo
-		if err := json.Unmarshal([]byte(line), &fi); err != nil {
-			continue
-		}
-		files = append(files, fi)
+	err = json.Unmarshal([]byte(output), &files)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse glob output: %w", err)
 	}
-
 	return files, nil
+	
 }
 
 // Write creates file content.

--- a/adk/backend/agentkit/sandbox_test.go
+++ b/adk/backend/agentkit/sandbox_test.go
@@ -253,7 +253,7 @@ func TestArkSandbox_FileSystemMethods(t *testing.T) {
 	// GlobInfo Tests
 	t.Run("GlobInfo: Success", func(t *testing.T) {
 		mockAPIHandler = func(w http.ResponseWriter, r *http.Request) {
-			globOutput := `{"path": "file.go", "is_dir": false}`
+			globOutput := `[{"path": "file.go", "is_dir": false}]`
 			w.WriteHeader(http.StatusOK)
 			w.Write(createMockResponse(t, true, globOutput, "", ""))
 		}


### PR DESCRIPTION
- Change Python glob template to collect results into a list and output a single JSON array instead of one JSON object per line
- Simplify Go-side parsing by unmarshalling the entire output as a JSON array instead of splitting by newlines
- Update test mock to return JSON array format
