### PR TITLE
feat(devops)!: add WithDevServerIP and change default listen to 127.0.0.1

### DIFF
--- a/devops/dev.go
+++ b/devops/dev.go
@@ -25,14 +25,18 @@ import (
 	"github.com/cloudwego/eino-ext/devops/internal/utils/safego"
 )
 
-// Init start eino devops server
+// Init start eino devops server.
+// By default, the server listens on 127.0.0.1:52538.
+// Use WithDevServerIP and WithDevServerPort to customize the listen address.
+// If the IP is unknown, you can set it to "0.0.0.0" to listen on all interfaces,
+// but be aware this may expose the server to external access and pose security risks.
 func Init(ctx context.Context, opts ...model.DevOption) error {
 	opt := model.NewDevOpt(opts)
 	apihandler.InitDebug(opt)
 
 	errCh := make(chan error)
 	safego.Go(ctx, func() {
-		errCh <- apihandler.StartHTTPServer(ctx, opt.DevServerPort)
+		errCh <- apihandler.StartHTTPServer(ctx, opt.DevServerIP, opt.DevServerPort)
 	})
 
 	select {

--- a/devops/internal/apihandler/middlewares.go
+++ b/devops/internal/apihandler/middlewares.go
@@ -36,21 +36,3 @@ func recoverMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		method := r.Method
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS,DELETE,PUT")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type,X-CSRF-Token, Authorization")
-		w.Header().Set("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type, New-Token, New-Expires-At")
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-
-		// 放行所有OPTIONS方法
-		if method == "OPTIONS" {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}

--- a/devops/internal/apihandler/server.go
+++ b/devops/internal/apihandler/server.go
@@ -36,14 +36,15 @@ var (
 	startOnce sync.Once
 )
 
-// StartHTTPServer init http sever use the specified port.
-func StartHTTPServer(_ context.Context, port string) error {
-	log.Infof("start debug http server at port=%s", port)
+// StartHTTPServer init http sever use the specified ip and port.
+func StartHTTPServer(_ context.Context, ip, port string) error {
+	addr := ip + ":" + port
+	log.Infof("start debug http server at addr=%s", addr)
 	var err error
 	startOnce.Do(func() {
 		r := mux.NewRouter()
 		registerRoutes(r)
-		err = http.ListenAndServe(":"+port, r)
+		err = http.ListenAndServe(addr, r)
 		if err != nil {
 			log.Errorf("start debug http server failed, err=%v", err)
 		}
@@ -57,7 +58,7 @@ func registerRoutes(r *mux.Router) {
 		debugBiz = "/debug/v1"
 	)
 
-	r.Use(recoverMiddleware, corsMiddleware)
+	r.Use(recoverMiddleware)
 
 	rootR := r.PathPrefix(root).Subrouter()
 	rootR.Path("/ping").HandlerFunc(Ping).Methods(http.MethodGet)

--- a/devops/internal/model/option.go
+++ b/devops/internal/model/option.go
@@ -18,9 +18,11 @@ package model
 
 const (
 	defaultHttpPort = "52538"
+	defaultHttpIP   = "127.0.0.1"
 )
 
 type DevOpt struct {
+	DevServerIP   string
 	DevServerPort string
 	GoTypes       []RegisteredType
 }
@@ -29,6 +31,7 @@ type DevOption func(*DevOpt)
 
 func NewDevOpt(opts []DevOption) *DevOpt {
 	o := &DevOpt{
+		DevServerIP:   defaultHttpIP,
 		DevServerPort: defaultHttpPort,
 	}
 	for _, opt := range opts {

--- a/devops/option.go
+++ b/devops/option.go
@@ -22,6 +22,13 @@ import (
 	"github.com/cloudwego/eino-ext/devops/internal/model"
 )
 
+// WithDevServerIP sets dev server listen ip, default to 127.0.0.1
+func WithDevServerIP(ip string) model.DevOption {
+	return func(o *model.DevOpt) {
+		o.DevServerIP = ip
+	}
+}
+
 // WithDevServerPort sets dev server port, default to 52538
 func WithDevServerPort(port string) model.DevOption {
 	return func(o *model.DevOpt) {


### PR DESCRIPTION
**BREAKING CHANGE**: the default listen address changed from
0.0.0.0:52538 to 127.0.0.1:52538.

The previous default (0.0.0.0) binds to all network interfaces,
which means any device on the same network can access the devops
debug API. For example, an attacker on the same LAN could send
crafted requests to /eino/devops/debug/v1/graphs/{id}/threads to
trigger arbitrary Graph debug execution and inspect internal state.
Changing the default to 127.0.0.1 restricts access to localhost only.

If you need the server accessible from other machines, use
WithDevServerIP("0.0.0.0").

- Add WithDevServerIP option to configure server listen IP
- Change default listen IP to 127.0.0.1 for security
- Update StartHTTPServer to accept ip parameter
- Remove unused corsMiddleware from route setup

