### PR TITLE
fix(openai): use json.Unmarshal for reasoning content extraction

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/bytedance/sonic"
 	"github.com/eino-contrib/jsonschema"
 	"github.com/meguminnnnnnnnn/go-openai"
 
@@ -1185,11 +1186,15 @@ func populateRCFromExtra(extra map[string]json.RawMessage, msg *schema.Message) 
 	if extra == nil {
 		return
 	}
+
 	for _, key := range otherReasoningKeys {
-		if reasoningRawMessage, ok := extra[key]; ok && len(reasoningRawMessage) > 0 && string(reasoningRawMessage) != "null" {
-			msg.ReasoningContent = string(reasoningRawMessage)
-			setReasoningContent(msg, string(reasoningRawMessage))
-			break
+		if reasoningRawMessage, ok := extra[key]; ok {
+			var reasoningContent string
+			if err := sonic.Unmarshal(reasoningRawMessage, &reasoningContent); err == nil && reasoningContent != "" {
+				msg.ReasoningContent = reasoningContent
+				setReasoningContent(msg, reasoningContent)
+				break
+			}
 		}
 	}
 }

--- a/libs/acl/openai/go.mod
+++ b/libs/acl/openai/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.3.0
+	github.com/bytedance/sonic v1.14.1
 	github.com/cloudwego/eino v0.7.13
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/meguminnnnnnnnn/go-openai v0.1.2 // fork from github.com/sashabaranov/go-openai, temporary solution, switch to github.com/openai/openai-go in the future.
@@ -14,7 +15,6 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/libs/acl/openai/message_extra_test.go
+++ b/libs/acl/openai/message_extra_test.go
@@ -17,6 +17,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudwego/eino/schema"
@@ -64,4 +65,63 @@ func TestSetMsgExtra(t *testing.T) {
 	extraVal, ok := getMsgExtraValue[string](msg, "key")
 	assert.Equal(t, true, ok)
 	assert.Equal(t, "val", extraVal)
+}
+
+func TestPopulateRCFromExtra(t *testing.T) {
+	tests := []struct {
+		name            string
+		extra           map[string]json.RawMessage
+		wantRC          string
+		wantHasRC       bool
+	}{
+		{
+			name:      "normal string value",
+			extra:     map[string]json.RawMessage{"reasoning": json.RawMessage(`"thinking step by step"`)},
+			wantRC:    "thinking step by step",
+			wantHasRC: true,
+		},
+		{
+			name:      "null value",
+			extra:     map[string]json.RawMessage{"reasoning": json.RawMessage(`null`)},
+			wantRC:    "",
+			wantHasRC: false,
+		},
+		{
+			name:      "empty string value",
+			extra:     map[string]json.RawMessage{"reasoning": json.RawMessage(`""`)},
+			wantRC:    "",
+			wantHasRC: false,
+		},
+		{
+			name:      "non-string json type",
+			extra:     map[string]json.RawMessage{"reasoning": json.RawMessage(`{"key":"val"}`)},
+			wantRC:    "",
+			wantHasRC: false,
+		},
+		{
+			name:      "key not present",
+			extra:     map[string]json.RawMessage{"other": json.RawMessage(`"value"`)},
+			wantRC:    "",
+			wantHasRC: false,
+		},
+		{
+			name:      "nil extra",
+			extra:     nil,
+			wantRC:    "",
+			wantHasRC: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &schema.Message{}
+			populateRCFromExtra(tt.extra, msg)
+			assert.Equal(t, tt.wantRC, msg.ReasoningContent)
+			rc, ok := GetReasoningContent(msg)
+			assert.Equal(t, tt.wantHasRC, ok)
+			if tt.wantHasRC {
+				assert.Equal(t, tt.wantRC, rc)
+			}
+		})
+	}
 }


### PR DESCRIPTION
- Replace string(rawMessage) with json.Unmarshal to correctly decode JSON string values without surrounding quotes
- Properly handle null, empty string, and non-string JSON types
- Add table-driven tests for populateRCFromExtra covering 6 scenarios
