### PR TITLE
feat(deepseek): support ExtraFields via request-level option

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -532,6 +532,7 @@ func (cm *ChatModel) generateStreamRequest(ctx context.Context, in []*schema.Mes
 		Tools:            origReq.Tools,
 		LogProbs:         origReq.LogProbs,
 		TopLogProbs:      origReq.TopLogProbs,
+		ExtraFields:      origReq.ExtraFields,
 	}
 	return req, cbIn, nil
 }
@@ -548,6 +549,8 @@ func (cm *ChatModel) generateRequest(_ context.Context, in []*schema.Message, op
 		ToolChoice:  cm.toolChoice,
 	}, opts...)
 
+	specOpts := model.GetImplSpecificOptions(&deepseekOptions{}, opts...)
+
 	req := &deepseek.ChatCompletionRequest{
 		Model:            *options.Model,
 		MaxTokens:        dereferenceOrZero(options.MaxTokens),
@@ -559,6 +562,7 @@ func (cm *ChatModel) generateRequest(_ context.Context, in []*schema.Message, op
 		LogProbs:         cm.conf.LogProbs,
 		TopLogProbs:      cm.conf.TopLogProbs,
 		Thinking:         cm.conf.ThinkingConfig,
+		ExtraFields:      specOpts.extraFields,
 	}
 
 	cbInput := &model.CallbackInput{

--- a/components/model/deepseek/option.go
+++ b/components/model/deepseek/option.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deepseek
+
+import (
+	"github.com/cloudwego/eino/components/model"
+)
+
+type deepseekOptions struct {
+	// extraFields carries arbitrary passthrough fields that will be merged into the
+	// top-level JSON payload of a chat completion request.
+	//
+	// It is useful when the upstream DeepSeek API introduces new request parameters
+	// that are not yet modeled as first-class fields by this component (or by the
+	// underlying deepseek-go SDK).
+	extraFields map[string]interface{}
+}
+
+// WithExtraFields returns a request-level option that merges the provided
+// key/value pairs into the top-level JSON payload sent to the DeepSeek API.
+//
+// Keys that collide with fields already populated by this component (e.g.
+// "model", "messages", "temperature", "thinking", ...) will override them,
+// which mirrors the behavior of the underlying deepseek-go SDK.
+//
+// Passing a nil or empty map is a no-op.
+//
+// Example:
+//
+//	msg, err := cm.Generate(ctx, in,
+//	    deepseek.WithExtraFields(map[string]interface{}{
+//	        "chat_template_kwargs": map[string]interface{}{
+//	            "thinking": true,
+//	        },
+//	    }),
+//	)
+func WithExtraFields(extraFields map[string]interface{}) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *deepseekOptions) {
+		o.extraFields = extraFields
+	})
+}

--- a/components/model/deepseek/option_test.go
+++ b/components/model/deepseek/option_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deepseek
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cohesion-org/deepseek-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestWithExtraFields(t *testing.T) {
+	t.Run("option merges into specific options", func(t *testing.T) {
+		extra := map[string]interface{}{
+			"chat_template_kwargs": map[string]interface{}{
+				"thinking": true,
+			},
+			"custom_flag": "value",
+		}
+
+		specOpts := model.GetImplSpecificOptions(&deepseekOptions{}, WithExtraFields(extra))
+		assert.Equal(t, extra, specOpts.extraFields)
+	})
+
+	t.Run("nil extra fields is a no-op", func(t *testing.T) {
+		specOpts := model.GetImplSpecificOptions(&deepseekOptions{}, WithExtraFields(nil))
+		assert.Nil(t, specOpts.extraFields)
+	})
+
+	t.Run("generate forwards extra fields into request", func(t *testing.T) {
+		var capturedReq *deepseek.ChatCompletionRequest
+		defer mockey.Mock((*deepseek.Client).CreateChatCompletion).To(func(ctx context.Context, request *deepseek.ChatCompletionRequest) (*deepseek.ChatCompletionResponse, error) {
+			capturedReq = request
+			return &deepseek.ChatCompletionResponse{
+				Choices: []deepseek.Choice{
+					{Index: 0, Message: deepseek.Message{Role: "assistant", Content: "ok"}},
+				},
+			}, nil
+		}).Build().UnPatch()
+
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey: "test-key",
+			Model:  "deepseek-chat",
+		})
+		assert.Nil(t, err)
+
+		extra := map[string]interface{}{
+			"chat_template_kwargs": map[string]interface{}{
+				"thinking": true,
+			},
+		}
+
+		_, err = cm.Generate(ctx, []*schema.Message{schema.UserMessage("hello")}, WithExtraFields(extra))
+		assert.Nil(t, err)
+		assert.NotNil(t, capturedReq)
+		assert.Equal(t, extra, capturedReq.ExtraFields)
+	})
+
+	t.Run("stream forwards extra fields into stream request", func(t *testing.T) {
+		var capturedReq *deepseek.StreamChatCompletionRequest
+		defer mockey.Mock((*deepseek.Client).CreateChatCompletionStream).To(func(ctx context.Context, request *deepseek.StreamChatCompletionRequest) (deepseek.ChatCompletionStream, error) {
+			capturedReq = request
+			return &mockStream{responses: nil, idx: 0}, nil
+		}).Build().UnPatch()
+
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey: "test-key",
+			Model:  "deepseek-chat",
+		})
+		assert.Nil(t, err)
+
+		extra := map[string]interface{}{
+			"top_k": 10,
+		}
+
+		_, err = cm.Stream(ctx, []*schema.Message{schema.UserMessage("hello")}, WithExtraFields(extra))
+		assert.Nil(t, err)
+		assert.NotNil(t, capturedReq)
+		assert.Equal(t, extra, capturedReq.ExtraFields)
+	})
+
+	t.Run("without option leaves extra fields empty", func(t *testing.T) {
+		var capturedReq *deepseek.ChatCompletionRequest
+		defer mockey.Mock((*deepseek.Client).CreateChatCompletion).To(func(ctx context.Context, request *deepseek.ChatCompletionRequest) (*deepseek.ChatCompletionResponse, error) {
+			capturedReq = request
+			return &deepseek.ChatCompletionResponse{
+				Choices: []deepseek.Choice{
+					{Index: 0, Message: deepseek.Message{Role: "assistant", Content: "ok"}},
+				},
+			}, nil
+		}).Build().UnPatch()
+
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &ChatModelConfig{
+			APIKey: "test-key",
+			Model:  "deepseek-chat",
+		})
+		assert.Nil(t, err)
+
+		_, err = cm.Generate(ctx, []*schema.Message{schema.UserMessage("hello")})
+		assert.Nil(t, err)
+		assert.NotNil(t, capturedReq)
+		assert.Nil(t, capturedReq.ExtraFields)
+	})
+}


### PR DESCRIPTION
### What type of PR is this?

- [x] feat

### Summary

Introduce a new `WithExtraFields` request-level option for the DeepSeek chat model so callers can inject arbitrary passthrough fields into the top-level JSON payload sent to the DeepSeek API on a per-request basis.

This mirrors the `ExtraFields` (`extra_fields`) map that already exists on the underlying `deepseek-go` SDK's `ChatCompletionRequest` / `StreamChatCompletionRequest`, which the SDK merges into the outgoing request body via `finalizePayload`.

### Motivation

The DeepSeek API occasionally ships new request parameters (e.g. `chat_template_kwargs`, provider-specific flags) before this component — or even the underlying `deepseek-go` SDK — models them as first-class fields. Today, users of `components/model/deepseek` have no way to send those fields without maintaining a fork of this package.

`WithExtraFields` closes that gap in a minimal, forward-compatible way: arbitrary JSON keys can be attached to a single `Generate` / `Stream` call without touching `ChatModelConfig` or `ChatCompletionRequest`.

### Changes

- `components/model/deepseek/option.go` (new): define `deepseekOptions` and `WithExtraFields(map[string]interface{}) model.Option`.
- `components/model/deepseek/deepseek.go`:
  - `generateRequest`: read impl-specific options via `model.GetImplSpecificOptions` and forward `extraFields` to `deepseek.ChatCompletionRequest.ExtraFields`.
  - `generateStreamRequest`: propagate `ExtraFields` from the intermediate `ChatCompletionRequest` to `StreamChatCompletionRequest`.
- `components/model/deepseek/option_test.go` (new): unit tests covering:
  - option aggregation via `GetImplSpecificOptions`
  - nil map is a no-op
  - `Generate` forwards `ExtraFields` into the captured request
  - `Stream` forwards `ExtraFields` into the captured stream request
  - omitting the option leaves `ExtraFields` as `nil`

### Usage

```go
msg, err := cm.Generate(ctx, in,
    deepseek.WithExtraFields(map[string]interface{}{
        "chat_template_kwargs": map[string]interface{}{
            "thinking": true,
        },
    }),
)
```

### Backward compatibility

Purely additive. Existing callers are unaffected; when the option is not supplied, `ExtraFields` remains `nil` and the produced request is byte-identical to before.

### Tests

```bash
cd components/model/deepseek
go vet ./...
go build ./...
go test -gcflags="all=-l" -count=1 ./...
```

All existing and newly added tests pass locally.

Made with [Cursor](https://cursor.com)