### PR TITLE
[codex] fix deepseek thinking config for streams

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -532,6 +532,7 @@ func (cm *ChatModel) generateStreamRequest(ctx context.Context, in []*schema.Mes
 		Tools:            origReq.Tools,
 		LogProbs:         origReq.LogProbs,
 		TopLogProbs:      origReq.TopLogProbs,
+		Thinking:         origReq.Thinking,
 		ExtraFields:      origReq.ExtraFields,
 	}
 	return req, cbIn, nil

--- a/components/model/deepseek/deepseek_test.go
+++ b/components/model/deepseek/deepseek_test.go
@@ -459,6 +459,32 @@ func TestThinkingConfig(t *testing.T) {
 	})
 }
 
+func TestThinkingConfigStream(t *testing.T) {
+	var capturedReq *deepseek.StreamChatCompletionRequest
+	defer mockey.Mock((*deepseek.Client).CreateChatCompletionStream).To(func(ctx context.Context, request *deepseek.StreamChatCompletionRequest) (deepseek.ChatCompletionStream, error) {
+		capturedReq = request
+		return &mockStream{}, nil
+	}).Build().UnPatch()
+
+	ctx := context.Background()
+	cm, err := NewChatModel(ctx, &ChatModelConfig{
+		APIKey: "test-key",
+		Model:  "deepseek-reasoner",
+		ThinkingConfig: &ThinkingConfig{
+			Type: "enabled",
+		},
+	})
+	assert.Nil(t, err)
+
+	stream, err := cm.Stream(ctx, []*schema.Message{schema.UserMessage("hello")})
+	assert.Nil(t, err)
+	if assert.NotNil(t, stream) &&
+		assert.NotNil(t, capturedReq) &&
+		assert.NotNil(t, capturedReq.Thinking) {
+		assert.Equal(t, "enabled", capturedReq.Thinking.Type)
+	}
+}
+
 func TestNewChatModel(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- forward DeepSeek ThinkingConfig into stream chat completion requests
- add regression coverage for stream requests carrying thinking config

## Root Cause
`generateStreamRequest` builds a stream request from the non-stream request but did not copy the `Thinking` field, so `ChatModelConfig.ThinkingConfig` was applied to Generate but dropped for Stream.

## Validation
- `git diff --check main...HEAD`
- `GOTOOLCHAIN=go1.24.1 go test ./... -count=1 -gcflags="all=-N -l"` in `components/model/deepseek`

Fixes #807