### PR TITLE
docs(embedding/ark): add multimodal embedding example

### DIFF
--- a/components/embedding/ark/README.md
+++ b/components/embedding/ark/README.md
@@ -169,6 +169,7 @@ For more details about authentication, see the [VolcEngine documentation](https:
 See the following examples for more usage:
 
 - [Text Embedding](./examples/embedding/)
+- [Multi-Modal Embedding](./examples/multimodal_embedding/)
 
 ## License
 

--- a/components/embedding/ark/README_zh.md
+++ b/components/embedding/ark/README_zh.md
@@ -169,6 +169,7 @@ embedder 支持两种认证方式：
 查看以下示例了解更多用法：
 
 - [文本嵌入](./examples/embedding/)
+- [多模态嵌入](./examples/multimodal_embedding/)
 
 ## 许可证
 

--- a/components/embedding/ark/examples/multimodal_embedding/embedding.go
+++ b/components/embedding/ark/examples/multimodal_embedding/embedding.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/cloudwego/eino-ext/components/embedding/ark"
+)
+
+func main() {
+	ctx := context.Background()
+	apiType := ark.APITypeMultiModal
+
+	embedder, err := ark.NewEmbedder(ctx, &ark.EmbeddingConfig{
+		// you can get key from https://cloud.bytedance.net/ark/region:ark+cn-beijing/endpoint
+		// attention: model must support embedding, for example: doubao-embedding
+		APIKey:  os.Getenv("ARK_API_KEY"), // for example, "xxxxxx-xxxx-xxxx-xxxx-xxxxxxx"
+		Model:   os.Getenv("ARK_MODEL"),   // for example, "ep-20260327101403-xxxx"
+		APIType: &apiType,
+	})
+	if err != nil {
+		log.Printf("new multimodal embedder error: %v\n", err)
+		return
+	}
+
+	embedding, err := embedder.EmbedStrings(ctx, []string{"hello world", "hello world"})
+	if err != nil {
+		log.Printf("multimodal embedding error: %v\n", err)
+		return
+	}
+
+	log.Printf("embedding: %v\n", embedding)
+}


### PR DESCRIPTION
## Summary

This PR adds a multimodal embedding example for the Ark embedding component and updates the English and Chinese README files to clarify when `APITypeMultiModal` should be used.

## Changes

- add `examples/multimodal_embedding/embedding.go`
- update `README.md`
- update `README_zh.md`
- clarify that multimodal embedding endpoints such as `embedding-vision` should use `APITypeMultiModal`
- clarify that the multimodal embedding API accepts text-only input

## Verification

Verified by running:

```bash
cd components/embedding/ark
go run ./examples/multimodal_embedding/embedding.go
