### PR TITLE
fix(gemini): include ThoughtsTokenCount in CompletionTokens

### DIFF
--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -1148,7 +1148,7 @@ func convResponse(resp *genai.GenerateContentResponse) (*schema.Message, error) 
 			PromptTokenDetails: schema.PromptTokenDetails{
 				CachedTokens: int(resp.UsageMetadata.CachedContentTokenCount),
 			},
-			CompletionTokens: int(resp.UsageMetadata.CandidatesTokenCount),
+			CompletionTokens: int(resp.UsageMetadata.CandidatesTokenCount) + int(resp.UsageMetadata.ThoughtsTokenCount),
 			TotalTokens:      int(resp.UsageMetadata.TotalTokenCount),
 			CompletionTokensDetails: schema.CompletionTokensDetails{
 				ReasoningTokens: int(resp.UsageMetadata.ThoughtsTokenCount),

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -69,6 +69,7 @@ func TestGemini(t *testing.T) {
 		assert.Equal(t, "Hello, how can I help you?", resp.Content)
 		assert.Equal(t, schema.Assistant, resp.Role)
 		assert.Equal(t, 100, resp.ResponseMeta.Usage.TotalTokens)
+		assert.Equal(t, 100, resp.ResponseMeta.Usage.CompletionTokens)
 		assert.Equal(t, 50, resp.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens)
 	})
 	mockey.PatchConvey("stream", t, func() {


### PR DESCRIPTION
## Summary

- Map Gemini usage `CompletionTokens` to `CandidatesTokenCount + ThoughtsTokenCount` so reported completion usage matches total model output (visible reply plus reasoning/thought tokens).
- Extend `TestGemini` to assert `CompletionTokens` when both counts are present.

## Background

Per `google.golang.org/genai` `GenerateContentResponseUsageMetadata`, `ThoughtsTokenCount` is reported separately from `CandidatesTokenCount`; downstream billing and OpenAI-style `completion_tokens` semantics expect the full output side, not candidates-only.

## Test plan

- [x] `cd components/model/gemini && go test ./...`


Made with [Cursor](https://cursor.com)