### PR TITLE
feat(ark): add EnableReasoningContentPassback config for ResponsesAPI

### DIFF
--- a/components/model/ark/option.go
+++ b/components/model/ark/option.go
@@ -33,6 +33,8 @@ type arkOptions struct {
 	enableWebSearch *ToolWebSearch
 
 	maxToolCalls *int64
+
+	enableReasoningContentPassback bool
 }
 
 // WithCustomHeader sets custom headers for a single request
@@ -140,4 +142,14 @@ func WithMaxToolCalls(n int64) model.Option {
 		o.maxToolCalls = &n
 	})
 
+}
+
+// WithEnableReasoningContentPassback controls whether reasoning content is passed back
+// to the model in multi-turn conversations.
+// This option is only supported for the ResponsesAPIChatModel.
+// See [ResponsesAPIConfig.EnableReasoningContentPassback].
+func WithEnableReasoningContentPassback(enable bool) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
+		o.enableReasoningContentPassback = enable
+	})
 }

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -136,6 +136,20 @@ type ResponsesAPIConfig struct {
 	// For more details, see https://www.volcengine.com/docs/82379/1569618?lang=zh
 	// Optional.
 	MaxToolCalls *int64 `json:"max_tool_calls,omitempty"`
+
+	// EnableReasoningContentPassback controls whether reasoning content
+	// from assistant messages is passed back to the model in multi-turn conversations.
+	// When enabled, reasoning content is included as reasoning summary items in the input,
+	// allowing the model to be aware of its prior chain-of-thought.
+	// However, if a valid previous_response_id is set (via session cache), the passback is
+	// automatically skipped because previous_response_id already preserves the full conversation
+	// context including the chain-of-thought on the server side.
+	// Note: This feature requires doubao models v1.8+. Earlier versions (e.g., v1.6) do not
+	// support reasoning items in the input and will return an error.
+	// For more details, see https://www.volcengine.com/docs/82379/1449737
+	// Default: false.
+	// Optional.
+	EnableReasoningContentPassback bool `json:"enable_reasoning_content_passback,omitempty"`
 }
 
 func NewResponsesAPIChatModel(_ context.Context, config *ResponsesAPIConfig) (*ResponsesAPIChatModel, error) {
@@ -191,6 +205,8 @@ func NewResponsesAPIChatModel(_ context.Context, config *ResponsesAPIConfig) (*R
 
 		enableToolWebSearch: config.EnableToolWebSearch,
 		maxToolCalls:        config.MaxToolCalls,
+
+		enableReasoningContentPassback: config.EnableReasoningContentPassback,
 	}, nil
 }
 
@@ -214,6 +230,8 @@ type ResponsesAPIChatModel struct {
 	enableToolWebSearch *ToolWebSearch
 
 	maxToolCalls *int64
+
+	enableReasoningContentPassback bool
 }
 type cacheConfig struct {
 	Enabled  bool
@@ -492,7 +510,7 @@ func (cm *ResponsesAPIChatModel) genRequestAndOptions(in []*schema.Message, opti
 		return nil, err
 	}
 
-	err = cm.populateInput(in, responseReq)
+	err = cm.populateInput(in, responseReq, specOptions.enableReasoningContentPassback)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +631,7 @@ func (cm *ResponsesAPIChatModel) populateCache(in []*schema.Message, responseReq
 	return in, nil
 }
 
-func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq *responses.ResponsesRequest) error {
+func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq *responses.ResponsesRequest, enableReasoningPassback bool) error {
 	itemList := make([]*responses.InputItem, 0, len(in))
 	if len(in) == 0 {
 		return nil
@@ -627,6 +645,16 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 			}
 			itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_InputMessage{InputMessage: inputMessage}})
 		case schema.Assistant:
+			if enableReasoningPassback && responseReq.PreviousResponseId == nil && msg.ReasoningContent != "" {
+				itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_Reasoning{Reasoning: &responses.ItemReasoning{
+					Type: responses.ItemType_reasoning,
+					Summary: []*responses.ReasoningSummaryPart{
+						{Text: msg.ReasoningContent},
+					},
+				}}})
+
+			}
+
 			inputMessage, err := cm.toArkAssistantRoleItemInputMessage(msg)
 			if err != nil {
 				return err
@@ -906,11 +934,12 @@ func (cm *ResponsesAPIChatModel) getOptions(opts []model.Option) (*model.Options
 	}, opts...)
 
 	arkOpts := model.GetImplSpecificOptions(&arkOptions{
-		customHeaders:   cm.customHeader,
-		thinking:        cm.thinking,
-		reasoningEffort: cm.reasoningEffort,
-		enableWebSearch: cm.enableToolWebSearch,
-		maxToolCalls:    cm.maxToolCalls,
+		customHeaders:                  cm.customHeader,
+		thinking:                       cm.thinking,
+		reasoningEffort:                cm.reasoningEffort,
+		enableWebSearch:                cm.enableToolWebSearch,
+		maxToolCalls:                   cm.maxToolCalls,
+		enableReasoningContentPassback: cm.enableReasoningContentPassback,
 	}, opts...)
 
 	if err := cm.checkOptions(options, arkOpts); err != nil {
@@ -1673,7 +1702,7 @@ func (cm *ResponsesAPIChatModel) CreatePrefixCache(ctx context.Context, prefix [
 	if err != nil {
 		return nil, err
 	}
-	err = cm.populateInput(prefix, responseReq)
+	err = cm.populateInput(prefix, responseReq, specOptions.enableReasoningContentPassback)
 	if err != nil {
 		return nil, err
 	}

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -127,7 +127,7 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 			Model: "test-model",
 		}
 		var in []*schema.Message
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.Nil(t, err)
 	})
 
@@ -142,7 +142,7 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 			},
 		}
 
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(req.GetInput().GetListValue().GetListValue()))
 		item := req.GetInput().GetListValue().GetListValue()[0].GetInputMessage()
@@ -161,7 +161,7 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 			},
 		}
 
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(req.GetInput().GetListValue().GetListValue()))
 
@@ -181,7 +181,7 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 			},
 		}
 
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.Nil(t, err)
 
 		assert.Nil(t, err)
@@ -205,7 +205,7 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 			},
 		}
 
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(req.GetInput().GetListValue().GetListValue()))
 
@@ -224,8 +224,67 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 				Content: "some content",
 			},
 		}
-		err := cm.populateInput(in, req)
+		err := cm.populateInput(in, req, false)
 		assert.NotNil(t, err)
+	})
+}
+
+func TestResponsesAPIChatModelPopulateInputReasoningPassback(t *testing.T) {
+	cm := &ResponsesAPIChatModel{}
+
+	PatchConvey("enabled, no previous_response_id, has reasoning content", t, func() {
+		req := &responses.ResponsesRequest{Model: "test-model"}
+		in := []*schema.Message{
+			{
+				Role:             schema.Assistant,
+				Content:          "Hi",
+				ReasoningContent: "thinking step",
+			},
+		}
+		err := cm.populateInput(in, req, true)
+		assert.Nil(t, err)
+		items := req.GetInput().GetListValue().GetListValue()
+		assert.Equal(t, 2, len(items))
+		reasoning := items[0].GetReasoning()
+		assert.NotNil(t, reasoning)
+		assert.Equal(t, "thinking step", reasoning.GetSummary()[0].Text)
+		msg := items[1].GetInputMessage()
+		assert.Equal(t, responses.MessageRole_assistant, msg.Role)
+	})
+
+	PatchConvey("enabled, has previous_response_id, should skip reasoning passback", t, func() {
+		req := &responses.ResponsesRequest{
+			Model:              "test-model",
+			PreviousResponseId: ptrOf("resp_123"),
+		}
+		in := []*schema.Message{
+			{
+				Role:             schema.Assistant,
+				Content:          "Hi",
+				ReasoningContent: "thinking step",
+			},
+		}
+		err := cm.populateInput(in, req, true)
+		assert.Nil(t, err)
+		items := req.GetInput().GetListValue().GetListValue()
+		assert.Equal(t, 1, len(items))
+		assert.Nil(t, items[0].GetReasoning())
+	})
+
+	PatchConvey("disabled, has reasoning content, should not passback", t, func() {
+		req := &responses.ResponsesRequest{Model: "test-model"}
+		in := []*schema.Message{
+			{
+				Role:             schema.Assistant,
+				Content:          "Hi",
+				ReasoningContent: "thinking step",
+			},
+		}
+		err := cm.populateInput(in, req, false)
+		assert.Nil(t, err)
+		items := req.GetInput().GetListValue().GetListValue()
+		assert.Equal(t, 1, len(items))
+		assert.Nil(t, items[0].GetReasoning())
 	})
 }
 
@@ -1116,6 +1175,8 @@ func TestNewResponsesAPIChatModel(t *testing.T) {
 				},
 				EnableToolWebSearch: &ToolWebSearch{},
 				MaxToolCalls:        ptrOf(int64(5)),
+
+				EnableReasoningContentPassback: true,
 			}
 			m, err := NewResponsesAPIChatModel(ctx, config)
 			assert.NoError(t, err)
@@ -1133,6 +1194,7 @@ func TestNewResponsesAPIChatModel(t *testing.T) {
 			assert.NotNil(t, m.reasoningEffort)
 			assert.NotNil(t, m.enableToolWebSearch)
 			assert.Equal(t, int64(5), *m.maxToolCalls)
+			assert.True(t, m.enableReasoningContentPassback)
 		})
 	})
 }


### PR DESCRIPTION
- Add EnableReasoningContentPassback field to ResponsesAPIConfig to control whether reasoning content is passed back to the model in multi-turn conversations (default: false/disabled)
- Add WithEnableReasoningContentPassback option for per-request override
- Skip reasoning passback when a valid previous_response_id is set, as it already preserves the chain-of-thought on the server side
- Note: this feature requires doubao models v1.8+; earlier versions will return an error if reasoning items are included in the input
- Add unit tests covering all three key scenarios: enabled without previous_response_id, enabled with previous_response_id, and disabled
