### PR TITLE
fix(devops): use errEvt payload when sending error SSE event

### DIFF
--- a/devops/internal/apihandler/debug.go
+++ b/devops/internal/apihandler/debug.go
@@ -162,7 +162,7 @@ func StreamDebugRun(res http.ResponseWriter, req *http.Request) {
 				evt := types.DebugRunDataEVT(debugID, state)
 				if err != nil {
 					errEvt := types.DebugRunErrEVT(debugID, err.Error())
-					sseStreamResponseChan <- NewStreamResponse(string(errEvt.Type), string(evt.JsonBytes()))
+					sseStreamResponseChan <- NewStreamResponse(string(errEvt.Type), string(errEvt.JsonBytes()))
 					return
 				}
 				sseStreamResponseChan <- NewStreamResponse(string(evt.Type), string(evt.JsonBytes()))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
发送错误 SSE 事件时使用 errEvt 的 payload

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
In `devops/internal/apihandler/debug.go:165`, when constructing the SSE response for the error branch, the event type is correctly taken from `errEvt.Type` but the payload is mistakenly taken from `evt.JsonBytes()` (the data event constructed one line earlier) instead of `errEvt.JsonBytes()`. As a result, the frontend receives an SSE message whose `event:` claims `error` but whose `data:` body is actually a regular data event JSON, so the real error string (`err.Error()`) is silently dropped and the error reporting path becomes unusable.
  **Before**
  ```go
  errEvt := types.DebugRunErrEVT(debugID, err.Error())
  sseStreamResponseChan <- NewStreamResponse(string(errEvt.Type), string(evt.JsonBytes()))
  //                                                              ^^^^^^^^^^^^^^^^^^^^ wrong source
```
  **After**
```go
  errEvt := types.DebugRunErrEVT(debugID, err.Error())
  sseStreamResponseChan <- NewStreamResponse(string(errEvt.Type), string(errEvt.JsonBytes()))
```
This aligns with the other error-sending site in the same file (line 178), where both the type and the payload come from the same event variable.
zh(optional): 
`devops/internal/apihandler/debug.go:165` 在错误分支构造 SSE 响应时，事件类型正确地使用 errEvt.Type，但数据体却错误地取自 evt.JsonBytes()，而不是应该使用的 errEvt.JsonBytes()。这导致前端收到一条 event: error 但 data却是普通数据事件 JSON 的不一致消息，真实错误信息 err.Error() 被静默丢弃， 该修改与同文件第 178 行的另一处错误上报（类型与 payload 同源于一个事件变量）保持一致。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
