### PR TITLE
feat(openai): support Strict parameter for tool function definitions via ToolInfo.Extra

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -658,6 +658,7 @@ func (c *Client) genRequest(ctx context.Context, in []*schema.Message, opts ...m
 					Name:        t.Function.Name,
 					Description: t.Function.Description,
 					Parameters:  t.Function.Parameters,
+					Strict:      t.Function.Strict,
 				},
 			}
 		}
@@ -1291,11 +1292,19 @@ func toTools(tis []*schema.ToolInfo) ([]tool, error) {
 
 		sortArrayFields(paramsJSONSchema)
 
+		var strict bool
+		if v, ok := ti.Extra["strict"]; ok {
+			if b, ok := v.(bool); ok {
+				strict = b
+			}
+		}
+
 		tools[i] = tool{
 			Function: &functionDefinition{
 				Name:        ti.Name,
 				Description: ti.Desc,
 				Parameters:  paramsJSONSchema,
+				Strict:      strict,
 			},
 		}
 	}

--- a/libs/acl/openai/chat_model_test.go
+++ b/libs/acl/openai/chat_model_test.go
@@ -373,6 +373,85 @@ func TestToTools(t *testing.T) {
 	})
 }
 
+func TestToToolsStrict(t *testing.T) {
+	mockey.PatchConvey("strict via Extra", t, func() {
+		mockTools := []*schema.ToolInfo{
+			{
+				Name: "strict_tool",
+				Desc: "a tool with strict mode",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"query": {
+						Type:     schema.String,
+						Required: true,
+					},
+				}),
+				Extra: map[string]any{"strict": true},
+			},
+			{
+				Name: "non_strict_tool",
+				Desc: "a tool without strict mode",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"query": {
+						Type:     schema.String,
+						Required: true,
+					},
+				}),
+			},
+			{
+				Name: "invalid_strict_tool",
+				Desc: "a tool with invalid strict value",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"query": {
+						Type:     schema.String,
+						Required: true,
+					},
+				}),
+				Extra: map[string]any{"strict": "yes"},
+			},
+		}
+
+		tools, err := toTools(mockTools)
+		assert.Nil(t, err)
+		assert.Len(t, tools, 3)
+
+		assert.True(t, tools[0].Function.Strict, "strict_tool should have Strict=true")
+		assert.False(t, tools[1].Function.Strict, "non_strict_tool should have Strict=false")
+		assert.False(t, tools[2].Function.Strict, "invalid strict value should default to false")
+	})
+
+	mockey.PatchConvey("strict propagated to genRequest", t, func() {
+		ctx := context.Background()
+		strictTools := []*schema.ToolInfo{
+			{
+				Name: "strict_tool",
+				Desc: "a tool with strict mode",
+				ParamsOneOf: schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
+					"queries": {
+						Type:     schema.Array,
+						Required: true,
+					},
+				}),
+				Extra: map[string]any{"strict": true},
+			},
+		}
+
+		c := &Client{
+			config: &Config{Model: "test-model"},
+		}
+
+		nc, err := c.WithToolsForClient(strictTools)
+		assert.Nil(t, err)
+
+		req, _, _, _, err := nc.genRequest(ctx, []*schema.Message{
+			{Role: schema.User, Content: "hello"},
+		})
+		assert.Nil(t, err)
+		assert.Len(t, req.Tools, 1)
+		assert.True(t, req.Tools[0].Function.Strict, "FunctionDefinition.Strict should be true")
+		assert.Equal(t, "strict_tool", req.Tools[0].Function.Name)
+	})
+}
+
 func TestBuildMessages(t *testing.T) {
 	t.Run("buildMessageFromAssistantGenMultiContent", func(t *testing.T) {
 		t.Run("success with audio", func(t *testing.T) {

--- a/libs/acl/openai/tool.go
+++ b/libs/acl/openai/tool.go
@@ -28,4 +28,5 @@ type functionDefinition struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description,omitempty"`
 	Parameters  *jsonschema.Schema `json:"parameters"`
+	Strict      bool               `json:"strict,omitempty"`
 }


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

feat(openai): 通过 ToolInfo.Extra 支持 Tool Function 的 Strict 参数

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

### Background

OpenAI's Structured Outputs feature supports a `strict` parameter on tool function definitions. When set to `true`, the model is guaranteed to generate arguments that exactly match the provided JSON Schema — no additional or missing properties, correct types, and valid values.

Currently, the internal `functionDefinition` struct in `libs/acl/openai/tool.go` lacks a `Strict` field, and the `toTools()` / `genRequest()` conversion path completely ignores it. There is no way for users to enable strict mode from business code.

Additionally, DeepSeek V4 now supports `strict` on tool calls as well, meaning this change benefits both OpenAI and DeepSeek users (when using the OpenAI-compatible endpoint).

### What this PR does

This is a minimal, backward-compatible change across 3 files:

1. **`tool.go`**: Add `Strict bool` field to `functionDefinition`
2. **`chat_model.go`**: Read `strict` from `ToolInfo.Extra["strict"]` in `toTools()`, propagate it through `genRequest()` to `openai.FunctionDefinition.Strict`
3. **`chat_model_test.go`**: Add `TestToToolsStrict` covering strict/non-strict/invalid values and full `genRequest` propagation

### Usage

```go
toolInfo := &schema.ToolInfo{
    Name:        "my_tool",
    Desc:        "description of the tool",
    ParamsOneOf: schema.NewParamsOneOfByJSONSchema(jsonSchema),
    Extra:       map[string]any{"strict": true},
}
```

### Note

After this PR is merged, `components/model/openai/go.mod` should be updated to reference the new version of `libs/acl/openai`.

zh(optional):

### 背景

OpenAI Structured Outputs 支持在 tool function 定义中设置 `strict` 参数。设为 `true` 时，模型保证生成的参数严格匹配 JSON Schema。

当前 `libs/acl/openai` 内部的 `functionDefinition` 缺少 `Strict` 字段，`toTools()` 和 `genRequest()` 的转换链路也完全忽略了该参数，业务代码无法启用 strict 模式。

此外，DeepSeek V4 现在也支持 tool call 的 `strict` 参数，因此此改动同时惠及通过 OpenAI 兼容接口使用 DeepSeek 的用户。

### 改动说明

最小化、向后兼容的改动，共涉及 3 个文件：

1. **`tool.go`**: `functionDefinition` 增加 `Strict` 字段
2. **`chat_model.go`**: 从 `ToolInfo.Extra["strict"]` 读取 bool 值，经 `toTools()` → `genRequest()` 全链路透传到 `openai.FunctionDefinition.Strict`
3. **`chat_model_test.go`**: 新增 `TestToToolsStrict`，覆盖 strict/非 strict/无效值三种场景及 `genRequest` 完整传播

### 使用方式

```go
toolInfo := &schema.ToolInfo{
    Name:        "my_tool",
    Desc:        "工具描述",
    ParamsOneOf: schema.NewParamsOneOfByJSONSchema(jsonSchema),
    Extra:       map[string]any{"strict": true},
}
```

### 备注

此 PR 合入后，需要更新 `components/model/openai/go.mod` 中对 `libs/acl/openai` 的版本引用。

#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation: