### PR TITLE
fix(deepseek): propagate Thinking config in stream request

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -533,6 +533,7 @@ func (cm *ChatModel) generateStreamRequest(ctx context.Context, in []*schema.Mes
 		LogProbs:         origReq.LogProbs,
 		TopLogProbs:      origReq.TopLogProbs,
 		ExtraFields:      origReq.ExtraFields,
+		Thinking:         origReq.Thinking,
 	}
 	return req, cbIn, nil
 }


### PR DESCRIPTION
- Pass through the Thinking field when building the streaming request in generateStreamRequest, matching the non-streaming path
- Fix an issue where ThinkingConfig set by the caller was silently dropped on streaming calls, causing thinking/non-thinking mode to be ignored in stream responses

