### PR TITLE
fix(ark): make cache status tri-state to avoid sending caching field when unset

### DIFF
--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -486,6 +486,7 @@ func (cm *ResponsesAPIChatModel) genRequestAndOptions(in []*schema.Message, opti
 	if err != nil {
 		return nil, err
 	}
+
 	in, err = cm.populateCache(in, responseReq, specOptions)
 	if err != nil {
 		return nil, err
@@ -511,7 +512,7 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 
 	var (
 		store       = false
-		cacheStatus = cachingDisabled
+		cacheStatus *caching
 		cacheTTL    *int
 		headRespID  *string
 		contextID   *string
@@ -519,11 +520,15 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 
 	if cm.cache != nil {
 		if sCache := cm.cache.SessionCache; sCache != nil {
+			cacheTTL = &sCache.TTL
 			if sCache.EnableCache {
 				store = true
-				cacheStatus = cachingEnabled
+				cacheStatus = ptrOf(cachingEnabled)
+			} else {
+				store = false
+				cacheStatus = ptrOf(cachingDisabled)
 			}
-			cacheTTL = &sCache.TTL
+
 		}
 	}
 
@@ -537,10 +542,10 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 
 			if sCacheOpt.EnableCache {
 				store = true
-				cacheStatus = cachingEnabled
+				cacheStatus = ptrOf(cachingEnabled)
 			} else {
 				store = false
-				cacheStatus = cachingDisabled
+				cacheStatus = ptrOf(cachingDisabled)
 			}
 		}
 	}
@@ -556,7 +561,7 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 	// ContextID and ResponseID will exist at the same time.
 	// Using ContextID is prioritized to maintain compatibility with the old logic.
 	// In this usage scenario, ResponseID cannot be used.
-	if cacheStatus == cachingEnabled && contextID == nil {
+	if cacheStatus != nil && *cacheStatus == cachingEnabled && contextID == nil {
 		for i := len(in) - 1; i >= 0; i-- {
 			msg := in[i]
 			inputIdx = i
@@ -592,15 +597,17 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 		responseReq.ExpireAt = ptrOf(now + int64(*cacheTTL))
 	}
 
-	var cacheType *responses.CacheType_Enum
-	if cacheStatus == cachingDisabled {
-		cacheType = responses.CacheType_disabled.Enum()
-	} else {
-		cacheType = responses.CacheType_enabled.Enum()
-	}
-
-	responseReq.Caching = &responses.ResponsesCaching{
-		Type: cacheType,
+	if cacheStatus != nil {
+		switch *cacheStatus {
+		case cachingEnabled:
+			responseReq.Caching = &responses.ResponsesCaching{
+				Type: responses.CacheType_enabled.Enum(),
+			}
+		case cachingDisabled:
+			responseReq.Caching = &responses.ResponsesCaching{
+				Type: responses.CacheType_disabled.Enum(),
+			}
+		}
 	}
 
 	return in, nil

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -317,6 +317,7 @@ func TestResponsesAPIChatModelInjectCache(t *testing.T) {
 		in_, err := cm.populateCache(msgs, reqParams, arkOpts)
 		assert.Nil(t, err)
 		assert.Equal(t, false, *reqParams.Store)
+		assert.Nil(t, reqParams.Caching)
 		assert.Len(t, in_, 1)
 	})
 
@@ -351,6 +352,8 @@ func TestResponsesAPIChatModelInjectCache(t *testing.T) {
 		assert.Len(t, in_, 1)
 		assert.Equal(t, "World", in_[0].Content)
 		assert.NotNil(t, reqParams.ExpireAt)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_enabled, *reqParams.Caching.Type)
 	})
 	PatchConvey("option overridden config", t, func() {
 		cm := &ResponsesAPIChatModel{
@@ -393,6 +396,103 @@ func TestResponsesAPIChatModelInjectCache(t *testing.T) {
 		assert.Equal(t, "test-context", *reqParams.PreviousResponseId)
 		assert.Len(t, in_, 2)
 		assert.NotNil(t, reqParams.ExpireAt)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_enabled, *reqParams.Caching.Type)
+	})
+
+	PatchConvey("config disabled, option not set", t, func() {
+		cm := &ResponsesAPIChatModel{
+			cache: &CacheConfig{
+				SessionCache: &SessionCacheConfig{
+					EnableCache: false,
+					TTL:         300,
+				},
+			},
+		}
+		arkOpts := &arkOptions{}
+		msgs := []*schema.Message{
+			{Role: schema.User, Content: "Hello"},
+		}
+		reqParams := &responses.ResponsesRequest{}
+		in_, err := cm.populateCache(msgs, reqParams, arkOpts)
+		assert.Nil(t, err)
+		assert.Equal(t, false, *reqParams.Store)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_disabled, *reqParams.Caching.Type)
+		assert.Len(t, in_, 1)
+	})
+
+	PatchConvey("config enabled, option explicitly disables", t, func() {
+		cm := &ResponsesAPIChatModel{
+			cache: &CacheConfig{
+				SessionCache: &SessionCacheConfig{
+					EnableCache: true,
+					TTL:         300,
+				},
+			},
+		}
+		arkOpts := &arkOptions{
+			cache: &CacheOption{
+				SessionCache: &SessionCacheConfig{
+					EnableCache: false,
+					TTL:         600,
+				},
+			},
+		}
+		msgs := []*schema.Message{
+			{Role: schema.User, Content: "Hello"},
+		}
+		reqParams := &responses.ResponsesRequest{}
+		in_, err := cm.populateCache(msgs, reqParams, arkOpts)
+		assert.Nil(t, err)
+		assert.Equal(t, false, *reqParams.Store)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_disabled, *reqParams.Caching.Type)
+		assert.Len(t, in_, 1)
+	})
+
+	PatchConvey("config not set, option enabled", t, func() {
+		cm := &ResponsesAPIChatModel{}
+		arkOpts := &arkOptions{
+			cache: &CacheOption{
+				SessionCache: &SessionCacheConfig{
+					EnableCache: true,
+					TTL:         300,
+				},
+			},
+		}
+		msgs := []*schema.Message{
+			{Role: schema.User, Content: "Hello"},
+		}
+		reqParams := &responses.ResponsesRequest{}
+		in_, err := cm.populateCache(msgs, reqParams, arkOpts)
+		assert.Nil(t, err)
+		assert.Equal(t, true, *reqParams.Store)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_enabled, *reqParams.Caching.Type)
+		assert.Len(t, in_, 1)
+	})
+
+	PatchConvey("config not set, option disabled", t, func() {
+		cm := &ResponsesAPIChatModel{}
+		arkOpts := &arkOptions{
+			cache: &CacheOption{
+				SessionCache: &SessionCacheConfig{
+					EnableCache: false,
+					TTL:         300,
+				},
+			},
+		}
+		msgs := []*schema.Message{
+			{Role: schema.User, Content: "Hello"},
+		}
+		reqParams := &responses.ResponsesRequest{}
+		in_, err := cm.populateCache(msgs, reqParams, arkOpts)
+		assert.Nil(t, err)
+		assert.Equal(t, false, *reqParams.Store)
+		assert.NotNil(t, reqParams.Caching)
+		assert.Equal(t, responses.CacheType_disabled, *reqParams.Caching.Type)
+		assert.Len(t, in_, 1)
 	})
 }
 


### PR DESCRIPTION
Closes #770

- Change cacheStatus from default cachingDisabled to *caching pointer (nil/enabled/disabled)
- Only set responseReq.Caching when user explicitly configures session cache
- Add explicit store=false and cacheStatus=cachingDisabled in else branches
- Move cacheTTL assignment to align with sCache != nil scope

