### PR TITLE
feat(ark): support audio input in Responses API

### DIFF
--- a/components/model/ark/chat_completion_api.go
+++ b/components/model/ark/chat_completion_api.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log"
 	"runtime/debug"
+	"strings"
 
 	"github.com/eino-contrib/jsonschema"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime"
@@ -428,6 +429,52 @@ func runeSlice2int64(in []rune) []int64 {
 	return ret
 }
 
+// audioFormatFromMIME derives the ark SDK audio Format field from a MIME type.
+// Examples: "audio/mp3" -> "mp3", "audio/wav" -> "wav",
+// "audio/mpeg; codecs=mp3" -> "mpeg" (RFC 2045 parameters are stripped).
+// Returns input as-is when it is empty or does not carry the "audio/" prefix.
+func audioFormatFromMIME(mime string) string {
+	if mime == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(mime, ';'); idx >= 0 {
+		mime = mime[:idx]
+	}
+	mime = strings.TrimSpace(mime)
+	return strings.TrimPrefix(mime, "audio/")
+}
+
+// validateMessagePartCommon validates the URL / Base64Data branching rules
+// shared by audio, image and video parts. partName is interpolated into error
+// messages (e.g., "audio", "image"). It returns the chosen raw value (URL or
+// raw base64), a flag indicating whether Base64Data was used, and an error
+// when neither field is provided or the input is malformed. The caller is
+// responsible for mapping the raw value into the SDK field expected by the
+// target API (e.g., wrapping base64 into a data URL for image/video, or
+// keeping it raw for audio).
+func validateMessagePartCommon(c schema.MessagePartCommon, partName string) (raw string, isBase64 bool, err error) {
+	if c.URL != nil && *c.URL != "" {
+		return *c.URL, false, nil
+	}
+	if c.Base64Data != nil && *c.Base64Data != "" {
+		if strings.HasPrefix(*c.Base64Data, "data:") {
+			return "", true, fmt.Errorf("%s Base64Data must be a raw base64 string (use Base64Data + MIMEType separately, not a 'data:' URL)", partName)
+		}
+		if c.MIMEType == "" {
+			return "", true, fmt.Errorf("%s part must have MIMEType when using Base64Data", partName)
+		}
+		return *c.Base64Data, true, nil
+	}
+	return "", false, fmt.Errorf("%s part must contain either a URL or Base64Data", partName)
+}
+
+// toBase64DataURL formats a raw base64 string and MIME type into an RFC 2397
+// data URL. The caller is expected to have validated both inputs (e.g., via
+// validateMessagePartCommon) before invoking it.
+func toBase64DataURL(rawBase64, mime string) string {
+	return fmt.Sprintf("data:%s;base64,%s", mime, rawBase64)
+}
+
 func (cm *completionAPIChatModel) resolveChatResponse(resp model.ChatCompletionResponse) (msg *schema.Message, err error) {
 	if len(resp.Choices) == 0 {
 		return nil, ErrEmptyResponse
@@ -587,7 +634,6 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 			return nil, fmt.Errorf("user input multi content only support user&tool role, got %s", msg.Role)
 		}
 		parts = make([]*model.ChatCompletionMessageContentPart, 0, len(msg.UserInputMultiContent))
-		var err error
 		for _, part := range msg.UserInputMultiContent {
 			switch part.Type {
 			case schema.ChatMessagePartTypeText:
@@ -599,19 +645,13 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 				if part.Image == nil {
 					return nil, fmt.Errorf("image field must not be nil when Type is ChatMessagePartTypeImageURL in user message")
 				}
-				var imageURL string
-				if part.Image.URL != nil && *part.Image.URL != "" {
-					imageURL = *part.Image.URL
-				} else if part.Image.Base64Data != nil && *part.Image.Base64Data != "" {
-					if part.Image.MIMEType == "" {
-						return nil, fmt.Errorf("image part must have MIMEType when using Base64Data")
-					}
-					imageURL, err = ensureDataURL(*part.Image.Base64Data, part.Image.MIMEType)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					return nil, fmt.Errorf("image part for user input must contain either a URL or Base64Data, but got: %+v", part.Image)
+				raw, isBase64, vErr := validateMessagePartCommon(part.Image.MessagePartCommon, "image")
+				if vErr != nil {
+					return nil, vErr
+				}
+				imageURL := raw
+				if isBase64 {
+					imageURL = toBase64DataURL(raw, part.Image.MIMEType)
 				}
 				parts = append(parts, &model.ChatCompletionMessageContentPart{
 					Type: model.ChatCompletionMessageContentPartTypeImageURL,
@@ -624,19 +664,13 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 				if part.Video == nil {
 					return nil, fmt.Errorf("video field must not be nil when Type is ChatMessagePartTypeVideoURL in user message")
 				}
-				var videoURL string
-				if part.Video.URL != nil && *part.Video.URL != "" {
-					videoURL = *part.Video.URL
-				} else if part.Video.Base64Data != nil && *part.Video.Base64Data != "" {
-					if part.Video.MIMEType == "" {
-						return nil, fmt.Errorf("video part must have MIMEType when using Base64Data")
-					}
-					videoURL, err = ensureDataURL(*part.Video.Base64Data, part.Video.MIMEType)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					return nil, fmt.Errorf("video part for user input must contain either a URL or Base64Data, but got: %+v", part.Video)
+				raw, isBase64, vErr := validateMessagePartCommon(part.Video.MessagePartCommon, "video")
+				if vErr != nil {
+					return nil, vErr
+				}
+				videoURL := raw
+				if isBase64 {
+					videoURL = toBase64DataURL(raw, part.Video.MIMEType)
 				}
 				parts = append(parts, &model.ChatCompletionMessageContentPart{
 					Type: model.ChatCompletionMessageContentPartTypeVideoURL,
@@ -645,6 +679,27 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 						FPS: GetInputVideoFPS(part.Video),
 					},
 				})
+			case schema.ChatMessagePartTypeAudioURL:
+				if part.Audio == nil {
+					return nil, fmt.Errorf("audio field must not be nil when Type is ChatMessagePartTypeAudioURL in user message")
+				}
+				raw, isBase64, vErr := validateMessagePartCommon(part.Audio.MessagePartCommon, "audio")
+				if vErr != nil {
+					return nil, vErr
+				}
+				audioURL := &model.ChatMessageAudioURL{
+					Format: audioFormatFromMIME(part.Audio.MIMEType),
+				}
+				if isBase64 {
+					audioURL.Data = raw
+				} else {
+					audioURL.URL = raw
+				}
+				parts = append(parts, &model.ChatCompletionMessageContentPart{
+					Type:       model.ChatCompletionMessageContentPartTypeAudioURL,
+					InputAudio: audioURL,
+				})
+
 			default:
 				return nil, fmt.Errorf("unsupported chat message part type in user message: %s", part.Type)
 			}
@@ -654,7 +709,6 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 			return nil, fmt.Errorf("assistant gen multi content only support assistant role, got %s", msg.Role)
 		}
 		parts = make([]*model.ChatCompletionMessageContentPart, 0, len(msg.AssistantGenMultiContent))
-		var err error
 		for _, part := range msg.AssistantGenMultiContent {
 			switch part.Type {
 			case schema.ChatMessagePartTypeText:
@@ -666,19 +720,13 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 				if part.Image == nil {
 					return nil, fmt.Errorf("image field must not be nil when Type is ChatMessagePartTypeImageURL in assistant message")
 				}
-				var imageURL string
-				if part.Image.URL != nil && *part.Image.URL != "" {
-					imageURL = *part.Image.URL
-				} else if part.Image.Base64Data != nil && *part.Image.Base64Data != "" {
-					if part.Image.MIMEType == "" {
-						return nil, fmt.Errorf("image part must have MIMEType when using Base64Data")
-					}
-					imageURL, err = ensureDataURL(*part.Image.Base64Data, part.Image.MIMEType)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					return nil, fmt.Errorf("image part for assistant output must contain either a URL or Base64Data, but got: %+v", part.Image)
+				raw, isBase64, vErr := validateMessagePartCommon(part.Image.MessagePartCommon, "image")
+				if vErr != nil {
+					return nil, vErr
+				}
+				imageURL := raw
+				if isBase64 {
+					imageURL = toBase64DataURL(raw, part.Image.MIMEType)
 				}
 				parts = append(parts, &model.ChatCompletionMessageContentPart{
 					Type: model.ChatCompletionMessageContentPartTypeImageURL,
@@ -690,19 +738,13 @@ func (cm *completionAPIChatModel) toArkContent(msg *schema.Message) (*model.Chat
 				if part.Video == nil {
 					return nil, fmt.Errorf("video field must not be nil when Type is ChatMessagePartTypeVideoURL in assistant message")
 				}
-				var videoURL string
-				if part.Video.URL != nil && *part.Video.URL != "" {
-					videoURL = *part.Video.URL
-				} else if part.Video.Base64Data != nil && *part.Video.Base64Data != "" {
-					if part.Video.MIMEType == "" {
-						return nil, fmt.Errorf("video part must have MIMEType when using Base64Data")
-					}
-					videoURL, err = ensureDataURL(*part.Video.Base64Data, part.Video.MIMEType)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					return nil, fmt.Errorf("video part for assistant output must contain either a URL or Base64Data, but got: %+v", part.Video)
+				raw, isBase64, vErr := validateMessagePartCommon(part.Video.MessagePartCommon, "video")
+				if vErr != nil {
+					return nil, vErr
+				}
+				videoURL := raw
+				if isBase64 {
+					videoURL = toBase64DataURL(raw, part.Video.MIMEType)
 				}
 				parts = append(parts, &model.ChatCompletionMessageContentPart{
 					Type: model.ChatCompletionMessageContentPartTypeVideoURL,

--- a/components/model/ark/chat_completion_api_test.go
+++ b/components/model/ark/chat_completion_api_test.go
@@ -446,6 +446,87 @@ func TestCompletionAPIChatModel_toArkContent(t *testing.T) {
 				_, err := cm.toArkContent(msg)
 				convey.So(err, convey.ShouldNotBeNil)
 			})
+
+			PatchConvey("Audio success with URL", func() {
+				audioURL := "https://example.com/audio.mp3"
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{URL: &audioURL, MIMEType: "audio/mp3"},
+						}},
+					},
+				}
+				content, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldBeNil)
+				convey.So(content.ListValue, convey.ShouldHaveLength, 1)
+				convey.So(content.ListValue[0].InputAudio.URL, convey.ShouldEqual, audioURL)
+				convey.So(content.ListValue[0].InputAudio.Format, convey.ShouldEqual, "mp3")
+				convey.So(content.ListValue[0].InputAudio.Data, convey.ShouldEqual, "")
+			})
+
+			PatchConvey("Audio success with Base64Data", func() {
+				audioB64 := "SGVsbG9BdWRpbw=="
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64, MIMEType: "audio/wav"},
+						}},
+					},
+				}
+				content, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldBeNil)
+				convey.So(content.ListValue, convey.ShouldHaveLength, 1)
+				convey.So(content.ListValue[0].InputAudio.Data, convey.ShouldEqual, audioB64)
+				convey.So(content.ListValue[0].InputAudio.Format, convey.ShouldEqual, "wav")
+				convey.So(content.ListValue[0].InputAudio.URL, convey.ShouldEqual, "")
+			})
+
+			PatchConvey("Error on nil audio", func() {
+				msg := &schema.Message{Role: schema.User, UserInputMultiContent: []schema.MessageInputPart{{Type: schema.ChatMessagePartTypeAudioURL, Audio: nil}}}
+				_, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldNotBeNil)
+				convey.So(err.Error(), convey.ShouldContainSubstring, "audio field must not be nil")
+			})
+
+			PatchConvey("Error on empty audio data", func() {
+				msg := &schema.Message{Role: schema.User, UserInputMultiContent: []schema.MessageInputPart{{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{}}}}
+				_, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldNotBeNil)
+				convey.So(err.Error(), convey.ShouldContainSubstring, "must contain either a URL or Base64Data")
+			})
+
+			PatchConvey("Error on missing MIMEType for audio Base64Data", func() {
+				audioB64 := "SGVsbG9BdWRpbw=="
+				msg := &schema.Message{Role: schema.User, UserInputMultiContent: []schema.MessageInputPart{{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64}}}}}
+				_, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldNotBeNil)
+				convey.So(err.Error(), convey.ShouldContainSubstring, "must have MIMEType when using Base64Data")
+			})
+
+			PatchConvey("Audio Format strips RFC 2045 parameters", func() {
+				audioB64 := "SGVsbG9BdWRpbw=="
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64, MIMEType: "audio/mpeg; codecs=mp3"},
+						}},
+					},
+				}
+				content, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldBeNil)
+				convey.So(content.ListValue[0].InputAudio.Format, convey.ShouldEqual, "mpeg")
+			})
+
+			PatchConvey("Error on audio Base64Data with data: prefix", func() {
+				audioB64 := "data:audio/mp3;base64,SGVsbG9BdWRpbw=="
+				msg := &schema.Message{Role: schema.User, UserInputMultiContent: []schema.MessageInputPart{{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64, MIMEType: "audio/mp3"}}}}}
+				_, err := cm.toArkContent(msg)
+				convey.So(err, convey.ShouldNotBeNil)
+				convey.So(err.Error(), convey.ShouldContainSubstring, "audio Base64Data must be a raw base64 string")
+			})
 		})
 
 		PatchConvey("AssistantGenMultiContent", func() {

--- a/components/model/ark/go.mod
+++ b/components/model/ark/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.11.1
-	github.com/volcengine/volcengine-go-sdk v1.2.9
+	github.com/volcengine/volcengine-go-sdk v1.2.27
 )
 
 require (

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -137,8 +137,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.9 h1:du2gnImtyWXKkQFnJW/GXCs+UBibGGOXIbP1Ams2pB8=
-github.com/volcengine/volcengine-go-sdk v1.2.9/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.27 h1:azBueeKhhGQukss+ob6m3oJ5K8GGYbfDNj8RKAEXVTE=
+github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -652,7 +652,6 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 						{Text: msg.ReasoningContent},
 					},
 				}}})
-
 			}
 
 			inputMessage, err := cm.toArkAssistantRoleItemInputMessage(msg)
@@ -1430,6 +1429,16 @@ func convUserInputMultiContentToContentItems(parts []schema.MessageInputPart) ([
 			}
 			items = append(items, item)
 
+		case schema.ChatMessagePartTypeAudioURL:
+			if part.Audio == nil {
+				return nil, fmt.Errorf("audio field must not be nil when Type is ChatMessagePartTypeAudioURL")
+			}
+			item, err := convMsgInputAudioToResponseContentItem(part.Audio)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+
 		default:
 			return nil, fmt.Errorf("unsupported content type in UserInputMultiContent: %s", part.Type)
 		}
@@ -1476,6 +1485,25 @@ func convMsgInputVideoToResponseContentItem(video *schema.MessageInputVideo) (*r
 	return &responses.ContentItem{
 		Union: &responses.ContentItem_Video{
 			Video: contentItemVideo,
+		},
+	}, nil
+
+}
+
+func convMsgInputAudioToResponseContentItem(audio *schema.MessageInputAudio) (*responses.ContentItem, error) {
+	audioURL, err := convMessagePartCommonToURL(audio.MessagePartCommon)
+	if err != nil {
+		return nil, fmt.Errorf("convert message input audio failed err: %w", err)
+	}
+
+	contentItemAudio := &responses.ContentItemAudio{
+		Type:     responses.ContentItemType_input_audio,
+		AudioUrl: audioURL,
+	}
+
+	return &responses.ContentItem{
+		Union: &responses.ContentItem_Audio{
+			Audio: contentItemAudio,
 		},
 	}, nil
 

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -867,6 +867,82 @@ func TestResponsesAPIChatModel_toOpenaiMultiModalContent(t *testing.T) {
 				assert.ErrorContains(t, err, "image field must not be nil")
 			})
 
+			PatchConvey("Audio success with URL", func() {
+				audioURL := "https://example.com/audio.mp3"
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{URL: &audioURL},
+						}},
+					},
+				}
+				inputMessage, err := cm.toArkUserRoleItemInputMessage(msg)
+				assert.Nil(t, err)
+				assert.Len(t, inputMessage.Content, 1)
+				audioItem := inputMessage.Content[0].GetAudio()
+				assert.NotNil(t, audioItem)
+				assert.Equal(t, audioURL, audioItem.AudioUrl)
+				assert.Equal(t, responses.ContentItemType_input_audio, audioItem.Type)
+			})
+
+			PatchConvey("Audio success with Base64 and MIMEType", func() {
+				audioB64 := "SGVsbG9BdWRpbw=="
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64, MIMEType: "audio/mpeg"},
+						}},
+					},
+				}
+				inputMessage, err := cm.toArkUserRoleItemInputMessage(msg)
+				assert.Nil(t, err)
+				assert.Len(t, inputMessage.Content, 1)
+				audioItem := inputMessage.Content[0].GetAudio()
+				assert.NotNil(t, audioItem)
+				assert.Contains(t, audioItem.AudioUrl, "data:audio/mpeg;base64,")
+			})
+
+			PatchConvey("Audio error on nil Audio", func() {
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: nil},
+					},
+				}
+				_, err := cm.toArkUserRoleItemInputMessage(msg)
+				assert.NotNil(t, err)
+				assert.ErrorContains(t, err, "audio field must not be nil")
+			})
+
+			PatchConvey("Audio error on missing URL and Base64", func() {
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{}},
+					},
+				}
+				_, err := cm.toArkUserRoleItemInputMessage(msg)
+				assert.NotNil(t, err)
+				assert.ErrorContains(t, err, "must have URL or Base64Data")
+			})
+
+			PatchConvey("Audio error on missing MIMEType for Base64", func() {
+				audioB64 := "SGVsbG9BdWRpbw=="
+				msg := &schema.Message{
+					Role: schema.User,
+					UserInputMultiContent: []schema.MessageInputPart{
+						{Type: schema.ChatMessagePartTypeAudioURL, Audio: &schema.MessageInputAudio{
+							MessagePartCommon: schema.MessagePartCommon{Base64Data: &audioB64},
+						}},
+					},
+				}
+				_, err := cm.toArkUserRoleItemInputMessage(msg)
+				assert.NotNil(t, err)
+				assert.ErrorContains(t, err, "must have MIMEType when use Base64Data")
+			})
+
 		})
 
 		PatchConvey("AssistantGenMultiContent", func() {


### PR DESCRIPTION
- Add ChatMessagePartTypeAudioURL handling in convUserInputMultiContentToContentItems
- Add convMsgInputAudioToResponseContentItem to build ContentItemAudio from schema.MessageInputAudio (URL or Base64 + MIMEType)
- Bump volcengine-go-sdk from v1.2.9 to v1.2.26 for ContentItemAudio support
- Add unit tests covering audio URL / Base64 success paths and nil / missing-URL / missing-MIMEType error paths

