### PR TITLE
fix(ark): add ProjectName in EmbeddingConfig to support preset endpoints

### DIFF
--- a/components/embedding/ark/embedding.go
+++ b/components/embedding/ark/embedding.go
@@ -69,6 +69,11 @@ type EmbeddingConfig struct {
 	AccessKey string `json:"access_key"`
 	SecretKey string `json:"secret_key"`
 
+	// ProjectName specifies the project name for preset endpoint (ep-m-*) authentication
+	// Required only when using AccessKey/SecretKey with preset endpoints
+	// Optional.
+	ProjectName string `json:"project_name,omitempty"`
+
 	// Model specifies the ID of endpoint on ark platform
 	// Required
 	Model string `json:"model"`
@@ -195,7 +200,7 @@ func (e *Embedder) EmbedStrings(ctx context.Context, texts []string, opts ...emb
 			req.Dimensions = *e.conf.Dimensions
 		}
 
-		resp, err := e.client.CreateEmbeddings(ctx, req)
+		resp, err := e.client.CreateEmbeddings(ctx, req, arkruntime.WithProjectName(e.conf.ProjectName))
 		if err != nil {
 			return nil, fmt.Errorf("[Ark] CreateEmbeddings error: %w", err)
 		}
@@ -229,7 +234,7 @@ func (e *Embedder) EmbedStrings(ctx context.Context, texts []string, opts ...emb
 					Model:          conf.Model,
 					EncodingFormat: &encodingFormat,
 					Dimensions:     e.conf.Dimensions,
-				})
+				}, arkruntime.WithProjectName(e.conf.ProjectName))
 				if err != nil {
 					return fmt.Errorf("[Ark] CreateMultiModalEmbeddings error: %w", err)
 				}


### PR DESCRIPTION
Preset endpoints (ep-m-*) require a project name header when using AK/SK authentication. This change adds a ProjectName field to EmbeddingConfig and passes it via WithProjectName request option to both CreateEmbeddings and CreateMultiModalEmbeddings calls.

### What type of PR is this?
Bug fix

- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

### (Optional) More detailed description for this PR(en: English/zh: Chinese).
**en:** 
Added `ProjectName` field to `EmbeddingConfig` and ensured it is passed to the underlying SDK as a request option. This resolves the 400 RequestError (`project name is required for preset endpoint`) when using Ark's preset models.

**zh(optional):** 
在 `EmbeddingConfig` 结构体中新增了 `ProjectName` 字段，并在调用底层 SDK 的 `CreateEmbeddings` 等方法时，通过 `WithProjectName` 透传了该参数。修复了在火山引擎 Ark 平台使用预置模型时，因漏传项目名称导致的 400 报错问题。

### Which issue(s) this PR fixes:
Fixes #730