### PR TITLE
feat(deepseek): add ThinkingConfig support for thinking/non-thinking mode

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -45,6 +45,8 @@ const (
 	ResponseFormatTypeJSONObject = "json_object"
 )
 
+type ThinkingConfig = deepseek.ThinkingConfig
+
 const (
 	toolChoiceNone     = "none"     // none means the model will not call any tool and instead generates a message.
 	toolChoiceAuto     = "auto"     // auto means the model can pick between generating a message or calling one or more tools.
@@ -119,6 +121,9 @@ type ChatModelConfig struct {
 
 	// TopLogProbs specifies the number of most likely tokens to return at each token position, each with an associated log probability.
 	TopLogProbs int `json:"top_log_probs"`
+
+	// ThinkingConfig controls the switch between thinking and non-thinking mode.
+	ThinkingConfig *ThinkingConfig `json:"thinking_config,omitempty"`
 }
 
 var _ model.ToolCallingChatModel = (*ChatModel)(nil)
@@ -553,6 +558,7 @@ func (cm *ChatModel) generateRequest(_ context.Context, in []*schema.Message, op
 		FrequencyPenalty: cm.conf.FrequencyPenalty,
 		LogProbs:         cm.conf.LogProbs,
 		TopLogProbs:      cm.conf.TopLogProbs,
+		Thinking:         cm.conf.ThinkingConfig,
 	}
 
 	cbInput := &model.CallbackInput{

--- a/components/model/deepseek/deepseek_test.go
+++ b/components/model/deepseek/deepseek_test.go
@@ -413,3 +413,482 @@ func TestPopulateToolChoice(t *testing.T) {
 		})
 	}
 }
+
+func TestThinkingConfig(t *testing.T) {
+	var capturedReq *deepseek.ChatCompletionRequest
+	defer mockey.Mock((*deepseek.Client).CreateChatCompletion).To(func(ctx context.Context, request *deepseek.ChatCompletionRequest) (*deepseek.ChatCompletionResponse, error) {
+		capturedReq = request
+		return &deepseek.ChatCompletionResponse{
+			Choices: []deepseek.Choice{
+				{
+					Index:   0,
+					Message: deepseek.Message{Role: "assistant", Content: "hello"},
+				},
+			},
+		}, nil
+	}).Build().UnPatch()
+
+	ctx := context.Background()
+
+	t.Run("with thinking config", func(t *testing.T) {
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey: "test-key",
+			Model:  "deepseek-reasoner",
+			ThinkingConfig: &ThinkingConfig{
+				Type: "enabled",
+			},
+		})
+		assert.Nil(t, err)
+
+		_, err = cm.Generate(ctx, []*schema.Message{schema.UserMessage("hello")})
+		assert.Nil(t, err)
+		assert.NotNil(t, capturedReq.Thinking)
+		assert.Equal(t, "enabled", capturedReq.Thinking.Type)
+	})
+
+	t.Run("without thinking config", func(t *testing.T) {
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey: "test-key",
+			Model:  "deepseek-chat",
+		})
+		assert.Nil(t, err)
+
+		_, err = cm.Generate(ctx, []*schema.Message{schema.UserMessage("hello")})
+		assert.Nil(t, err)
+		assert.Nil(t, capturedReq.Thinking)
+	})
+}
+
+func TestNewChatModel(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty model returns error", func(t *testing.T) {
+		_, err := NewChatModel(ctx, &ChatModelConfig{APIKey: "key"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("base url without trailing slash", func(t *testing.T) {
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey:  "key",
+			Model:   "deepseek-chat",
+			BaseURL: "https://custom.api.com",
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, cm)
+	})
+
+	t.Run("with all options", func(t *testing.T) {
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey:  "key",
+			Model:   "deepseek-chat",
+			Timeout: 10 * time.Second,
+			BaseURL: "https://custom.api.com/",
+			Path:    "/v1/chat",
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, cm)
+	})
+}
+
+func TestToDeepSeekMessage(t *testing.T) {
+	t.Run("role mapping", func(t *testing.T) {
+		cases := []struct {
+			role     schema.RoleType
+			expected string
+		}{
+			{schema.System, "system"},
+			{schema.User, "user"},
+			{schema.Assistant, "assistant"},
+			{schema.Tool, "tool"},
+		}
+		for _, tc := range cases {
+			msg := &schema.Message{Role: tc.role, Content: "hi"}
+			result, err := toDeepSeekMessage(msg)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected, result.Role)
+		}
+	})
+
+	t.Run("unknown role returns error", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.RoleType("unknown"), Content: "hi"}
+		_, err := toDeepSeekMessage(msg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown role type")
+	})
+
+	t.Run("multi content not supported", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.User,
+			MultiContent: []schema.ChatMessagePart{
+				{Type: schema.ChatMessagePartTypeText, Text: "hello"},
+			},
+		}
+		_, err := toDeepSeekMessage(msg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multi content is not supported")
+	})
+
+	t.Run("user input multi content text only", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{
+				{Type: schema.ChatMessagePartTypeText, Text: "hello"},
+				{Type: schema.ChatMessagePartTypeText, Text: "world"},
+			},
+		}
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Equal(t, "hello\n\nworld", result.Content)
+	})
+
+	t.Run("user input multi content unsupported type", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.User,
+			UserInputMultiContent: []schema.MessageInputPart{
+				{Type: schema.ChatMessagePartTypeImageURL, Text: "img"},
+			},
+		}
+		_, err := toDeepSeekMessage(msg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "user input multi content")
+	})
+
+	t.Run("assistant gen multi content text only", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{
+				{Type: schema.ChatMessagePartTypeText, Text: "foo"},
+				{Type: schema.ChatMessagePartTypeText, Text: "bar"},
+			},
+		}
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Equal(t, "foo\n\nbar", result.Content)
+	})
+
+	t.Run("assistant gen multi content unsupported type", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.Assistant,
+			AssistantGenMultiContent: []schema.MessageOutputPart{
+				{Type: schema.ChatMessagePartTypeImageURL, Text: "img"},
+			},
+		}
+		_, err := toDeepSeekMessage(msg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "assistant gen multi content")
+	})
+
+	t.Run("prefix on non-assistant returns error", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.User, Content: "hi"}
+		SetPrefix(msg)
+		_, err := toDeepSeekMessage(msg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "prefix only supported for assistant message")
+	})
+
+	t.Run("prefix on assistant is ok", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.Assistant, Content: "hi"}
+		SetPrefix(msg)
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.True(t, result.Prefix)
+	})
+
+	t.Run("reasoning content from field", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.Assistant, Content: "hi", ReasoningContent: "think"}
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Equal(t, "think", result.ReasoningContent)
+	})
+
+	t.Run("reasoning content fallback from extra", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.Assistant, Content: "hi"}
+		SetReasoningContent(msg, "from extra")
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Equal(t, "from extra", result.ReasoningContent)
+	})
+
+	t.Run("tool role with tool call id", func(t *testing.T) {
+		msg := &schema.Message{Role: schema.Tool, Content: "result", ToolCallID: "call-123"}
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Equal(t, "call-123", result.ToolCallID)
+	})
+
+	t.Run("assistant with tool calls nil index", func(t *testing.T) {
+		msg := &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{
+				{ID: "id1", Type: "function", Function: schema.FunctionCall{Name: "fn", Arguments: "{}"}},
+			},
+		}
+		result, err := toDeepSeekMessage(msg)
+		assert.Nil(t, err)
+		assert.Len(t, result.ToolCalls, 1)
+		assert.Equal(t, 0, result.ToolCalls[0].Index)
+		assert.Equal(t, "id1", result.ToolCalls[0].ID)
+	})
+}
+
+func TestResolveStreamResponse(t *testing.T) {
+	t.Run("normal choice index 0", func(t *testing.T) {
+		resp := &deepseek.StreamChatCompletionResponse{
+			Choices: []deepseek.StreamChoices{
+				{Index: 0, Delta: deepseek.StreamDelta{Role: "assistant", Content: "hello"}},
+			},
+		}
+		msg, found, err := resolveStreamResponse(resp)
+		assert.Nil(t, err)
+		assert.True(t, found)
+		assert.Equal(t, "hello", msg.Content)
+	})
+
+	t.Run("skip non-zero index", func(t *testing.T) {
+		resp := &deepseek.StreamChatCompletionResponse{
+			Choices: []deepseek.StreamChoices{
+				{Index: 1, Delta: deepseek.StreamDelta{Role: "assistant", Content: "skip"}},
+			},
+		}
+		msg, found, err := resolveStreamResponse(resp)
+		assert.Nil(t, err)
+		assert.False(t, found)
+		assert.Nil(t, msg)
+	})
+
+	t.Run("usage only response", func(t *testing.T) {
+		resp := &deepseek.StreamChatCompletionResponse{
+			Usage: &deepseek.StreamUsage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		}
+		msg, found, err := resolveStreamResponse(resp)
+		assert.Nil(t, err)
+		assert.True(t, found)
+		assert.NotNil(t, msg.ResponseMeta)
+		assert.Equal(t, 10, msg.ResponseMeta.Usage.PromptTokens)
+	})
+
+	t.Run("reasoning content in delta", func(t *testing.T) {
+		resp := &deepseek.StreamChatCompletionResponse{
+			Choices: []deepseek.StreamChoices{
+				{Index: 0, Delta: deepseek.StreamDelta{Role: "assistant", ReasoningContent: "thinking..."}},
+			},
+		}
+		msg, found, err := resolveStreamResponse(resp)
+		assert.Nil(t, err)
+		assert.True(t, found)
+		rc, ok := GetReasoningContent(msg)
+		assert.True(t, ok)
+		assert.Equal(t, "thinking...", rc)
+		assert.Equal(t, "thinking...", msg.ReasoningContent)
+	})
+}
+
+func TestConcatTextParts(t *testing.T) {
+	t.Run("text parts joined", func(t *testing.T) {
+		parts := []schema.MessageInputPart{
+			{Type: schema.ChatMessagePartTypeText, Text: "a"},
+			{Type: schema.ChatMessagePartTypeText, Text: "b"},
+		}
+		result, err := concatTextParts(parts, func(p schema.MessageInputPart) (schema.ChatMessagePartType, string) {
+			return p.Type, p.Text
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, "a\n\nb", result)
+	})
+
+	t.Run("unsupported type returns error", func(t *testing.T) {
+		parts := []schema.MessageInputPart{
+			{Type: schema.ChatMessagePartTypeImageURL, Text: "img"},
+		}
+		_, err := concatTextParts(parts, func(p schema.MessageInputPart) (schema.ChatMessagePartType, string) {
+			return p.Type, p.Text
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not support")
+	})
+}
+
+func TestExtractLogProbs(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		result, err := extractLogProbs(nil)
+		assert.Nil(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("non-map type returns error", func(t *testing.T) {
+		_, err := extractLogProbs("invalid")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected to map[string]any")
+	})
+
+	t.Run("valid map", func(t *testing.T) {
+		input := map[string]any{
+			"content": []any{
+				map[string]any{
+					"token":   "hello",
+					"logprob": 0.5,
+				},
+			},
+		}
+		result, err := extractLogProbs(input)
+		assert.Nil(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result.Content, 1)
+	})
+}
+
+func TestToToolParam(t *testing.T) {
+	t.Run("nil schema returns nil", func(t *testing.T) {
+		result := toToolParam(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("with properties and required", func(t *testing.T) {
+		s := &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"name"},
+			Properties: orderedmap.New[string, *jsonschema.Schema](
+				orderedmap.WithInitialData[string, *jsonschema.Schema](
+					orderedmap.Pair[string, *jsonschema.Schema]{
+						Key:   "name",
+						Value: &jsonschema.Schema{Type: "string"},
+					},
+				),
+			),
+		}
+		result := toToolParam(s)
+		assert.NotNil(t, result)
+		assert.Equal(t, "object", result.Type)
+		assert.Equal(t, []string{"name"}, result.Required)
+		assert.Contains(t, result.Properties, "name")
+	})
+}
+
+func TestTokenUsageConversions(t *testing.T) {
+	t.Run("toEinoTokenUsage nil", func(t *testing.T) {
+		assert.Nil(t, toEinoTokenUsage(nil))
+	})
+
+	t.Run("toCallbackUsage nil", func(t *testing.T) {
+		assert.Nil(t, toCallbackUsage(nil))
+	})
+
+	t.Run("toModelCallbackUsage nil respMeta", func(t *testing.T) {
+		assert.Nil(t, toModelCallbackUsage(nil))
+	})
+
+	t.Run("toModelCallbackUsage nil usage", func(t *testing.T) {
+		assert.Nil(t, toModelCallbackUsage(&schema.ResponseMeta{}))
+	})
+
+	t.Run("toModelCallbackUsage with usage", func(t *testing.T) {
+		result := toModelCallbackUsage(&schema.ResponseMeta{
+			Usage: &schema.TokenUsage{
+				PromptTokens:     1,
+				CompletionTokens: 2,
+				TotalTokens:      3,
+			},
+		})
+		assert.NotNil(t, result)
+		assert.Equal(t, 1, result.PromptTokens)
+	})
+
+	t.Run("streamToEinoTokenUsage nil", func(t *testing.T) {
+		assert.Nil(t, streamToEinoTokenUsage(nil))
+	})
+
+	t.Run("streamToEinoTokenUsage all zero", func(t *testing.T) {
+		assert.Nil(t, streamToEinoTokenUsage(&deepseek.StreamUsage{}))
+	})
+
+	t.Run("streamToEinoTokenUsage with values", func(t *testing.T) {
+		result := streamToEinoTokenUsage(&deepseek.StreamUsage{
+			PromptTokens:     5,
+			CompletionTokens: 10,
+			TotalTokens:      15,
+		})
+		assert.NotNil(t, result)
+		assert.Equal(t, 5, result.PromptTokens)
+		assert.Equal(t, 15, result.TotalTokens)
+	})
+
+	t.Run("toEinoTokenUsage with cache hit", func(t *testing.T) {
+		result := toEinoTokenUsage(&deepseek.Usage{
+			PromptTokens:         10,
+			PromptCacheHitTokens: 5,
+			CompletionTokens:     20,
+			TotalTokens:          30,
+		})
+		assert.NotNil(t, result)
+		assert.Equal(t, 5, result.PromptTokenDetails.CachedTokens)
+	})
+
+	t.Run("toCallbackUsage with values", func(t *testing.T) {
+		result := toCallbackUsage(&schema.TokenUsage{
+			PromptTokens:       1,
+			CompletionTokens:   2,
+			TotalTokens:        3,
+			PromptTokenDetails: schema.PromptTokenDetails{CachedTokens: 1},
+		})
+		assert.NotNil(t, result)
+		assert.Equal(t, 1, result.PromptTokenDetails.CachedTokens)
+	})
+}
+
+func TestBindToolsError(t *testing.T) {
+	cm := &ChatModel{conf: &ChatModelConfig{Model: "test"}}
+
+	t.Run("BindTools empty", func(t *testing.T) {
+		err := cm.BindTools(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no tools to bind")
+	})
+
+	t.Run("BindForcedTools empty", func(t *testing.T) {
+		err := cm.BindForcedTools(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no tools to bind")
+	})
+
+	t.Run("WithTools empty", func(t *testing.T) {
+		_, err := cm.WithTools(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no tools to bind")
+	})
+
+	t.Run("BindTools nil tool info", func(t *testing.T) {
+		err := cm.BindTools([]*schema.ToolInfo{nil})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tool info cannot be nil")
+	})
+}
+
+func TestToMessageRole(t *testing.T) {
+	assert.Equal(t, schema.User, toMessageRole("user"))
+	assert.Equal(t, schema.Assistant, toMessageRole("assistant"))
+	assert.Equal(t, schema.System, toMessageRole("system"))
+	assert.Equal(t, schema.Tool, toMessageRole("tool"))
+	assert.Equal(t, schema.RoleType("custom"), toMessageRole("custom"))
+}
+
+func TestToMessageToolCalls(t *testing.T) {
+	t.Run("empty returns nil", func(t *testing.T) {
+		assert.Nil(t, toMessageToolCalls(nil))
+		assert.Nil(t, toMessageToolCalls([]deepseek.ToolCall{}))
+	})
+
+	t.Run("converts correctly", func(t *testing.T) {
+		calls := []deepseek.ToolCall{
+			{Index: 0, ID: "c1", Type: "function", Function: deepseek.ToolCallFunction{Name: "fn1", Arguments: "{}"}},
+		}
+		result := toMessageToolCalls(calls)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "c1", result[0].ID)
+		assert.Equal(t, 0, *result[0].Index)
+	})
+}

--- a/components/model/deepseek/go.mod
+++ b/components/model/deepseek/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bytedance/mockey v1.2.14
 	github.com/bytedance/sonic v1.14.1
 	github.com/cloudwego/eino v0.7.13
-	github.com/cohesion-org/deepseek-go v1.3.2
+	github.com/cohesion-org/deepseek-go v1.3.4
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/components/model/deepseek/go.sum
+++ b/components/model/deepseek/go.sum
@@ -22,6 +22,8 @@ github.com/cloudwego/eino v0.7.13 h1:Ku7hY+83gGJJjf4On3UgqjC57UcA+DXe0tqAZiNDDew
 github.com/cloudwego/eino v0.7.13/go.mod h1:nA8Vacmuqv3pqKBQbTWENBLQ8MmGmPt/WqiyLeB8ohQ=
 github.com/cohesion-org/deepseek-go v1.3.2 h1:WTZ/2346KFYca+n+DL5p+Ar1RQxF2w/wGkU4jDvyXaQ=
 github.com/cohesion-org/deepseek-go v1.3.2/go.mod h1:bOVyKj38r90UEYZFrmJOzJKPxuAh8sIzHOCnLOpiXeI=
+github.com/cohesion-org/deepseek-go v1.3.4 h1:YQ0Fg6eXj9ImVh9VkCIx2gA7pa/kMNJ5RLr9no13QaQ=
+github.com/cohesion-org/deepseek-go v1.3.4/go.mod h1:bOVyKj38r90UEYZFrmJOzJKPxuAh8sIzHOCnLOpiXeI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION


Add ThinkingConfig to ChatModelConfig to allow users to control the thinking mode switch. Upgrade deepseek-go from v1.3.2 to v1.3.4.
