### PR TITLE
fix(devops): correct CompletionTokens assignment typo in callback handler

### DIFF
--- a/devops/internal/service/call_option.go
+++ b/devops/internal/service/call_option.go
@@ -140,7 +140,7 @@ func (c *callbackHandler) OnEnd(ctx context.Context, info *callbacks.RunInfo, ou
 	ext := c.ConvCallbackOutput(output)
 	if ext != nil && ext.TokenUsage != nil {
 		state.Metrics.PromptTokens = int64(ext.TokenUsage.PromptTokens)
-		state.Metrics.CompletionTokens = int64(ext.TokenUsage.PromptTokens)
+		state.Metrics.CompletionTokens = int64(ext.TokenUsage.CompletionTokens)
 	}
 
 	// append result

--- a/devops/internal/service/call_option_test.go
+++ b/devops/internal/service/call_option_test.go
@@ -148,6 +148,28 @@ func Test_OnEnd(t *testing.T) {
 		})
 		assert.Equal(t, actualCtx, ctx)
 	})
+	PatchConvey("Test token usage is correctly assigned to metrics", t, func() {
+		cb := &callbackHandler{
+			nodeKey:  "nodeKey",
+			threadID: "threadID",
+		}
+		cb.stateCh = make(chan *model.NodeDebugState, 1)
+		Mock(getNodeDebugStateCtx).Return(&nodeDebugStateCtxValue{invokeTimeMS: int64(1728630000), callbackInput: "input"}, true).Build()
+		output := &einomodel.CallbackOutput{
+			Message: &schema.Message{},
+			TokenUsage: &einomodel.TokenUsage{
+				PromptTokens:     42,
+				CompletionTokens: 420,
+			},
+		}
+		actualCtx := cb.OnEnd(ctx, info, output)
+		safego.Go(ctx, func() {
+			res, _ := <-cb.stateCh
+			assert.Equal(t, int64(42), res.Metrics.PromptTokens)
+			assert.Equal(t, int64(420), res.Metrics.CompletionTokens)
+		})
+		assert.Equal(t, actualCtx, ctx)
+	})
 }
 
 func Test_OnError(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
CompletionTokens 被错误赋值成 PromptTokens

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: In `devops/internal/service/call_option.go:143`, `CompletionTokens` was incorrectly assigned `ext.TokenUsage.PromptTokens` due to a copy-paste error. This causes the completion token count in DevOps debug metrics to always equal the prompt token count, making token usage statistics unreliable for billing analysis and performance monitoring.

zh(optional): 在 `devops/internal/service/call_option.go:143` 中，`CompletionTokens` 被错误地赋值为 `ext.TokenUsage.PromptTokens`。这导致 DevOps 调试指标中的 completion token 数量永远等于 prompt token 数量，使得 token 使用统计在计费分析和性能监控场景下不可信。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
