### PR TITLE
fix(agenticopenai): avoid duplicate tool search registration

### DIFF
--- a/components/model/agenticopenai/model.go
+++ b/components/model/agenticopenai/model.go
@@ -772,9 +772,11 @@ func (m *Model) populateTools(responseReq *responses.ResponseNewParams, options 
 			return err
 		}
 		functionTools = append(functionTools, deferredTools...)
-		functionTools = append(functionTools, responses.ToolUnionParam{
-			OfToolSearch: &responses.ToolSearchToolParam{}, // add hosted tool search automatically if deferred tools has been set
-		})
+		if options.ToolSearchTool == nil {
+			functionTools = append(functionTools, responses.ToolUnionParam{
+				OfToolSearch: &responses.ToolSearchToolParam{}, // add hosted tool search automatically if deferred tools has been set
+			})
+		}
 	}
 
 	if options.ToolSearchTool != nil {

--- a/components/model/agenticopenai/model_test.go
+++ b/components/model/agenticopenai/model_test.go
@@ -265,6 +265,39 @@ func TestPopulateToolsWithDeferredTools(t *testing.T) {
 			}
 			assert.True(t, hasToolSearch, "should add client tool search when ToolSearchTool is set")
 		})
+
+		mockey.PatchConvey("uses_client_tool_search_when_deferred_tools_and_tool_search_tool_are_set", func() {
+			deferredTools := []*schema.ToolInfo{
+				{Name: "deferred1", Desc: "d", ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&jsonschema.Schema{Type: "object"})},
+			}
+			toolSearchTool := &schema.ToolInfo{
+				Name:        "my_search",
+				Desc:        "search tools",
+				ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&jsonschema.Schema{Type: "object"}),
+			}
+			options := &model.Options{
+				DeferredTools:  deferredTools,
+				ToolSearchTool: toolSearchTool,
+			}
+			specOptions := &openaiOptions{}
+			req := &responses.ResponseNewParams{}
+			err := m.populateTools(req, options, specOptions)
+			assert.NoError(t, err)
+
+			toolSearchCount := 0
+			hasDeferredTool := false
+			for _, tool := range req.Tools {
+				if tool.OfFunction != nil && tool.OfFunction.Name == "deferred1" {
+					hasDeferredTool = true
+				}
+				if tool.OfToolSearch != nil {
+					toolSearchCount++
+					assert.Equal(t, responses.ToolSearchToolExecutionClient, tool.OfToolSearch.Execution)
+				}
+			}
+			assert.True(t, hasDeferredTool, "should keep deferred tools registered")
+			assert.Equal(t, 1, toolSearchCount, "should not add both hosted and client tool search")
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary
- Avoid registering both hosted and client tool search when `DeferredTools` and `ToolSearchTool` are both set.
- Keep automatic hosted tool-search registration only for the deferred-tools-only case.
- Add `populateTools` coverage for the combined deferred/client tool-search configuration.

## Motivation
When a caller explicitly supplies `ToolSearchTool`, agentic OpenAI should use client-executed tool search. Adding hosted tool search on top of that can create duplicate/conflicting tool-search registration in the Responses request.

## Tests
- `cd components/model/agenticopenai && go test ./...`