### PR TITLE
fix(langfuse): correct nil check variable typo in extractModelInput

### DIFF
--- a/callbacks/langfuse/utils.go
+++ b/callbacks/langfuse/utils.go
@@ -35,7 +35,7 @@ func convModelCallbackInput(in []callbacks.CallbackInput) []*model.CallbackInput
 func extractModelInput(ins []*model.CallbackInput) (config *model.Config, messages []*schema.Message, extra map[string]interface{}, err error) {
 	var mas [][]*schema.Message
 	for _, in := range ins {
-		if ins == nil {
+		if in == nil {
 			continue
 		}
 		if len(in.Messages) > 0 {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修正 extractModelInput 中 nil 检查的循环变量的使用错误，应当使用in而非ins

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
In `callbacks/langfuse/utils.go:38`, the nil-check inside the `for _, in := range ins` loop was mistakenly comparing `ins == nil` (the slice itself) instead of `in == nil` (the current element). This makes the guard useless: when `ins` is nil, the loop body never executes; when `ins` is non-nil but contains nil elements, the guard always evaluates to false, and the subsequent `in.Messages` / `in.Extra` / `in.Config` accesses will panic on nil pointer dereference.

  **Before**
  ```go
  for _, in := range ins {
      if ins == nil {   // bug: checks the slice, not the element
          continue
      }
      if len(in.Messages) > 0 { ... }  // panics if in is nil
  }
```
  **After**
```go
  for _, in := range ins {
      if in == nil {    // correct: checks the current element
          continue
      }
      if len(in.Messages) > 0 { ... }
  }
```
zh(optional): 
`callbacks/langfuse/utils.go:38` 中 for _, in := range ins 循环里的 nil 检查误将 in == nil（当前元素）写成了应该检查的 ins == nil（切片本身）。ins 为 nil 时循环根本不会进入；ins 非 nil 但含 nil 元素时，该判断恒为 false，后续 in.Messages 等访问会因空指针解引用 panic。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
