### PR TITLE
 feat(openrouter): add top-level cache control and support non-text parts 

### DIFF
--- a/components/model/openrouter/README.md
+++ b/components/model/openrouter/README.md
@@ -200,6 +200,14 @@ type Config struct {
     // Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters.
     Metadata map[string]string `json:"metadata,omitempty"`
     
+    // CacheControl sets the top-level cache_control for all requests from this model instance.
+    // This enables automatic prompt caching for supported providers:
+    //   - Anthropic Claude: auto-caching (recommended for multi-turn conversations)
+    //   - Gemini 2.5: explicit breakpoints
+    // Can be overridden per-request via WithCacheControl option.
+    // Optional.
+    CacheControl *CacheControl `json:"cache_control,omitempty"`
+    
     // ExtraFields will override any existing fields with the same key.
     // Optional. Useful for experimental features not yet officially supported.
     ExtraFields map[string]any `json:"extra_fields,omitempty"`
@@ -269,7 +277,31 @@ type Reasoning struct {
     Enabled *bool `json:"enabled,omitempty"`
 }
 
+type CacheControlTTL string
+
+const (
+    CacheControlTTL5Minutes  CacheControlTTL = "5m"
+    CacheControlTTL1Hour     CacheControlTTL = "1h"
+)
+
+// CacheControl is the cache control configuration for prompt caching.
+// If TTL is empty, it defaults to CacheControlTTL5Minutes.
+type CacheControl struct {
+    TTL CacheControlTTL `json:"ttl,omitempty"`
+}
+
 ```
+
+## Request Options
+
+Per-request options can override Config-level settings:
+
+- `WithModels(models []string)` — Override model fallback list
+- `WithReasoning(r *Reasoning)` — Override reasoning configuration
+- `WithMetadata(m map[string]string)` — Override metadata
+- `WithCacheControl(ctrl CacheControl)` — Override cache control
+- `WithResponseFormat(rf *ChatCompletionResponseFormat)` — Override response format
+
 ## Examples
 
 See the following examples for more usage:

--- a/components/model/openrouter/README_zh.md
+++ b/components/model/openrouter/README_zh.md
@@ -199,6 +199,14 @@ type Config struct {
     // Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters.
     Metadata map[string]string `json:"metadata,omitempty"`
     
+    // CacheControl sets the top-level cache_control for all requests from this model instance.
+    // This enables automatic prompt caching for supported providers:
+    //   - Anthropic Claude: auto-caching (recommended for multi-turn conversations)
+    //   - Gemini 2.5: explicit breakpoints
+    // Can be overridden per-request via WithCacheControl option.
+    // Optional.
+    CacheControl *CacheControl `json:"cache_control,omitempty"`
+    
     // ExtraFields will override any existing fields with the same key.
     // Optional. Useful for experimental features not yet officially supported.
     ExtraFields map[string]any `json:"extra_fields,omitempty"`
@@ -268,7 +276,30 @@ type Reasoning struct {
     Enabled *bool `json:"enabled,omitempty"`
 }
 
+type CacheControlTTL string
+
+const (
+    CacheControlTTL5Minutes  CacheControlTTL = "5m"
+    CacheControlTTL1Hour     CacheControlTTL = "1h"
+)
+
+// CacheControl is the cache control configuration for prompt caching.
+// If TTL is empty, it defaults to CacheControlTTL5Minutes.
+type CacheControl struct {
+    TTL CacheControlTTL `json:"ttl,omitempty"`
+}
+
 ```
+
+## 请求级选项
+
+以下选项可在每次请求时覆盖 Config 级别的设置：
+
+- `WithModels(models []string)` — 覆盖模型回退列表
+- `WithReasoning(r *Reasoning)` — 覆盖推理配置
+- `WithMetadata(m map[string]string)` — 覆盖元数据
+- `WithCacheControl(ctrl CacheControl)` — 覆盖缓存控制
+- `WithResponseFormat(rf *ChatCompletionResponseFormat)` — 覆盖响应格式
 
 ## 示例
 

--- a/components/model/openrouter/chatmodel.go
+++ b/components/model/openrouter/chatmodel.go
@@ -127,17 +127,27 @@ type Config struct {
 	// Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters.
 	Metadata map[string]string `json:"metadata,omitempty"`
 
+	// CacheControl sets the top-level cache_control for all requests from this model instance.
+	// This enables automatic prompt caching for supported providers:
+	//   - Anthropic Claude: auto-caching (recommended for multi-turn conversations)
+	//   - Gemini 2.5: explicit breakpoints
+	// Can be overridden per-request via WithCacheControl option.
+	// Optional.
+	CacheControl *CacheControl `json:"cache_control,omitempty"`
+
 	// ExtraFields will override any existing fields with the same key.
 	// Optional. Useful for experimental features not yet officially supported.
 	ExtraFields map[string]any `json:"extra_fields,omitempty"`
 }
 
 type ChatModel struct {
-	cli            *openai.Client
+	cli *openai.Client
+
 	models         []string
 	reasoning      *Reasoning
 	responseFormat *ChatCompletionResponseFormat
 	metadata       map[string]string
+	cacheControl   *cacheControl
 }
 
 func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
@@ -189,6 +199,7 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 	chatModel.reasoning = config.Reasoning
 	chatModel.metadata = config.Metadata
 	chatModel.responseFormat = config.ResponseFormat
+	chatModel.cacheControl = config.CacheControl.toInternal()
 
 	return chatModel, nil
 }
@@ -219,10 +230,18 @@ func (cm *ChatModel) buildRequestModifier(option *openrouterOption) openai.Reque
 			models          = option.models
 			reasoning       = option.reasoning
 			metadata        = option.metadata
+			responseFormat  = option.responseFormat
 			modifiedRawBody = make([]byte, len(rawBody))
 		)
 
 		_ = copy(modifiedRawBody, rawBody)
+
+		if responseFormat != nil {
+			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "response_format", responseFormat)
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		if len(models) > 0 {
 			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "models", models)
@@ -230,6 +249,7 @@ func (cm *ChatModel) buildRequestModifier(option *openrouterOption) openai.Reque
 				return nil, err
 			}
 		}
+
 		if reasoning != nil {
 			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "reasoning", reasoning)
 			if err != nil {
@@ -237,15 +257,14 @@ func (cm *ChatModel) buildRequestModifier(option *openrouterOption) openai.Reque
 			}
 		}
 
-		if cm.metadata != nil {
+		if metadata != nil {
 			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "metadata", metadata)
 			if err != nil {
 				return nil, err
 			}
 		}
-
-		if cm.responseFormat != nil {
-			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "response_format", cm.responseFormat)
+		if option.cacheControl != nil {
+			modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, "cache_control", option.cacheControl)
 			if err != nil {
 				return nil, err
 			}
@@ -261,30 +280,25 @@ func (cm *ChatModel) buildRequestModifier(option *openrouterOption) openai.Reque
 
 			if len(msg.UserInputMultiContent) > 0 {
 				for cIdx, part := range msg.UserInputMultiContent {
-					if part.Type == schema.ChatMessagePartTypeText {
-						if ctrl, ok := getMessageInputPartCacheControl(&part); ok {
-							modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, fmt.Sprintf("messages.%d.content.%d.cache_control", index, cIdx), ctrl)
-							if err != nil {
-								return nil, err
-							}
-						}
-					} else {
-						return nil, fmt.Errorf("only 'ChatMessagePartTypeText' support cache control in 'MessageInputPart', but got part type '%s'", part.Type)
+					ctrl, ok := getMessageInputPartCacheControl(&part)
+					if !ok {
+						continue
+					}
+					modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, fmt.Sprintf("messages.%d.content.%d.cache_control", index, cIdx), ctrl)
+					if err != nil {
+						return nil, err
 					}
 				}
 
 			} else if len(msg.AssistantGenMultiContent) > 0 {
 				for cIdx, part := range msg.AssistantGenMultiContent {
-					if part.Type == schema.ChatMessagePartTypeText {
-						if ctrl, ok := getMessageOutputPartCacheControl(&part); ok {
-							modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, fmt.Sprintf("messages.%d.content.%d.cache_control", index, cIdx), ctrl)
-							if err != nil {
-								return nil, err
-							}
-						}
-					} else {
-						return nil, fmt.Errorf("only 'ChatMessagePartTypeText' support cache control in 'MessageOutputPart', but got part type '%s'", part.Type)
-
+					ctrl, ok := getMessageOutputPartCacheControl(&part)
+					if !ok {
+						continue
+					}
+					modifiedRawBody, err = sjson.SetBytes(modifiedRawBody, fmt.Sprintf("messages.%d.content.%d.cache_control", index, cIdx), ctrl)
+					if err != nil {
+						return nil, err
 					}
 				}
 			} else if msg.Content != "" {
@@ -375,9 +389,11 @@ func (cm *ChatModel) buildResponseChunkMessageModifier() openai.ResponseChunkMes
 
 func (cm *ChatModel) buildOptions(_ context.Context, isStream bool, opts ...model.Option) []model.Option {
 	specificOption := model.GetImplSpecificOptions(&openrouterOption{
-		models:    cm.models,
-		reasoning: cm.reasoning,
-		metadata:  cm.metadata,
+		models:         cm.models,
+		reasoning:      cm.reasoning,
+		metadata:       cm.metadata,
+		cacheControl:   cm.cacheControl,
+		responseFormat: cm.responseFormat,
 	}, opts...)
 
 	modelOptions := model.GetCommonOptions(&model.Options{}, opts...)
@@ -434,7 +450,15 @@ func (cm *ChatModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatM
 	if err != nil {
 		return nil, err
 	}
-	return &ChatModel{cli: cli}, nil
+	return &ChatModel{
+		cli: cli,
+
+		models:         cm.models,
+		reasoning:      cm.reasoning,
+		responseFormat: cm.responseFormat,
+		metadata:       cm.metadata,
+		cacheControl:   cm.cacheControl,
+	}, nil
 }
 
 func populateSchemaMessageFields(msg *schema.Message, message *message) {

--- a/components/model/openrouter/chatmodel_test.go
+++ b/components/model/openrouter/chatmodel_test.go
@@ -175,6 +175,9 @@ func TestChatModel_buildRequestModifier(t *testing.T) {
 	}
 	modifier := cm.buildRequestModifier(&openrouterOption{
 		models: []string{"option_v1", "option_v2"},
+		responseFormat: &ChatCompletionResponseFormat{
+			Type: "json_object",
+		},
 	})
 
 	inMsg := []*schema.Message{
@@ -376,4 +379,237 @@ func TestChatModel_Tools(t *testing.T) {
 
 	assert.NoError(t, err)
 
+}
+
+func TestChatModel_buildRequestModifier_CacheControl(t *testing.T) {
+	cm := &ChatModel{}
+
+	t.Run("UserInputMultiContent text part with cache control", func(t *testing.T) {
+		part := schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: "hello",
+		}
+		EnableMessageInputPartCacheControl(&part)
+
+		msg := &schema.Message{
+			Role:                  schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{part},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "content", 0, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+	})
+
+	t.Run("UserInputMultiContent text part without cache control skipped", func(t *testing.T) {
+		part := schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: "hello",
+		}
+
+		msg := &schema.Message{
+			Role:                  schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{part},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "content", 0, "cache_control")
+		assert.Equal(t, jsoniter.InvalidValue, cacheCtrl.ValueType())
+	})
+
+	t.Run("UserInputMultiContent non-text part without cache control skipped", func(t *testing.T) {
+		textPart := schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: "hello",
+		}
+		imgPart := schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+		}
+
+		msg := &schema.Message{
+			Role:                  schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{textPart, imgPart},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"image_url"}]}]}`))
+		assert.NoError(t, err)
+		assert.NotNil(t, body)
+	})
+
+	t.Run("UserInputMultiContent non-text part with cache control injects cache_control", func(t *testing.T) {
+		imgPart := schema.MessageInputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+		}
+		EnableMessageInputPartCacheControl(&imgPart)
+
+		msg := &schema.Message{
+			Role:                  schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{imgPart},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":[{"type":"image_url"}]}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "content", 0, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+	})
+
+	t.Run("AssistantGenMultiContent text part with cache control", func(t *testing.T) {
+		part := schema.MessageOutputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: "response",
+		}
+		EnableMessageOutputPartCacheControl(&part)
+
+		msg := &schema.Message{
+			Role:                     schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{part},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"response"}]}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "content", 0, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+	})
+
+	t.Run("AssistantGenMultiContent non-text part without cache control skipped", func(t *testing.T) {
+		textPart := schema.MessageOutputPart{
+			Type: schema.ChatMessagePartTypeText,
+			Text: "response",
+		}
+		imgPart := schema.MessageOutputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+		}
+
+		msg := &schema.Message{
+			Role:                     schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{textPart, imgPart},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"response"},{"type":"image_url"}]}]}`))
+		assert.NoError(t, err)
+		assert.NotNil(t, body)
+	})
+
+	t.Run("AssistantGenMultiContent non-text part with cache control injects cache_control", func(t *testing.T) {
+		imgPart := schema.MessageOutputPart{
+			Type: schema.ChatMessagePartTypeImageURL,
+		}
+		EnableMessageOutputPartCacheControl(&imgPart)
+
+		msg := &schema.Message{
+			Role:                     schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{imgPart},
+		}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"assistant","content":[{"type":"image_url"}]}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "content", 0, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+	})
+
+	t.Run("message content with cache control", func(t *testing.T) {
+		msg := &schema.Message{
+			Role:    schema.User,
+			Content: "hello",
+		}
+		EnableMessageContentCacheControl(msg)
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":"hello"}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "messages", 0, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+	})
+
+	t.Run("top-level cache_control via option", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.User, Content: "hello"}
+
+		ctrl := CacheControl{TTL: CacheControlTTL1Hour}
+		modifier := cm.buildRequestModifier(&openrouterOption{cacheControl: ctrl.toInternal()})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":"hello"}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+		assert.Equal(t, "1h", cacheCtrl.Get("ttl").ToString())
+	})
+
+	t.Run("top-level cache_control not set when option is nil", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.User, Content: "hello"}
+
+		modifier := cm.buildRequestModifier(&openrouterOption{})
+		body, err := modifier(t.Context(), []*schema.Message{msg}, []byte(`{"messages":[{"role":"user","content":"hello"}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "cache_control")
+		assert.Equal(t, jsoniter.InvalidValue, cacheCtrl.ValueType())
+	})
+}
+
+func TestChatModel_buildOptions_CacheControlFallback(t *testing.T) {
+	configCtrl := &CacheControl{TTL: CacheControlTTL5Minutes}
+	cm := &ChatModel{
+		cacheControl: configCtrl.toInternal(),
+	}
+
+	t.Run("config-level cacheControl used when no option override", func(t *testing.T) {
+		modifier := cm.buildRequestModifier(&openrouterOption{cacheControl: cm.cacheControl})
+		body, err := modifier(t.Context(), []*schema.Message{{Role: schema.User, Content: "hi"}}, []byte(`{"messages":[{"role":"user","content":"hi"}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "cache_control")
+		assert.Equal(t, "ephemeral", cacheCtrl.Get("type").ToString())
+		assert.Equal(t, "5m", cacheCtrl.Get("ttl").ToString())
+	})
+
+	t.Run("option-level cacheControl overrides config", func(t *testing.T) {
+		optCtrl := CacheControl{TTL: CacheControlTTL1Hour}
+		modifier := cm.buildRequestModifier(&openrouterOption{cacheControl: optCtrl.toInternal()})
+		body, err := modifier(t.Context(), []*schema.Message{{Role: schema.User, Content: "hi"}}, []byte(`{"messages":[{"role":"user","content":"hi"}]}`))
+		assert.NoError(t, err)
+
+		cacheCtrl := jsoniter.Get(body, "cache_control")
+		assert.Equal(t, "1h", cacheCtrl.Get("ttl").ToString())
+	})
+}
+
+func TestChatModel_WithTools_PreservesFields(t *testing.T) {
+	ctrl := &CacheControl{TTL: CacheControlTTL1Hour}
+	rf := &ChatCompletionResponseFormat{Type: ChatCompletionResponseFormatTypeText}
+	cm := &ChatModel{
+		models:         []string{"model-a", "model-b"},
+		reasoning:      &Reasoning{Effort: "high"},
+		metadata:       map[string]string{"key": "value"},
+		cacheControl:   ctrl.toInternal(),
+		responseFormat: rf,
+	}
+
+	mockey.PatchConvey("WithTools preserves all fields", t, func() {
+		mockey.Mock((*openai.Client).WithToolsForClient).Return(&openai.Client{}, nil).Build()
+
+		toolModel, err := cm.WithTools([]*schema.ToolInfo{{Name: "test"}})
+		assert.NoError(t, err)
+
+		newCM := toolModel.(*ChatModel)
+		assert.Equal(t, cm.models, newCM.models)
+		assert.Equal(t, cm.reasoning, newCM.reasoning)
+		assert.Equal(t, cm.metadata, newCM.metadata)
+		assert.Equal(t, cm.cacheControl, newCM.cacheControl)
+		assert.Equal(t, cm.responseFormat, newCM.responseFormat)
+	})
 }

--- a/components/model/openrouter/message_extra.go
+++ b/components/model/openrouter/message_extra.go
@@ -129,13 +129,31 @@ const (
 	CacheControlTTL1Hour      CacheControlTTL = "1h"
 )
 
+// CacheControl is the exported cache control configuration, used only for Config and WithCacheControl option.
+// Internally it is converted to cacheControl via toInternal().
+// If TTL is empty, it defaults to CacheControlTTL5Minutes. Type is always set to "ephemeral" internally.
+type CacheControl struct {
+	TTL CacheControlTTL `json:"ttl,omitempty"`
+}
+
+func (c *CacheControl) toInternal() *cacheControl {
+	if c == nil {
+		return nil
+	}
+	cc := &cacheControl{Type: cacheControlEphemeralType, TTL: c.TTL}
+	if cc.TTL == "" {
+		cc.TTL = CacheControlTTL5Minutes
+	}
+	return cc
+}
+
+type CacheControlOption func(control *cacheControl)
+
 func WithCacheControlTTL(ttl CacheControlTTL) CacheControlOption {
 	return func(control *cacheControl) {
 		control.TTL = ttl
 	}
 }
-
-type CacheControlOption func(control *cacheControl)
 
 type cacheControl struct {
 	Type string          `json:"type,omitempty"`
@@ -225,7 +243,7 @@ func getMessageContentCacheControl(msg *schema.Message) (*cacheControl, bool) {
 		return nil, false
 	}
 	if msg.Extra == nil {
-		msg.Extra = map[string]any{}
+		return nil, false
 	}
 	ctrl, ok := msg.Extra[openrouterCacheControlKey].(*cacheControl)
 	return ctrl, ok

--- a/components/model/openrouter/message_extra_test.go
+++ b/components/model/openrouter/message_extra_test.go
@@ -211,12 +211,12 @@ func TestEnableMessageContentCacheControl(t *testing.T) {
 		assert.Equal(t, CacheControlTTL1Hour, ctrl.TTL)
 	})
 
-	t.Run("nil extra should be initialized", func(t *testing.T) {
+	t.Run("nil extra should not be initialized on get", func(t *testing.T) {
 		msg := &schema.Message{}
 		ctrl, ok := getMessageContentCacheControl(msg)
 		assert.False(t, ok)
 		assert.Nil(t, ctrl)
-		assert.NotNil(t, msg.Extra)
+		assert.Nil(t, msg.Extra)
 	})
 }
 

--- a/components/model/openrouter/option.go
+++ b/components/model/openrouter/option.go
@@ -19,9 +19,11 @@ package openrouter
 import "github.com/cloudwego/eino/components/model"
 
 type openrouterOption struct {
-	models    []string
-	reasoning *Reasoning
-	metadata  map[string]string
+	models         []string
+	reasoning      *Reasoning
+	metadata       map[string]string
+	cacheControl   *cacheControl
+	responseFormat *ChatCompletionResponseFormat
 }
 
 // WithModels provider an array of model IDs in priority order.
@@ -49,5 +51,22 @@ func WithMetadata(m map[string]string) model.Option {
 		for k, v := range m {
 			o.metadata[k] = v
 		}
+	})
+}
+
+// WithCacheControl sets the top-level cache_control for the request.
+// This enables automatic prompt caching for supported providers (e.g. Anthropic Claude, Gemini 2.5).
+// When set, it overrides the CacheControl field configured in Config for this specific request.
+func WithCacheControl(ctrl CacheControl) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *openrouterOption) {
+		o.cacheControl = ctrl.toInternal()
+	})
+}
+
+// WithResponseFormat sets the response format for the request.
+// When set, it overrides the ResponseFormat field configured in Config for this specific request.
+func WithResponseFormat(rf *ChatCompletionResponseFormat) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *openrouterOption) {
+		o.responseFormat = rf
 	})
 }


### PR DESCRIPTION
 ## Summary

  Closes #763

  - Export `CacheControl` type and add `NewCacheControl` constructor for flexible cache control configuration
  - Add top-level `cache_control` support in request body, enabling automatic multi-turn caching for Anthropic Claude and explicit breakpoints for Gemini 2.5
  - Add `WithCacheControl` option for per-request cache control override
  - Remove text-only restriction for explicit cache control breakpoints, now supports image, document, tool_use, and tool_result content types
  - Simplify cache control logic in `buildRequestModifier` by removing redundant type checks
  - Fix `getMessageContentCacheControl` getter side effect on nil Extra

  ## Test plan

  - [x] Unit tests for top-level cache control with default and 1h TTL
  - [x] Unit tests for non-text part (image) cache control injection
  - [x] Unit tests for nil cache control option
  - [x] Existing cache control tests updated and passing
  - [x] `go test -race ./...` passes
