### PR TITLE
docs(skills): update all four skills for v0.9 agentic-runtime

### DIFF
--- a/callbacks/cozeloop/go.mod
+++ b/callbacks/cozeloop/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/coze-dev/cozeloop-go v0.1.20
 	github.com/coze-dev/cozeloop-go/spec v0.1.8
 	github.com/smartystreets/goconvey v1.8.1

--- a/callbacks/cozeloop/go.sum
+++ b/callbacks/cozeloop/go.sum
@@ -22,8 +22,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/coze-dev/cozeloop-go v0.1.20 h1:RO/o5cm8Nu71hG+7yoveA53oY9Q24u7NJBYZ9KBEDIo=
 github.com/coze-dev/cozeloop-go v0.1.20/go.mod h1:lM7cmUEZlnAlQYdwfk4Li0SC3RdZ++QMHX75nvKceSc=
 github.com/coze-dev/cozeloop-go/spec v0.1.8 h1:hFVBj/C1B6mUNGH/q52kO2n1pXuTomG578RbKlfYLGk=

--- a/callbacks/cozeloop/go.sum
+++ b/callbacks/cozeloop/go.sum
@@ -22,7 +22,7 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/coze-dev/cozeloop-go v0.1.20 h1:RO/o5cm8Nu71hG+7yoveA53oY9Q24u7NJBYZ9KBEDIo=
 github.com/coze-dev/cozeloop-go v0.1.20/go.mod h1:lM7cmUEZlnAlQYdwfk4Li0SC3RdZ++QMHX75nvKceSc=

--- a/components/model/agenticark/go.mod
+++ b/components/model/agenticark/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -23,8 +23,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -23,7 +23,7 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticdeepseek/go.mod
+++ b/components/model/agenticdeepseek/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticdeepseek/go.sum
+++ b/components/model/agenticdeepseek/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticdeepseek/go.sum
+++ b/components/model/agenticdeepseek/go.sum
@@ -18,7 +18,7 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=

--- a/components/model/agenticgemini/go.mod
+++ b/components/model/agenticgemini/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/genai v1.36.0

--- a/components/model/agenticgemini/go.sum
+++ b/components/model/agenticgemini/go.sum
@@ -28,8 +28,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticgemini/go.sum
+++ b/components/model/agenticgemini/go.sum
@@ -28,7 +28,7 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticopenai/go.mod
+++ b/components/model/agenticopenai/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/openai/openai-go/v3 v3.35.0

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -26,7 +26,7 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -26,8 +26,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticqwen/go.mod
+++ b/components/model/agenticqwen/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticqwen/go.sum
+++ b/components/model/agenticqwen/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticqwen/go.sum
+++ b/components/model/agenticqwen/go.sum
@@ -18,7 +18,7 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=

--- a/components/model/claude/go.mod
+++ b/components/model/claude/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.54
 	github.com/bytedance/mockey v1.2.13
-	github.com/cloudwego/eino v0.9.0-alpha.14
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/components/model/claude/go.sum
+++ b/components/model/claude/go.sum
@@ -58,7 +58,7 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:RHh/bckiWUQd6u/NASEdAWF0LUAOKQZuYdTg9iR5gL4=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/claude/go.sum
+++ b/components/model/claude/go.sum
@@ -58,8 +58,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.14 h1:RHh/bckiWUQd6u/NASEdAWF0LUAOKQZuYdTg9iR5gL4=
-github.com/cloudwego/eino v0.9.0-alpha.14/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:RHh/bckiWUQd6u/NASEdAWF0LUAOKQZuYdTg9iR5gL4=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/libs/acl/openai/go.mod
+++ b/libs/acl/openai/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.3.0
-	github.com/cloudwego/eino v0.9.0-alpha.22
+	github.com/cloudwego/eino v0.9.0-beta.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/meguminnnnnnnnn/go-openai v0.1.1 // fork from github.com/sashabaranov/go-openai, temporary solution, switch to github.com/openai/openai-go in the future.
 	github.com/stretchr/testify v1.11.1

--- a/libs/acl/openai/go.sum
+++ b/libs/acl/openai/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.22 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
-github.com/cloudwego/eino v0.9.0-alpha.22/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/libs/acl/openai/go.sum
+++ b/libs/acl/openai/go.sum
@@ -18,7 +18,7 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:C4+VvCoorDymitg5MZUef/M5O0L13RIbUbVcYxMWHS8=
+github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
 github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -167,8 +167,8 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     // ...
     ModelFailoverConfig: &adk.ModelFailoverConfig[*schema.Message]{
         MaxRetries: 2,
-        ShouldFailover: func(ctx context.Context, output *schema.Message, err error) bool {
-            return err != nil // failover on any error
+        ShouldFailover: func(ctx context.Context, outputMessage *schema.Message, outputErr error) bool {
+            return outputErr != nil // failover on any error
         },
         GetFailoverModel: func(ctx context.Context, failoverCtx *adk.FailoverContext[*schema.Message]) (
             model.BaseModel[*schema.Message], []*schema.Message, error) {

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -15,9 +15,9 @@ type MessageType interface {
 }
 
 type TypedAgent[M MessageType] interface {
-    Name() string
-    Description() string
-    Run(ctx context.Context, input *TypedAgentInput[M]) *AsyncIterator[*TypedAgentEvent[M]]
+    Name(ctx context.Context) string
+    Description(ctx context.Context) string
+    Run(ctx context.Context, input *TypedAgentInput[M], opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]]
 }
 
 // Convenience aliases for classic message type

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -1,20 +1,27 @@
 ---
 name: eino-agent
-description: Eino ADK agent construction, middleware, and runner. Use when a user needs to build an AI Agent, configure ChatModelAgent with ReAct pattern, use middleware (filesystem, tool search, tool reduction, summarization, plan-task, skill), set up the Runner for event-driven execution, implement human-in-the-loop with interrupt/resume, or wrap agents as tools. Covers ChatModelAgent and DeepAgents.
+description: Eino ADK agent construction, middleware, and runner. Use when a user needs to build an AI Agent, configure ChatModelAgent with ReAct pattern, use middleware (filesystem, tool search, tool reduction, summarization, plan-task, skill, agents.md), set up the Runner for event-driven execution, implement human-in-the-loop with interrupt/resume, use Cancel/Retry/Failover for model resilience, build push-based multi-turn loops with TurnLoop, or wrap agents as tools. Covers ChatModelAgent, DeepAgents, and TurnLoop.
 ---
 
 # Eino ADK Overview
 
 Import: `github.com/cloudwego/eino/adk`
 
-The Agent Development Kit (ADK) provides a framework for building agents in Go. Core interface:
+The Agent Development Kit (ADK) provides a framework for building agents in Go. The ADK is generically parameterized by `MessageType` to support both classic `*schema.Message` and the new `*schema.AgenticMessage`.
 
 ```go
-type Agent interface {
-    Name(ctx context.Context) string
-    Description(ctx context.Context) string
-    Run(ctx context.Context, input *AgentInput, opts ...AgentRunOption) *AsyncIterator[*AgentEvent]
+type MessageType interface {
+    *schema.Message | *schema.AgenticMessage
 }
+
+type TypedAgent[M MessageType] interface {
+    Name() string
+    Description() string
+    Run(ctx context.Context, input *TypedAgentInput[M]) *AsyncIterator[*TypedAgentEvent[M]]
+}
+
+// Convenience aliases for classic message type
+type Agent = TypedAgent[*schema.Message]
 ```
 
 # Agent Types
@@ -23,7 +30,8 @@ type Agent interface {
 |------|-------------|----------|
 | ChatModelAgent | ReAct pattern: LLM reasons, calls tools, loops until done | Dynamic (LLM) |
 | DeepAgent | Pre-built agent with planning, filesystem, sub-agents | Dynamic (LLM) |
-| Custom Agent | Implement the Agent interface directly | Custom |
+| TurnLoop | Push-based event loop for multi-turn execution with preemption and lifecycle management | Runtime |
+| Custom Agent | Implement the TypedAgent interface directly | Custom |
 
 # ChatModelAgent Quick Start
 
@@ -51,7 +59,7 @@ func main() {
             return `{"books": ["The Great Gatsby"]}`, nil
         })
 
-    // 2. Create model
+    // 2. Create model (BaseModel[M], not ToolCallingChatModel)
     cm, _ := openai.NewChatModel(ctx, &openai.ChatModelConfig{
         APIKey: "your-key", Model: "gpt-4o",
     })
@@ -80,11 +88,142 @@ func main() {
         if event.Err != nil {
             log.Fatal(event.Err)
         }
-        msg, _ := event.Output.MessageOutput.GetMessage()
-        fmt.Printf("Agent[%s]: %v\n", event.AgentName, msg)
+        if event.Output != nil && event.Output.MessageOutput != nil {
+            msg, _ := event.Output.MessageOutput.GetMessage()
+            fmt.Printf("Agent[%s]: %v\n", event.AgentName, msg)
+        }
     }
 }
 ```
+
+# Cancel Mechanism
+
+Cancel provides safe, controllable termination of agent execution.
+
+```go
+// Create a cancel function alongside the run
+cancelOpt, cancelFn := adk.WithCancel()
+iter := runner.Query(ctx, "do something", cancelOpt)
+
+// Cancel at a safe point (after current model call or tool calls complete)
+handle, ok := cancelFn(adk.WithAgentCancelMode(adk.CancelAfterChatModel))
+if ok {
+    err := handle.Wait() // blocks until cancel completes
+}
+```
+
+**CancelMode** (bitmask):
+
+| Mode | Behavior |
+|------|----------|
+| `CancelImmediate` (0) | Abort immediately, stream terminated |
+| `CancelAfterChatModel` | Wait for current model call to finish |
+| `CancelAfterToolCalls` | Wait for current tool calls to finish |
+
+**Cancel options:**
+- `WithAgentCancelMode(mode)` -- set safe point
+- `WithAgentCancelTimeout(d)` -- escalate to immediate if safe point not reached in time
+- `WithRecursive()` -- propagate cancel into nested AgentTool agents
+
+Cancel produces a `CancelError` on the event stream with checkpoint data for later resumption.
+
+# Model Retry
+
+Output-based retry with full control over retry decisions.
+
+```go
+agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+    // ...
+    ModelRetryConfig: &adk.ModelRetryConfig{
+        MaxRetries: 3,
+        ShouldRetry: func(ctx context.Context, retryCtx *adk.RetryContext) *adk.RetryDecision {
+            // Retry based on output content (e.g., empty response, bad finish reason)
+            if retryCtx.OutputMessage.Content == "" {
+                return &adk.RetryDecision{Retry: true, Backoff: time.Second}
+            }
+            return &adk.RetryDecision{Retry: false}
+        },
+    },
+})
+```
+
+**RetryContext** provides: `RetryAttempt`, `InputMessages`, `OutputMessage` (full concatenated response), `Err`.
+
+**RetryDecision** controls: `Retry`, `ModifiedInputMessages`, `AdditionalOptions`, `Backoff`, `RejectReason`.
+
+When streaming, a `WillRetryError` is emitted on the stream to signal retry is occurring.
+
+# Model Failover
+
+Dynamic model switching when primary model fails or produces unsatisfactory output.
+
+```go
+agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+    // ...
+    ModelFailoverConfig: &adk.ModelFailoverConfig[*schema.Message]{
+        MaxRetries: 2,
+        ShouldFailover: func(ctx context.Context, output *schema.Message, err error) bool {
+            return err != nil // failover on any error
+        },
+        GetFailoverModel: func(ctx context.Context, failoverCtx *adk.FailoverContext[*schema.Message]) (
+            model.BaseModel[*schema.Message], []*schema.Message, error) {
+            // Return a different model and optionally modified input
+            return backupModel, failoverCtx.InputMessages, nil
+        },
+    },
+})
+```
+
+Failover interacts with Retry: when both are configured, `FailoverContext.LastErr` will be a `*RetryExhaustedError` if retry was also exhausted.
+
+# TurnLoop
+
+Push-based event loop for multi-turn agent execution with preemption, idle timeout, and graceful shutdown.
+
+```go
+import "github.com/cloudwego/eino/adk"
+
+loop := adk.NewTurnLoop[string, *schema.Message](&adk.TurnLoopConfig[string, *schema.Message]{
+    GenInput: func(ctx context.Context, turnCtx *adk.TurnContext[string, *schema.Message], items []string) (*adk.GenInputResult[string, *schema.Message], error) {
+        // Convert pushed items into agent input
+        combined := strings.Join(items, "\n")
+        return &adk.GenInputResult[string, *schema.Message]{
+            RunCtx:   ctx,
+            Input:    &adk.TypedAgentInput[*schema.Message]{Messages: []*schema.Message{schema.UserMessage(combined)}},
+            Consumed: items,
+        }, nil
+    },
+    PrepareAgent: func(ctx context.Context) (*adk.TypedChatModelAgent[*schema.Message], []adk.AgentRunOption, error) {
+        return myAgent, nil, nil
+    },
+    OnAgentEvents: func(ctx context.Context, turnCtx *adk.TurnContext[string, *schema.Message], event *adk.AgentEvent) error {
+        // Process events (e.g., send to client)
+        return nil
+    },
+})
+
+// Start the loop
+loop.Run(ctx)
+
+// Push items (non-blocking)
+loop.Push("user message 1")
+
+// Preempt current turn with new input
+loop.Push("urgent message", adk.WithPreempt[string, *schema.Message](adk.AfterChatModel))
+
+// Stop gracefully
+loop.Stop(adk.WithGraceful())
+
+// Wait for exit and get final state
+exitState := loop.Wait()
+```
+
+**Key concepts:**
+- `Push()` queues items; the loop batches and processes them via `GenInput`
+- Preemption: cancel current turn at a safe point and start new turn with pending items
+- Idle timeout: `UntilIdleFor(d)` auto-stops after no items for duration `d`
+- Graceful shutdown: `WithGraceful()`, `WithGracefulTimeout(d)`, `WithImmediate()`
+- Exit state: `TurnLoopExitState` contains `ExitReason`, `UnhandledItems`, `InterruptedItems`
 
 # Runner
 
@@ -101,7 +240,7 @@ runner := adk.NewRunner(ctx, adk.RunnerConfig{
 iter := runner.Query(ctx, "hello")
 
 // Run (full control over input messages)
-iter := runner.Run(ctx, []adk.Message{schema.UserMessage("hello")})
+iter := runner.Run(ctx, []*schema.Message{schema.UserMessage("hello")})
 ```
 
 # Middleware System
@@ -115,7 +254,7 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 })
 ```
 
-Seven built-in middleware types (see reference/middleware.md for details):
+Eight built-in middleware types (see reference/middleware.md for details):
 
 | Middleware | Package | Purpose |
 |-----------|---------|---------|
@@ -126,6 +265,7 @@ Seven built-in middleware types (see reference/middleware.md for details):
 | PlanTask | `adk/middlewares/plantask` | Task creation and progress tracking |
 | Skill | `adk/middlewares/skill` | Skill-based progressive disclosure |
 | PatchToolCalls | `adk/middlewares/patchtoolcalls` | Fix dangling tool calls in history |
+| Agents.md | `adk/middlewares/agentsmd` | Inject Agents.md instructions into model input |
 
 # AgentAsTool
 
@@ -148,7 +288,7 @@ parentAgent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 
 ChatModelAgent supports interrupt and resume for human approval, clarification, and feedback. See reference/human-in-the-loop.md for details.
 
-Key pattern: tool returns `compose.NewInterruptAndRerunErr(info)` to pause, then `runner.ResumeWithParams(ctx, checkpointID, params)` to continue.
+Key pattern: tool returns `compose.Interrupt(ctx, info)` to pause, then `runner.ResumeWithParams(ctx, checkpointID, params)` to continue.
 
 # Instructions to Agent
 
@@ -157,14 +297,18 @@ Key pattern: tool returns `compose.NewInterruptAndRerunErr(info)` to pause, then
 - Middleware order matters: PatchToolCalls first, then Summarization, then Reduction
 - Use `DeepAgent` (`adk/prebuilt/deep`) when you need built-in planning + filesystem + sub-agents
 - Use `AgentAsTool` or DeepAgents' SubAgents when a sub-agent needs isolated context (no shared history)
+- Use `TurnLoop` when building interactive applications that need preemption, idle management, or push-based input
+- `Model` field accepts `model.BaseModel[M]` -- for classic path use any `BaseChatModel`, for agentic path use `AgenticModel`
+- Cancel, Retry, and Failover can all be combined; failover wraps retry
+- `WithCancel()` is a run option, not a config option -- create fresh per-run
 
 ## Reference Files
 
 Read these files on-demand for detailed API, examples, and advanced usage:
 
-- [reference/chat-model-agent.md](reference/chat-model-agent.md) -- ChatModelAgentConfig reference, ReAct pattern, ToolsConfig, streaming example
+- [reference/chat-model-agent.md](reference/chat-model-agent.md) -- ChatModelAgentConfig reference, ReAct pattern, ToolsConfig, streaming, Cancel/Retry/Failover details
 - [reference/deep-agents.md](reference/deep-agents.md) -- DeepAgent concept, config, architecture, comparison with ChatModelAgent
-- [reference/middleware.md](reference/middleware.md) -- All 7 middleware types with interface, config, and examples
+- [reference/middleware.md](reference/middleware.md) -- All 8 middleware types with interface, config, and examples
 - [reference/runner-and-events.md](reference/runner-and-events.md) -- Runner creation, AgentEvent/AgentOutput, event iteration patterns
 - [reference/agent-as-tool.md](reference/agent-as-tool.md) -- Wrapping an Agent as a Tool for use by another agent
 - [reference/human-in-the-loop.md](reference/human-in-the-loop.md) -- Interrupt APIs, ResumableAgent, CheckPointStore, resume patterns

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -7,7 +7,7 @@ description: Eino ADK agent construction, middleware, and runner. Use when a use
 
 Import: `github.com/cloudwego/eino/adk`
 
-The Agent Development Kit (ADK) provides a framework for building agents in Go. The ADK is generically parameterized by `MessageType` to support both classic `*schema.Message` and the new `*schema.AgenticMessage`.
+The Agent Development Kit (ADK) provides a framework for building agents in Go. The ADK is generically parameterized by `MessageType` to support both classic `*schema.Message` and the new `*schema.AgenticMessage`. Prefer `*schema.AgenticMessage` for new usage.
 
 ```go
 type MessageType interface {
@@ -17,7 +17,7 @@ type MessageType interface {
 type TypedAgent[M MessageType] interface {
     Name(ctx context.Context) string
     Description(ctx context.Context) string
-    Run(ctx context.Context, input *TypedAgentInput[M], opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]]
+    Run(ctx context.Context, input *TypedAgentInput[M], options ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]]
 }
 
 // Convenience aliases for classic message type
@@ -105,10 +105,12 @@ Cancel provides safe, controllable termination of agent execution.
 cancelOpt, cancelFn := adk.WithCancel()
 iter := runner.Query(ctx, "do something", cancelOpt)
 
-// Cancel at a safe point (after current model call or tool calls complete)
+// ... iterate events ...
+
+// Cancel at a safe point (cancelFn is non-blocking, Wait blocks until complete)
 handle, ok := cancelFn(adk.WithAgentCancelMode(adk.CancelAfterChatModel))
 if ok {
-    err := handle.Wait() // blocks until cancel completes
+    handle.Wait()
 }
 ```
 

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -183,8 +183,8 @@ Push-based event loop for multi-turn agent execution with preemption, idle timeo
 ```go
 import "github.com/cloudwego/eino/adk"
 
-loop := adk.NewTurnLoop[string, *schema.Message](&adk.TurnLoopConfig[string, *schema.Message]{
-    GenInput: func(ctx context.Context, turnCtx *adk.TurnContext[string, *schema.Message], items []string) (*adk.GenInputResult[string, *schema.Message], error) {
+loop := adk.NewTurnLoop(adk.TurnLoopConfig[string, *schema.Message]{
+    GenInput: func(ctx context.Context, loop *adk.TurnLoop[string, *schema.Message], items []string) (*adk.GenInputResult[string, *schema.Message], error) {
         // Convert pushed items into agent input
         combined := strings.Join(items, "\n")
         return &adk.GenInputResult[string, *schema.Message]{
@@ -193,11 +193,20 @@ loop := adk.NewTurnLoop[string, *schema.Message](&adk.TurnLoopConfig[string, *sc
             Consumed: items,
         }, nil
     },
-    PrepareAgent: func(ctx context.Context) (*adk.TypedChatModelAgent[*schema.Message], []adk.AgentRunOption, error) {
-        return myAgent, nil, nil
+    PrepareAgent: func(ctx context.Context, loop *adk.TurnLoop[string, *schema.Message], consumed []string) (adk.Agent, error) {
+        return myAgent, nil
     },
-    OnAgentEvents: func(ctx context.Context, turnCtx *adk.TurnContext[string, *schema.Message], event *adk.AgentEvent) error {
-        // Process events (e.g., send to client)
+    OnAgentEvents: func(ctx context.Context, tc *adk.TurnContext[string, *schema.Message], events *adk.AsyncIterator[*adk.AgentEvent]) error {
+        for {
+            event, ok := events.Next()
+            if !ok {
+                break
+            }
+            if event.Err != nil {
+                return event.Err
+            }
+            // Process events (e.g., send to client)
+        }
         return nil
     },
 })
@@ -205,7 +214,7 @@ loop := adk.NewTurnLoop[string, *schema.Message](&adk.TurnLoopConfig[string, *sc
 // Start the loop
 loop.Run(ctx)
 
-// Push items (non-blocking)
+// Push items (non-blocking, returns (ok bool, resolved <-chan struct{}))
 loop.Push("user message 1")
 
 // Preempt current turn with new input

--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -140,7 +140,10 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
         MaxRetries: 3,
         ShouldRetry: func(ctx context.Context, retryCtx *adk.RetryContext) *adk.RetryDecision {
             // Retry based on output content (e.g., empty response, bad finish reason)
-            if retryCtx.OutputMessage.Content == "" {
+            if retryCtx.Err != nil {
+                return &adk.RetryDecision{Retry: true, Backoff: time.Second}
+            }
+            if retryCtx.OutputMessage == nil || retryCtx.OutputMessage.Content == "" {
                 return &adk.RetryDecision{Retry: true, Backoff: time.Second}
             }
             return &adk.RetryDecision{Retry: false}

--- a/skills/eino-agent/reference/chat-model-agent.md
+++ b/skills/eino-agent/reference/chat-model-agent.md
@@ -31,10 +31,10 @@ type ChatModelAgentConfig struct {
     Instruction string
 
     // The LLM model. Must support tool calling.
-    Model model.ToolCallingChatModel
+    Model model.BaseModel[M] // model.BaseChatModel or model.AgenticModel
 
     // Tool configuration
-    ToolsConfig ToolsConfig
+    ToolsConfig *ToolsConfig // pointer in v0.9
 
     // Custom function to transform instruction + input into model messages.
     // Optional. Defaults to prepending instruction as system message.
@@ -42,16 +42,19 @@ type ChatModelAgentConfig struct {
 
     // Exit tool. When called, agent terminates immediately.
     // Use the built-in ExitTool: adk.ExitTool{}
-    Exit tool.BaseTool
+    Exit *Exit // Built-in exit tool config
 
     // Max ReAct iterations. Default: 20. Agent errors if exceeded.
     MaxIterations int
 
     // Retry config for ChatModel failures. Optional.
-    ModelRetryConfig *ModelRetryConfig
+    ModelRetryConfig *TypedModelRetryConfig[M]
+
+    // Failover config for model failures. Optional.
+    ModelFailoverConfig *ModelFailoverConfig[M]
 
     // Middleware list
-    Handlers []ChatModelAgentMiddleware
+    Handlers []TypedChatModelAgentMiddleware[M]
 }
 ```
 
@@ -73,8 +76,12 @@ type ToolsConfig struct {
 
 ```go
 type ToolsNodeConfig struct {
-    Tools              []tool.BaseTool
-    ToolCallMiddlewares []compose.ToolCallMiddleware
+    Tools               []tool.BaseTool
+    ToolAliases         map[string]ToolAliasConfig
+    UnknownToolsHandler func(ctx context.Context, name, input string) (string, error)
+    ExecuteSequentially bool
+    ToolArgumentsHandler func(ctx context.Context, name, arguments string) (string, error)
+    ToolCallMiddlewares  []ToolMiddleware
 }
 ```
 
@@ -225,19 +232,144 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 
 ## ModelRetryConfig
 
-Configure automatic retry on model failures:
+See the "ModelRetryConfig (v0.9 Enhanced)" section below for the full retry API with output-based decisions, modified inputs, and backoff control.
+
+When a streaming response will be retried, the stream emits a `WillRetryError` event. Handle it to show retry status to the user:
+
+```go
+if willRetry, ok := err.(*adk.WillRetryError); ok {
+    fmt.Printf("Retrying (attempt %d): %s\n", willRetry.RetryAttempt, willRetry.ErrStr)
+    reason := willRetry.RejectReason() // custom reason from RetryDecision
+}
+```
+
+## ModelRetryConfig (v0.9 Enhanced)
+
+Output-based retry with full decision control:
 
 ```go
 agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     // ...
     ModelRetryConfig: &adk.ModelRetryConfig{
         MaxRetries: 3,
-        // Additional retry policy fields...
+        ShouldRetry: func(ctx context.Context, retryCtx *adk.RetryContext) *adk.RetryDecision {
+            // Access the full output message for decision
+            if retryCtx.Err != nil {
+                return &adk.RetryDecision{Retry: true}
+            }
+            if retryCtx.OutputMessage.Content == "" {
+                return &adk.RetryDecision{
+                    Retry:                 true,
+                    ModifiedInputMessages: append(retryCtx.InputMessages, schema.UserMessage("Please provide a non-empty response")),
+                    PersistModifiedInputMessages: true,
+                    Backoff:               2 * time.Second,
+                }
+            }
+            return &adk.RetryDecision{Retry: false}
+        },
+        BackoffFunc: func(ctx context.Context, attempt int) time.Duration {
+            return time.Duration(attempt) * time.Second // linear backoff
+        },
     },
 })
 ```
 
-When a streaming response fails and will be retried, the stream returns a `WillRetryError`. Handle it to show retry status to the user.
+RetryContext fields:
+- `RetryAttempt int` -- current retry attempt (0-indexed)
+- `InputMessages []M` -- messages sent to the model
+- `OutputMessage M` -- full concatenated response (stream fully consumed for streaming)
+- `Err error` -- error from model call (nil if output-based retry)
+- `Options []model.Option` -- model options used
+
+RetryDecision fields:
+- `Retry bool` -- whether to retry
+- `RewriteError error` -- replace the original error
+- `ModifiedInputMessages []M` -- modified input for retry
+- `PersistModifiedInputMessages bool` -- keep modified input in agent state
+- `AdditionalOptions []model.Option` -- extra model options for retry
+- `Backoff time.Duration` -- wait before retry (overrides BackoffFunc)
+- `RejectReason any` -- attached to WillRetryError for stream consumers
+
+## ModelFailoverConfig
+
+Dynamic model switching when the primary model fails:
+
+```go
+agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
+    // ...
+    ModelFailoverConfig: &adk.ModelFailoverConfig[*schema.Message]{
+        MaxRetries: 2,
+        ShouldFailover: func(ctx context.Context, output *schema.Message, err error) bool {
+            return err != nil
+        },
+        GetFailoverModel: func(ctx context.Context, fCtx *adk.FailoverContext[*schema.Message]) (
+            model.BaseModel[*schema.Message], []*schema.Message, error) {
+            return backupModel, fCtx.InputMessages, nil
+        },
+    },
+})
+```
+
+FailoverContext fields:
+- `FailoverAttempt uint` -- current failover attempt
+- `InputMessages []M` -- original input messages
+- `LastOutputMessage M` -- last model output (may be nil)
+- `LastErr error` -- last error (may be `*RetryExhaustedError` if retry is also configured)
+
+## Cancel
+
+Cancel provides safe, controllable termination during a run:
+
+```go
+cancelOpt, cancelFn := adk.WithCancel()
+iter := runner.Query(ctx, "do something", cancelOpt)
+
+// Later: cancel at safe point
+handle, ok := cancelFn(
+    adk.WithAgentCancelMode(adk.CancelAfterToolCalls),
+    adk.WithAgentCancelTimeout(5*time.Second),
+    adk.WithRecursive(),
+)
+if ok {
+    err := handle.Wait()
+    // err is *CancelError with checkpoint for resume
+}
+```
+
+CancelMode values (bitmask, combinable):
+- `CancelImmediate` (0) -- abort now, stream terminated with StreamCanceledError
+- `CancelAfterChatModel` -- wait for model call to complete
+- `CancelAfterToolCalls` -- wait for tool execution to complete
+
+On cancel, a `CancelError` is delivered via the event stream. It contains `InterruptContexts` for checkpoint-based resumption.
+
+## WithAfterToolCallsHook
+
+Execute a callback after all tool calls in a ReAct iteration complete:
+
+```go
+iter := runner.Query(ctx, "do work",
+    adk.WithAfterToolCallsHook(func(ctx context.Context, tcc *adk.ToolCallsContext) error {
+        for _, tc := range tcc.ToolCalls {
+            fmt.Printf("Tool %s (call %s) completed\n", tc.Name, tc.CallID)
+        }
+        return nil
+    }),
+)
+```
+
+## WithHistoryModifier
+
+Modify message history before it's fed to the model (per-run):
+
+```go
+iter := runner.Query(ctx, "hello",
+    adk.WithHistoryModifier(func(msgs []*schema.Message) []*schema.Message {
+        // Inject additional context, filter messages, etc.
+        return append([]*schema.Message{schema.SystemMessage("Extra context")}, msgs...)
+    }),
+)
+```
 
 ## SessionValues
 

--- a/skills/eino-agent/reference/chat-model-agent.md
+++ b/skills/eino-agent/reference/chat-model-agent.md
@@ -33,16 +33,18 @@ type ChatModelAgentConfig struct {
     // The LLM model. Must support tool calling.
     Model model.BaseModel[M] // model.BaseChatModel or model.AgenticModel
 
-    // Tool configuration
-    ToolsConfig *ToolsConfig // pointer in v0.9
+    // Tool configuration (value type, not pointer)
+    ToolsConfig ToolsConfig
 
     // Custom function to transform instruction + input into model messages.
     // Optional. Defaults to prepending instruction as system message.
     GenModelInput GenModelInput
 
-    // Exit tool. When called, agent terminates immediately.
-    // Use the built-in ExitTool: adk.ExitTool{}
-    Exit *Exit // Built-in exit tool config
+    // NOT RECOMMENDED: Exit tool for agent transfer. Consider AgentTool or DeepAgent instead.
+    Exit tool.BaseTool
+
+    // NOT RECOMMENDED: OutputKey for agent transfer pattern.
+    OutputKey string
 
     // Max ReAct iterations. Default: 20. Agent errors if exceeded.
     MaxIterations int
@@ -53,7 +55,7 @@ type ChatModelAgentConfig struct {
     // Failover config for model failures. Optional.
     ModelFailoverConfig *ModelFailoverConfig[M]
 
-    // Middleware list
+    // Middleware list (replaces deprecated Middlewares field)
     Handlers []TypedChatModelAgentMiddleware[M]
 }
 ```
@@ -284,7 +286,7 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 ```
 
 RetryContext fields:
-- `RetryAttempt int` -- current retry attempt (0-indexed)
+- `RetryAttempt int` -- current retry attempt (1-based: first retry = 1)
 - `InputMessages []M` -- messages sent to the model
 - `OutputMessage M` -- full concatenated response (stream fully consumed for streaming)
 - `Err error` -- error from model call (nil if output-based retry)

--- a/skills/eino-agent/reference/chat-model-agent.md
+++ b/skills/eino-agent/reference/chat-model-agent.md
@@ -234,12 +234,19 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
 
 See the "ModelRetryConfig (v0.9 Enhanced)" section below for the full retry API with output-based decisions, modified inputs, and backoff control.
 
-When a streaming response will be retried, the stream emits a `WillRetryError` event. Handle it to show retry status to the user:
+When a streaming response will be retried, the stream emits a `WillRetryError` via `Recv()`. Handle it to show retry status to the user:
 
 ```go
-if willRetry, ok := err.(*adk.WillRetryError); ok {
-    fmt.Printf("Retrying (attempt %d): %s\n", willRetry.RetryAttempt, willRetry.ErrStr)
-    reason := willRetry.RejectReason() // custom reason from RetryDecision
+// WillRetryError is returned by stream.Recv() when an attempt is rejected and will be retried.
+// The stream continues after this error — call Recv() again to get the next attempt's chunks.
+chunk, err := stream.Recv()
+if err != nil {
+    var willRetry *adk.WillRetryError
+    if errors.As(err, &willRetry) {
+        fmt.Printf("Retrying (attempt %d): %s\n", willRetry.RetryAttempt, willRetry.ErrStr)
+        reason := willRetry.RejectReason() // custom reason from RetryDecision
+        continue // next Recv() will return chunks from the retry attempt
+    }
 }
 ```
 
@@ -267,6 +274,8 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
             }
             return &adk.RetryDecision{Retry: false}
         },
+        // BackoffFunc provides the default delay between retries.
+        // ShouldRetry can override this per-attempt via RetryDecision.Backoff (non-zero takes precedence).
         BackoffFunc: func(ctx context.Context, attempt int) time.Duration {
             return time.Duration(attempt) * time.Second // linear backoff
         },
@@ -345,28 +354,16 @@ On cancel, a `CancelError` is delivered via the event stream. It contains `Inter
 
 ## WithAfterToolCallsHook
 
-Execute a callback after all tool calls in a ReAct iteration complete:
+Execute a callback after all tool calls in a ReAct iteration complete, before the next ChatModel call:
 
 ```go
 iter := runner.Query(ctx, "do work",
-    adk.WithAfterToolCallsHook(func(ctx context.Context, tcc *adk.ToolCallsContext) error {
-        for _, tc := range tcc.ToolCalls {
-            fmt.Printf("Tool %s (call %s) completed\n", tc.Name, tc.CallID)
-        }
+    adk.WithAfterToolCallsHook(func(ctx context.Context) error {
+        // Fires after tool execution finishes, before the next model call.
+        // Useful for TurnLoop Push+Preempt patterns where pushed items
+        // must be visible to the next turn's GenInput.
+        fmt.Println("All tool calls completed")
         return nil
-    }),
-)
-```
-
-## WithHistoryModifier
-
-Modify message history before it's fed to the model (per-run):
-
-```go
-iter := runner.Query(ctx, "hello",
-    adk.WithHistoryModifier(func(msgs []*schema.Message) []*schema.Message {
-        // Inject additional context, filter messages, etc.
-        return append([]*schema.Message{schema.SystemMessage("Extra context")}, msgs...)
     }),
 )
 ```

--- a/skills/eino-agent/reference/chat-model-agent.md
+++ b/skills/eino-agent/reference/chat-model-agent.md
@@ -40,12 +40,6 @@ type TypedChatModelAgentConfig[M MessageType] struct {
     // Optional. Defaults to prepending instruction as system message.
     GenModelInput TypedGenModelInput[M]
 
-    // NOT RECOMMENDED: Exit tool for agent transfer. Consider AgentTool or DeepAgent instead.
-    Exit tool.BaseTool
-
-    // NOT RECOMMENDED: OutputKey for agent transfer pattern.
-    OutputKey string
-
     // Max ReAct iterations. Default: 20. Agent errors if exceeded.
     MaxIterations int
 
@@ -312,12 +306,12 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     // ...
     ModelFailoverConfig: &adk.ModelFailoverConfig[*schema.Message]{
         MaxRetries: 2,
-        ShouldFailover: func(ctx context.Context, output *schema.Message, err error) bool {
-            return err != nil
+        ShouldFailover: func(ctx context.Context, outputMessage *schema.Message, outputErr error) bool {
+            return outputErr != nil
         },
-        GetFailoverModel: func(ctx context.Context, fCtx *adk.FailoverContext[*schema.Message]) (
+        GetFailoverModel: func(ctx context.Context, failoverCtx *adk.FailoverContext[*schema.Message]) (
             model.BaseModel[*schema.Message], []*schema.Message, error) {
-            return backupModel, fCtx.InputMessages, nil
+            return backupModel, failoverCtx.InputMessages, nil
         },
     },
 })

--- a/skills/eino-agent/reference/chat-model-agent.md
+++ b/skills/eino-agent/reference/chat-model-agent.md
@@ -19,7 +19,7 @@ When no tools are configured, ChatModelAgent degrades to a single ChatModel call
 ## ChatModelAgentConfig
 
 ```go
-type ChatModelAgentConfig struct {
+type TypedChatModelAgentConfig[M MessageType] struct {
     // Name of the agent. Should be unique across all agents.
     Name string
 
@@ -38,7 +38,7 @@ type ChatModelAgentConfig struct {
 
     // Custom function to transform instruction + input into model messages.
     // Optional. Defaults to prepending instruction as system message.
-    GenModelInput GenModelInput
+    GenModelInput TypedGenModelInput[M]
 
     // NOT RECOMMENDED: Exit tool for agent transfer. Consider AgentTool or DeepAgent instead.
     Exit tool.BaseTool
@@ -58,6 +58,8 @@ type ChatModelAgentConfig struct {
     // Middleware list (replaces deprecated Middlewares field)
     Handlers []TypedChatModelAgentMiddleware[M]
 }
+
+type ChatModelAgentConfig = TypedChatModelAgentConfig[*schema.Message]
 ```
 
 ## ToolsConfig
@@ -266,7 +268,7 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
             if retryCtx.Err != nil {
                 return &adk.RetryDecision{Retry: true}
             }
-            if retryCtx.OutputMessage.Content == "" {
+            if retryCtx.OutputMessage == nil || retryCtx.OutputMessage.Content == "" {
                 return &adk.RetryDecision{
                     Retry:                 true,
                     ModifiedInputMessages: append(retryCtx.InputMessages, schema.UserMessage("Please provide a non-empty response")),

--- a/skills/eino-agent/reference/deep-agents.md
+++ b/skills/eino-agent/reference/deep-agents.md
@@ -85,9 +85,6 @@ type TypedConfig[M adk.MessageType] struct {
     // Optional: custom TaskTool description generator.
     TaskToolDescriptionGenerator func(ctx context.Context, availableAgents []adk.TypedAgent[M]) (string, error)
 
-    // Optional: struct-based middleware (deprecated style).
-    Middlewares []adk.AgentMiddleware
-
     // Optional: interface-based middleware (recommended).
     Handlers []adk.TypedChatModelAgentMiddleware[M]
 
@@ -95,8 +92,6 @@ type TypedConfig[M adk.MessageType] struct {
     ModelRetryConfig *adk.TypedModelRetryConfig[M]
     // Optional: model failover configuration.
     ModelFailoverConfig *adk.ModelFailoverConfig[M]
-    // Optional: store agent output in session values.
-    OutputKey string
 }
 
 type Config = TypedConfig[*schema.Message]

--- a/skills/eino-agent/reference/deep-agents.md
+++ b/skills/eino-agent/reference/deep-agents.md
@@ -44,58 +44,62 @@ MainAgent (ChatModelAgent + built-in tools + prompt)
 ## Configuration
 
 ```go
-type Config struct {
+type TypedConfig[M adk.MessageType] struct {
     // Name is the identifier for the Deep agent.
     Name string
     // Description provides a brief explanation of the agent's purpose.
     Description string
 
-    // Required: the LLM model (must support model.WithTools call option if tools are used)
-    ChatModel model.BaseChatModel
+    // Required: the LLM model.
+    // If tools are used, it must support the model.WithTools call option.
+    ChatModel model.BaseModel[M]
 
-    // Optional: tools and tool-calling configuration
+    // Optional: tools and tool-calling configuration.
     ToolsConfig adk.ToolsConfig
 
-    // Optional: filesystem backend for file operations
+    // Optional: filesystem backend for file operations.
     Backend filesystem.Backend
 
-    // Optional: shell execution (mutually exclusive with StreamingShell)
+    // Optional: shell execution (mutually exclusive with StreamingShell).
     Shell filesystem.Shell
 
-    // Optional: streaming shell execution
+    // Optional: streaming shell execution.
     StreamingShell filesystem.StreamingShell
 
-    // Optional: custom sub-agents
-    SubAgents []adk.Agent
+    // Optional: custom sub-agents.
+    // M = *schema.Message accepts standard agents; M = *schema.AgenticMessage accepts agentic agents.
+    SubAgents []adk.TypedAgent[M]
 
-    // Optional: custom system prompt (replaces built-in prompt when non-empty)
+    // Optional: custom system prompt (replaces built-in prompt when non-empty).
     Instruction string
 
-    // Optional: max reasoning iterations
+    // Optional: max reasoning iterations.
     MaxIteration int
 
-    // Optional: disable WriteTodos tool
+    // Optional: disable WriteTodos tool.
     WithoutWriteTodos bool
 
-    // Optional: disable the default general-purpose sub-agent
+    // Optional: disable the default general-purpose sub-agent.
     WithoutGeneralSubAgent bool
 
-    // Optional: custom TaskTool description generator
-    TaskToolDescriptionGenerator func(ctx context.Context, agents []adk.Agent) (string, error)
+    // Optional: custom TaskTool description generator.
+    TaskToolDescriptionGenerator func(ctx context.Context, availableAgents []adk.TypedAgent[M]) (string, error)
 
-    // Optional: struct-based middleware (deprecated style)
+    // Optional: struct-based middleware (deprecated style).
     Middlewares []adk.AgentMiddleware
 
-    // Optional: interface-based middleware (recommended)
-    Handlers []adk.ChatModelAgentMiddleware
+    // Optional: interface-based middleware (recommended).
+    Handlers []adk.TypedChatModelAgentMiddleware[M]
 
-    // Optional: model retry configuration
-    ModelRetryConfig *adk.TypedModelRetryConfig[*schema.Message]
-    // Optional: model failover configuration
-    ModelFailoverConfig *adk.ModelFailoverConfig[*schema.Message]
-    // Optional: store agent output in session values
+    // Optional: model retry configuration.
+    ModelRetryConfig *adk.TypedModelRetryConfig[M]
+    // Optional: model failover configuration.
+    ModelFailoverConfig *adk.ModelFailoverConfig[M]
+    // Optional: store agent output in session values.
     OutputKey string
 }
+
+type Config = TypedConfig[*schema.Message]
 ```
 
 ## Quick Start

--- a/skills/eino-agent/reference/deep-agents.md
+++ b/skills/eino-agent/reference/deep-agents.md
@@ -45,8 +45,16 @@ MainAgent (ChatModelAgent + built-in tools + prompt)
 
 ```go
 type Config struct {
-    // Required: the LLM model
-    Model model.ToolCallingChatModel
+    // Name is the identifier for the Deep agent.
+    Name string
+    // Description provides a brief explanation of the agent's purpose.
+    Description string
+
+    // Required: the LLM model (must support model.WithTools call option if tools are used)
+    ChatModel model.BaseChatModel
+
+    // Optional: tools and tool-calling configuration
+    ToolsConfig adk.ToolsConfig
 
     // Optional: filesystem backend for file operations
     Backend filesystem.Backend
@@ -57,14 +65,14 @@ type Config struct {
     // Optional: streaming shell execution
     StreamingShell filesystem.StreamingShell
 
-    // Optional: custom tools added to the main agent
-    Tools []tool.BaseTool
-
     // Optional: custom sub-agents
     SubAgents []adk.Agent
 
-    // Optional: custom system prompt (appended to built-in prompt)
+    // Optional: custom system prompt (replaces built-in prompt when non-empty)
     Instruction string
+
+    // Optional: max reasoning iterations
+    MaxIteration int
 
     // Optional: disable WriteTodos tool
     WithoutWriteTodos bool
@@ -73,10 +81,20 @@ type Config struct {
     WithoutGeneralSubAgent bool
 
     // Optional: custom TaskTool description generator
-    TaskToolDescriptionGenerator func(ctx context.Context, agents []adk.Agent) string
+    TaskToolDescriptionGenerator func(ctx context.Context, agents []adk.Agent) (string, error)
 
-    // Optional: middleware
+    // Optional: struct-based middleware (deprecated style)
+    Middlewares []adk.AgentMiddleware
+
+    // Optional: interface-based middleware (recommended)
     Handlers []adk.ChatModelAgentMiddleware
+
+    // Optional: model retry configuration
+    ModelRetryConfig *adk.TypedModelRetryConfig[*schema.Message]
+    // Optional: model failover configuration
+    ModelFailoverConfig *adk.ModelFailoverConfig[*schema.Message]
+    // Optional: store agent output in session values
+    OutputKey string
 }
 ```
 
@@ -104,8 +122,8 @@ func main() {
     backend := filesystem.NewInMemoryBackend()
 
     agent, err := deep.New(ctx, &deep.Config{
-        Model:   cm,
-        Backend: backend,
+        ChatModel: cm,
+        Backend:   backend,
     })
     if err != nil {
         log.Fatal(err)

--- a/skills/eino-agent/reference/filesystem.md
+++ b/skills/eino-agent/reference/filesystem.md
@@ -71,8 +71,8 @@ backend, _ := local.NewBackend(ctx, &local.Config{
 })
 
 agent, _ := deep.New(ctx, &deep.Config{
-    Model:   chatModel,
-    Backend: backend,
+    ChatModel: chatModel,
+    Backend:   backend,
 })
 ```
 

--- a/skills/eino-agent/reference/human-in-the-loop.md
+++ b/skills/eino-agent/reference/human-in-the-loop.md
@@ -197,10 +197,12 @@ iter, err := runner.Resume(ctx, checkpointID,
 Agents that support interrupt/resume must implement:
 
 ```go
-type ResumableAgent interface {
-    Agent
-    Resume(ctx context.Context, info *ResumeInfo, opts ...AgentRunOption) *AsyncIterator[*AgentEvent]
+type TypedResumableAgent[M MessageType] interface {
+    TypedAgent[M]
+    Resume(ctx context.Context, info *ResumeInfo, opts ...AgentRunOption) *AsyncIterator[*TypedAgentEvent[M]]
 }
+
+type ResumableAgent = TypedResumableAgent[*schema.Message]
 
 type ResumeInfo struct {
     WasInterrupted bool   // Always true when Resume is called

--- a/skills/eino-agent/reference/human-in-the-loop.md
+++ b/skills/eino-agent/reference/human-in-the-loop.md
@@ -12,8 +12,6 @@ Human-in-the-loop (HITL) enables agents to pause execution, request human input,
 
 ```go
 import (
-    "github.com/cloudwego/eino/adk"
-    "github.com/cloudwego/eino/components/tool"
     "github.com/cloudwego/eino/components/tool/utils"
     "github.com/cloudwego/eino/compose"
 )
@@ -23,13 +21,21 @@ type bookInput struct {
     PassengerName string `json:"passenger_name"`
 }
 
+// Tool that interrupts for approval before executing
 bookTool, _ := utils.InferTool("BookTicket", "Book a ticket",
     func(ctx context.Context, input *bookInput) (string, error) {
-        return "success", nil
-    })
+        // Check if this is a resume after approval
+        if isResume, hasData, data := compose.GetResumeContext[bool](ctx); isResume && hasData {
+            if data {
+                // User approved, execute the action
+                return fmt.Sprintf("Booked ticket to %s for %s", input.Location, input.PassengerName), nil
+            }
+            return "Booking rejected by user", nil
+        }
 
-// Wrap with approval -- interrupts before execution
-approvalTool := &tool.InvokableApprovableTool{InvokableTool: bookTool}
+        // First run: interrupt for approval
+        return "", compose.Interrupt(ctx, fmt.Sprintf("Approve booking to %s for %s?", input.Location, input.PassengerName))
+    })
 ```
 
 ### 2. Create agent and runner with CheckPointStore
@@ -41,7 +47,7 @@ agent, _ := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{
     Model:       cm,
     ToolsConfig: adk.ToolsConfig{
         ToolsNodeConfig: compose.ToolsNodeConfig{
-            Tools: []tool.BaseTool{approvalTool},
+            Tools: []tool.BaseTool{bookTool},
         },
     },
 })
@@ -80,12 +86,10 @@ for {
 ### 4. Resume with user decision
 
 ```go
-// User approves
-apResult := &tool.ApprovalResult{Approved: true}
-
+// User approves: pass true as resume data
 iter, err := runner.ResumeWithParams(ctx, "session-1", &adk.ResumeParams{
     Targets: map[string]any{
-        interruptID: apResult,
+        interruptID: true,  // matches compose.GetResumeContext[bool]
     },
 })
 if err != nil {
@@ -108,22 +112,37 @@ for {
 
 ```go
 // In a custom agent's Run method:
-return adk.Interrupt(ctx, "Please clarify your request.")
+iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+go func() {
+    defer gen.Close()
+    gen.Send(adk.Interrupt(ctx, "Please clarify your request."))
+}()
+return iter
 ```
 
 ### Stateful Interrupt
 
 ```go
-// Save internal state for later restoration
+// In a custom agent's Run method:
 state := &MyState{ProcessedItems: 42}
-return adk.StatefulInterrupt(ctx, "Need user feedback", state)
+iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+go func() {
+    defer gen.Close()
+    gen.Send(adk.StatefulInterrupt(ctx, "Need user feedback", state))
+}()
+return iter
 ```
 
 ### Composite Interrupt (for multi-agent)
 
 ```go
-// When a parent agent's sub-agent interrupts
-return adk.CompositeInterrupt(ctx, "Sub-agent needs attention", parentState, subInterruptSignals...)
+// In a custom agent's Run method (multi-agent):
+iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+go func() {
+    defer gen.Close()
+    gen.Send(adk.CompositeInterrupt(ctx, "Sub-agent needs attention", parentState, subInterruptSignals...))
+}()
+return iter
 ```
 
 ## Interrupt APIs (Compose Layer -- for tools/graph nodes)

--- a/skills/eino-agent/reference/middleware.md
+++ b/skills/eino-agent/reference/middleware.md
@@ -112,7 +112,7 @@ import "github.com/cloudwego/eino/adk/middlewares/reduction"
 mw, err := reduction.New(ctx, &reduction.Config{
     Backend:           myBackend,     // Required: storage for offloaded content
     MaxLengthForTrunc: 50000,         // Default: 50000 chars
-    MaxTokensForClear: 128000,        // 128000 tokens
+    MaxTokensForClear: 160000,        // Default: 160000 tokens
     SkipTruncation:    false,         // Set true to skip truncation
     SkipClear:         false,         // Set true to skip clearing
 })
@@ -132,12 +132,12 @@ import "github.com/cloudwego/eino/adk/middlewares/summarization"
 mw, err := summarization.New(ctx, &summarization.Config{
     Model: summarizationModel,  // Required: model used to generate summaries
     Trigger: &summarization.TriggerCondition{
-        ContextTokens: 190000,  // Default: 190000
+        ContextTokens: 160000,  // Default: 160000
     },
     TranscriptFilePath: "/path/to/transcript.txt",  // Optional: save full transcript
     PreserveUserMessages: &summarization.PreserveUserMessages{
-        Enabled:   true,       // Default: true
-        MaxTokens: 50000,      // Keep recent user messages up to this limit
+        Enabled:   true,       // Default: true (when nil)
+        MaxTokens: 30000,      // Default: 30000. Keep recent user messages up to this limit
     },
 })
 ```
@@ -252,7 +252,8 @@ Injects Agents.md file contents into model input as transient context. The injec
 import "github.com/cloudwego/eino/adk/middlewares/agentsmd"
 
 mw, err := agentsmd.New(ctx, &agentsmd.Config{
-    Loader: myLoader,  // Required: loads Agents.md content
+    Backend:       myBackend,                        // Required: file access backend
+    AgentsMDFiles: []string{"/path/to/Agents.md"},   // Ordered list of files to load
 })
 ```
 

--- a/skills/eino-agent/reference/middleware.md
+++ b/skills/eino-agent/reference/middleware.md
@@ -3,14 +3,20 @@ ChatModelAgentMiddleware extends ChatModelAgent behavior at various execution st
 ## Interface
 
 ```go
-type ChatModelAgentMiddleware interface {
+type TypedChatModelAgentMiddleware[M MessageType] interface {
     BeforeAgent(ctx context.Context, runCtx *ChatModelAgentContext) (context.Context, *ChatModelAgentContext, error)
-    BeforeModelRewriteState(ctx context.Context, state *ChatModelAgentState, mc *ModelContext) (context.Context, *ChatModelAgentState, error)
-    AfterModelRewriteState(ctx context.Context, state *ChatModelAgentState, mc *ModelContext) (context.Context, *ChatModelAgentState, error)
+    AfterAgent(ctx context.Context, state *TypedChatModelAgentState[M]) (context.Context, error)
+    BeforeModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error)
+    AfterModelRewriteState(ctx context.Context, state *TypedChatModelAgentState[M], mc *TypedModelContext[M]) (context.Context, *TypedChatModelAgentState[M], error)
     WrapInvokableToolCall(ctx context.Context, endpoint InvokableToolCallEndpoint, tCtx *ToolContext) (InvokableToolCallEndpoint, error)
     WrapStreamableToolCall(ctx context.Context, endpoint StreamableToolCallEndpoint, tCtx *ToolContext) (StreamableToolCallEndpoint, error)
-    WrapModel(ctx context.Context, m model.BaseChatModel, mc *ModelContext) (model.BaseChatModel, error)
+    WrapEnhancedInvokableToolCall(ctx context.Context, endpoint EnhancedInvokableToolCallEndpoint, tCtx *ToolContext) (EnhancedInvokableToolCallEndpoint, error)
+    WrapEnhancedStreamableToolCall(ctx context.Context, endpoint EnhancedStreamableToolCallEndpoint, tCtx *ToolContext) (EnhancedStreamableToolCallEndpoint, error)
+    WrapModel(ctx context.Context, m model.BaseModel[M], mc *TypedModelContext[M]) (model.BaseModel[M], error)
 }
+
+// Convenience alias for classic message path
+type ChatModelAgentMiddleware = TypedChatModelAgentMiddleware[*schema.Message]
 ```
 
 Embed `*adk.BaseChatModelAgentMiddleware` to get default no-op implementations and only override what you need.
@@ -30,6 +36,7 @@ Agent.Run(input)
             -> Tool.Run()
             -> Results added to messages
        -> Continue loop
+  -> AfterAgent (once per run: cleanup, final state processing)
   -> Agent.Run() ends
 ```
 
@@ -235,16 +242,69 @@ Place this middleware first in the chain to ensure clean message history for oth
 
 ---
 
+## Agents.md Middleware
+
+Package: `github.com/cloudwego/eino/adk/middlewares/agentsmd`
+
+Injects Agents.md file contents into model input as transient context. The injected content is excluded from summarization to avoid polluting compressed history.
+
+```go
+import "github.com/cloudwego/eino/adk/middlewares/agentsmd"
+
+mw, err := agentsmd.New(ctx, &agentsmd.Config{
+    Loader: myLoader,  // Required: loads Agents.md content
+})
+```
+
+Use this middleware when you want to provide persistent reference documentation to the agent without it being summarized away. The content is re-injected fresh on each model call.
+
+---
+
+## Run-Local State
+
+Middleware can persist key-value state that survives interrupt/resume cycles:
+
+```go
+// Inside any middleware method
+adk.SetRunLocalValue(ctx, "myKey", myValue)
+
+// Read later (even after resume)
+val, ok, err := adk.GetRunLocalValue(ctx, "myKey")
+
+// Delete
+adk.DeleteRunLocalValue(ctx, "myKey")
+```
+
+Values must be gob-serializable. Register custom types in `init()`.
+
+---
+
+## Event Emission from Middleware
+
+Middleware can emit custom events to the agent's event stream:
+
+```go
+adk.SendEvent(ctx, &adk.AgentEvent{
+    AgentName: "MyAgent",
+    Output: &adk.AgentOutput{
+        CustomizedOutput: myData,
+    },
+})
+```
+
+---
+
 ## Recommended Middleware Order
 
 ```go
 Handlers: []adk.ChatModelAgentMiddleware{
     patchToolCallsMW,    // 1. Fix message history first
-    summarizationMW,     // 2. Compress if needed
-    reductionMW,         // 3. Handle large tool results
-    filesystemMW,        // 4. Add file tools
-    skillMW,             // 5. Add skill discovery
-    planTaskMW,          // 6. Add task management
+    agentsMdMW,          // 2. Inject reference docs
+    summarizationMW,     // 3. Compress if needed
+    reductionMW,         // 4. Handle large tool results
+    filesystemMW,        // 5. Add file tools
+    skillMW,             // 6. Add skill discovery
+    planTaskMW,          // 7. Add task management
 }
 ```
 

--- a/skills/eino-agent/reference/middleware.md
+++ b/skills/eino-agent/reference/middleware.md
@@ -214,8 +214,8 @@ skills/
 
 Context modes in SKILL.md frontmatter:
 - (empty) -- inline: skill content returned as tool result
-- `fork` -- new agent with copied history
-- `isolate` -- new agent with isolated context
+- `fork` -- new agent with clean context, discarding parent message history
+- `fork_with_context` -- new agent carrying over parent message history
 
 ---
 

--- a/skills/eino-agent/reference/runner-and-events.md
+++ b/skills/eino-agent/reference/runner-and-events.md
@@ -47,7 +47,6 @@ Every event from `AsyncIterator` is an `AgentEvent`:
 ```go
 type TypedAgentEvent[M MessageType] struct {
     AgentName string                // Which agent produced this event
-    RunPath   []RunStep             // Full call chain from entry agent to current
     Output    *TypedAgentOutput[M]  // Message output (may be nil)
     Action    *AgentAction          // Control action (may be nil)
     Err       error                 // Error (may be nil; may be *CancelError or *RetryExhaustedError)
@@ -105,7 +104,6 @@ msg, err := mv.GetMessage()
 type AgentAction struct {
     Exit             bool                  // Immediately exit the multi-agent system
     Interrupted      *InterruptInfo        // Pause execution, save checkpoint
-    TransferToAgent  *TransferToAgentAction // Transfer control to another agent
     BreakLoop        *BreakLoopAction      // Break out of a LoopAgent
     CustomizedAction any                   // Custom action
 }
@@ -130,10 +128,6 @@ for {
     if event.Action != nil {
         if event.Action.Interrupted != nil {
             fmt.Printf("Interrupted: %v\n", event.Action.Interrupted)
-            continue
-        }
-        if event.Action.TransferToAgent != nil {
-            fmt.Printf("Transfer to: %s\n", event.Action.TransferToAgent.DestAgentName)
             continue
         }
     }

--- a/skills/eino-agent/reference/runner-and-events.md
+++ b/skills/eino-agent/reference/runner-and-events.md
@@ -103,11 +103,11 @@ msg, err := mv.GetMessage()
 
 ```go
 type AgentAction struct {
-    Exit             bool              // Immediately exit the multi-agent system
-    Interrupted      *InterruptInfo    // Pause execution, save checkpoint
-    TransferToAgent  string            // Transfer control to another agent (agent name)
-    BreakLoop        *BreakLoopAction  // Break out of a LoopAgent
-    CustomizedAction any               // Custom action
+    Exit             bool                  // Immediately exit the multi-agent system
+    Interrupted      *InterruptInfo        // Pause execution, save checkpoint
+    TransferToAgent  *TransferToAgentAction // Transfer control to another agent
+    BreakLoop        *BreakLoopAction      // Break out of a LoopAgent
+    CustomizedAction any                   // Custom action
 }
 ```
 
@@ -132,8 +132,8 @@ for {
             fmt.Printf("Interrupted: %v\n", event.Action.Interrupted)
             continue
         }
-        if event.Action.TransferToAgent != "" {
-            fmt.Printf("Transfer to: %s\n", event.Action.TransferToAgent)
+        if event.Action.TransferToAgent != nil {
+            fmt.Printf("Transfer to: %s\n", event.Action.TransferToAgent.DestAgentName)
             continue
         }
     }

--- a/skills/eino-agent/reference/runner-and-events.md
+++ b/skills/eino-agent/reference/runner-and-events.md
@@ -47,7 +47,7 @@ Every event from `AsyncIterator` is an `AgentEvent`:
 ```go
 type TypedAgentEvent[M MessageType] struct {
     AgentName string                // Which agent produced this event
-    RunPath   []string              // Full call chain from entry agent to current
+    RunPath   []RunStep             // Full call chain from entry agent to current
     Output    *TypedAgentOutput[M]  // Message output (may be nil)
     Action    *AgentAction          // Control action (may be nil)
     Err       error                 // Error (may be nil; may be *CancelError or *RetryExhaustedError)

--- a/skills/eino-agent/reference/runner-and-events.md
+++ b/skills/eino-agent/reference/runner-and-events.md
@@ -233,10 +233,10 @@ func (ai *AsyncIterator[T]) Next() (T, bool)
 ```go
 type MyAgent struct{}
 
-func (a *MyAgent) Name() string        { return "MyAgent" }
-func (a *MyAgent) Description() string { return "My custom agent" }
+func (a *MyAgent) Name(ctx context.Context) string        { return "MyAgent" }
+func (a *MyAgent) Description(ctx context.Context) string { return "My custom agent" }
 
-func (a *MyAgent) Run(ctx context.Context, input *adk.AgentInput) *adk.AsyncIterator[*adk.AgentEvent] {
+func (a *MyAgent) Run(ctx context.Context, input *adk.AgentInput, opts ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
     iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
     go func() {
         defer gen.Close()

--- a/skills/eino-agent/reference/runner-and-events.md
+++ b/skills/eino-agent/reference/runner-and-events.md
@@ -29,11 +29,12 @@ iter := runner.Run(ctx, []adk.Message{
 ## AgentInput
 
 ```go
-type AgentInput struct {
-    Messages       []Message  // Conversation messages (user, assistant, tool, system)
-    EnableStreaming bool       // Suggest streaming mode for capable components
+type TypedAgentInput[M MessageType] struct {
+    Messages       []M   // Conversation messages
+    EnableStreaming bool  // Suggest streaming mode for capable components
 }
 
+type AgentInput = TypedAgentInput[*schema.Message]
 type Message = *schema.Message
 ```
 
@@ -44,13 +45,15 @@ type Message = *schema.Message
 Every event from `AsyncIterator` is an `AgentEvent`:
 
 ```go
-type AgentEvent struct {
-    AgentName string         // Which agent produced this event
-    RunPath   []RunStep      // Full call chain from entry agent to current
-    Output    *AgentOutput   // Message output (may be nil)
-    Action    *AgentAction   // Control action (may be nil)
-    Err       error          // Error (may be nil)
+type TypedAgentEvent[M MessageType] struct {
+    AgentName string                // Which agent produced this event
+    RunPath   []string              // Full call chain from entry agent to current
+    Output    *TypedAgentOutput[M]  // Message output (may be nil)
+    Action    *AgentAction          // Control action (may be nil)
+    Err       error                 // Error (may be nil; may be *CancelError or *RetryExhaustedError)
 }
+
+type AgentEvent = TypedAgentEvent[*schema.Message]
 ```
 
 ### AgentOutput
@@ -100,11 +103,11 @@ msg, err := mv.GetMessage()
 
 ```go
 type AgentAction struct {
-    Exit            bool                    // Immediately exit the multi-agent system
-    Interrupted     *InterruptInfo          // Pause execution, save checkpoint
-    TransferToAgent *TransferToAgentAction  // Transfer control to another agent
-    BreakLoop       *BreakLoopAction        // Break out of a LoopAgent
-    CustomizedAction any                    // Custom action
+    Exit             bool              // Immediately exit the multi-agent system
+    Interrupted      *InterruptInfo    // Pause execution, save checkpoint
+    TransferToAgent  string            // Transfer control to another agent (agent name)
+    BreakLoop        *BreakLoopAction  // Break out of a LoopAgent
+    CustomizedAction any               // Custom action
 }
 ```
 
@@ -129,8 +132,8 @@ for {
             fmt.Printf("Interrupted: %v\n", event.Action.Interrupted)
             continue
         }
-        if event.Action.TransferToAgent != nil {
-            fmt.Printf("Transfer to: %s\n", event.Action.TransferToAgent.DestAgentName)
+        if event.Action.TransferToAgent != "" {
+            fmt.Printf("Transfer to: %s\n", event.Action.TransferToAgent)
             continue
         }
     }
@@ -143,6 +146,38 @@ for {
         }
         fmt.Printf("[%s][%s] %s\n", event.AgentName, event.Output.MessageOutput.Role, msg.Content)
     }
+}
+```
+
+## Cancel-Aware Event Handling
+
+When using `WithCancel()`, the event stream may deliver a `CancelError`:
+
+```go
+cancelOpt, cancelFn := adk.WithCancel()
+iter := runner.Query(ctx, "do work", cancelOpt)
+
+// In another goroutine: trigger cancel
+go func() {
+    time.Sleep(5 * time.Second)
+    handle, _ := cancelFn(adk.WithAgentCancelMode(adk.CancelAfterChatModel))
+    handle.Wait()
+}()
+
+for {
+    event, ok := iter.Next()
+    if !ok {
+        break
+    }
+    if event.Err != nil {
+        if cancelErr, ok := event.Err.(*adk.CancelError); ok {
+            fmt.Printf("Cancelled (mode=%v)\n", cancelErr.Info.Mode)
+            // cancelErr.InterruptContexts can be used for resume
+            break
+        }
+        log.Fatal(event.Err)
+    }
+    // Handle normal events...
 }
 ```
 
@@ -198,10 +233,10 @@ func (ai *AsyncIterator[T]) Next() (T, bool)
 ```go
 type MyAgent struct{}
 
-func (a *MyAgent) Name(ctx context.Context) string        { return "MyAgent" }
-func (a *MyAgent) Description(ctx context.Context) string  { return "My custom agent" }
+func (a *MyAgent) Name() string        { return "MyAgent" }
+func (a *MyAgent) Description() string { return "My custom agent" }
 
-func (a *MyAgent) Run(ctx context.Context, input *adk.AgentInput, opts ...adk.AgentRunOption) *adk.AsyncIterator[*adk.AgentEvent] {
+func (a *MyAgent) Run(ctx context.Context, input *adk.AgentInput) *adk.AsyncIterator[*adk.AgentEvent] {
     iter, gen := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
     go func() {
         defer gen.Close()
@@ -211,6 +246,36 @@ func (a *MyAgent) Run(ctx context.Context, input *adk.AgentInput, opts ...adk.Ag
         ))
     }()
     return iter
+}
+```
+
+## Typed Runner (AgenticMessage)
+
+For the agentic path using `*schema.AgenticMessage`:
+
+```go
+runner := adk.NewTypedRunner(adk.TypedRunnerConfig[*schema.AgenticMessage]{
+    Agent:          myAgenticAgent,
+    EnableStreaming: true,
+})
+
+iter := runner.Run(ctx, []*schema.AgenticMessage{
+    schema.UserAgenticMessage("hello"),
+})
+for {
+    event, ok := iter.Next()
+    if !ok {
+        break
+    }
+    // event is *TypedAgentEvent[*schema.AgenticMessage]
+    if event.Output != nil && event.Output.MessageOutput != nil {
+        msg, _ := event.Output.MessageOutput.GetMessage()
+        for _, block := range msg.ContentBlocks {
+            if block.Type == schema.ContentBlockTypeAssistantGenText {
+                fmt.Print(block.AssistantGenText.Text)
+            }
+        }
+    }
 }
 ```
 

--- a/skills/eino-component/SKILL.md
+++ b/skills/eino-component/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: eino-component
-description: Eino component selection, configuration, and usage. Use when a user needs to choose or configure a ChatModel, Embedding, Retriever, Indexer, Tool, Document loader/parser/transformer, Prompt template, or Callback handler. Covers all component interfaces and their implementations in eino-ext including OpenAI, Claude, Gemini, Ollama, Milvus, Elasticsearch, Redis, MCP tools, and more.
+description: Eino component selection, configuration, and usage. Use when a user needs to choose or configure a ChatModel, AgenticModel, Embedding, Retriever, Indexer, Tool, Document loader/parser/transformer, Prompt template, or Callback handler. Covers all component interfaces and their implementations in eino-ext including OpenAI, Claude, Gemini, Ark, Ollama, Milvus, Elasticsearch, Redis, MCP tools, and more.
 ---
 
 # Eino Component Guide
 
 ## Component Selection Guide
 
-### ChatModel -- LLM inference
+### ChatModel -- LLM inference (classic Message path)
 
 | Provider | Package | Notes |
 |----------|---------|-------|
@@ -20,6 +20,18 @@ description: Eino component selection, configuration, and usage. Use when a user
 | Qwen | `model/qwen` | Alibaba DashScope API |
 | Qianfan | `model/qianfan` | Baidu ERNIE models |
 | OpenRouter | `model/openrouter` | Multi-provider routing |
+
+### AgenticModel -- LLM inference (AgenticMessage path)
+
+AgenticModel operates on `*schema.AgenticMessage` with block-based content (reasoning, text, images, audio, video, tool calls/results). Tools are always passed at call time via `model.WithTools` option (no `WithTools` method).
+
+| Provider | Package | Notes |
+|----------|---------|-------|
+| OpenAI | `model/agenticopenai` | GPT-4o, o1, o3 series |
+| Gemini | `model/agenticgemini` | Gemini 2.x models |
+| DeepSeek | `model/agenticdeepseek` | DeepSeek-R1 with reasoning |
+| Ark (Volcengine) | `model/agenticark` | Doubao models (agentic path) |
+| Qwen | `model/agenticqwen` | Qwen series via DashScope |
 
 ### Embedding -- text to vector
 
@@ -65,11 +77,17 @@ description: Eino component selection, configuration, and usage. Use when a user
 ## Interface Quick Reference
 
 ```go
-// ChatModel
-type BaseChatModel interface {
-    Generate(ctx context.Context, input []*schema.Message, opts ...Option) (*schema.Message, error)
-    Stream(ctx context.Context, input []*schema.Message, opts ...Option) (*schema.StreamReader[*schema.Message], error)
+// BaseModel (generic)
+type BaseModel[M any] interface {
+    Generate(ctx context.Context, input []M, opts ...Option) (M, error)
+    Stream(ctx context.Context, input []M, opts ...Option) (*schema.StreamReader[M], error)
 }
+
+// Type aliases
+type BaseChatModel = BaseModel[*schema.Message]       // classic path
+type AgenticModel = BaseModel[*schema.AgenticMessage] // agentic path
+
+// ToolCallingChatModel (classic path, adds WithTools)
 type ToolCallingChatModel interface {
     BaseChatModel
     WithTools(tools []*schema.ToolInfo) (ToolCallingChatModel, error)
@@ -116,11 +134,12 @@ type ChatTemplate interface {
 go get github.com/cloudwego/eino-ext/components/{type}/{impl}@latest
 # Examples:
 go get github.com/cloudwego/eino-ext/components/model/openai@latest
+go get github.com/cloudwego/eino-ext/components/model/agenticopenai@latest
 go get github.com/cloudwego/eino-ext/components/retriever/milvus2@latest
 go get github.com/cloudwego/eino-ext/components/tool/mcp@latest
 ```
 
-## ChatModel Usage
+## ChatModel Usage (Classic Path)
 
 ### Generate
 
@@ -150,6 +169,40 @@ for {
 withTools, err := chatModel.WithTools([]*schema.ToolInfo{toolInfo})
 resp, err := withTools.Generate(ctx, messages)
 // resp.ToolCalls contains model's tool invocations
+```
+
+## AgenticModel Usage
+
+```go
+import (
+    "github.com/cloudwego/eino-ext/components/model/agenticopenai"
+    "github.com/cloudwego/eino/components/model"
+    "github.com/cloudwego/eino/schema"
+)
+
+// Create agentic model
+am, _ := agenticopenai.NewAgenticModel(ctx, &agenticopenai.AgenticModelConfig{
+    Model:  "gpt-4o",
+    APIKey: "your-key",
+})
+
+// Tools passed at call time (not via WithTools)
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("Search for Go tutorials")},
+    model.WithTools(toolInfos...),
+)
+
+// Response contains typed ContentBlocks
+for _, block := range resp.ContentBlocks {
+    switch block.Type {
+    case schema.ContentBlockTypeAssistantGenText:
+        fmt.Println(block.AssistantGenText.Text)
+    case schema.ContentBlockTypeFunctionToolCall:
+        fmt.Printf("Tool call: %s(%s)\n", block.FunctionToolCall.Name, block.FunctionToolCall.Arguments)
+    case schema.ContentBlockTypeReasoning:
+        fmt.Printf("Reasoning: %s\n", block.Reasoning.Text)
+    }
+}
 ```
 
 ## RAG Components
@@ -187,7 +240,9 @@ Implement `Info()` and `InvokableRun()` to create a custom tool.
 ## Instructions to Agent
 
 - Constructor signatures and Config struct names vary across implementations. Always read the provider's reference file in `reference/{type}/{impl}.md` before generating initialization code.
-- Use `ToolCallingChatModel` (not deprecated `ChatModel`) for tool binding.
+- Use `BaseChatModel` (classic path) or `AgenticModel` (agentic path) based on the user's needs.
+- AgenticModel does NOT have a `WithTools` method. Tools are always passed via `model.WithTools(...)` option at call time.
+- For ADK agents, the `ChatModelAgentConfig.Model` field accepts `model.BaseModel[M]` -- both paths work seamlessly.
 - For RAG, ensure the same Embedder model is used for both indexing and retrieval.
 - See reference files for detailed per-component documentation.
 
@@ -195,7 +250,7 @@ Implement `Info()` and `InvokableRun()` to create a custom tool.
 
 Read files on-demand for detailed API, config, and examples. Each `{type}/` directory contains an `overview.md` (interfaces + common patterns) and per-implementation files:
 
-- `reference/model/*.md` -- ChatModel interfaces, tool binding, streaming, and per-provider config (openai, claude, gemini, ark, ollama, deepseek, qwen, qianfan, openrouter)
+- `reference/model/*.md` -- ChatModel and AgenticModel interfaces, tool binding, streaming, and per-provider config (openai, claude, gemini, ark, ollama, deepseek, qwen, qianfan, openrouter)
 - `reference/embedding/*.md` -- Embedder interface and per-provider config (openai, ark, ollama, etc.)
 - `reference/retriever/*.md` -- Retriever interface, RAG example, and per-backend config (redis, milvus2, es8)
 - `reference/indexer/*.md` -- Indexer interface, indexing pipeline, and per-backend config (redis, milvus2, es8, qdrant)

--- a/skills/eino-component/SKILL.md
+++ b/skills/eino-component/SKILL.md
@@ -117,8 +117,12 @@ type Transformer interface {
 }
 
 // Tool
-type InvokableTool interface {
+type BaseTool interface {
     Info(ctx context.Context) (*schema.ToolInfo, error)
+}
+
+type InvokableTool interface {
+    BaseTool
     InvokableRun(ctx context.Context, argumentsInJSON string, opts ...Option) (string, error)
 }
 
@@ -181,7 +185,7 @@ import (
 )
 
 // Create agentic model
-am, _ := agenticopenai.NewAgenticModel(ctx, &agenticopenai.AgenticModelConfig{
+am, _ := agenticopenai.New(ctx, &agenticopenai.Config{
     Model:  "gpt-4o",
     APIKey: "your-key",
 })

--- a/skills/eino-component/SKILL.md
+++ b/skills/eino-component/SKILL.md
@@ -33,6 +33,13 @@ AgenticModel operates on `*schema.AgenticMessage` with block-based content (reas
 | Ark (Volcengine) | `model/agenticark` | Doubao models (agentic path) |
 | Qwen | `model/agenticqwen` | Qwen series via DashScope |
 
+Detailed configuration references:
+- `reference/model/agenticopenai.md`
+- `reference/model/agenticgemini.md`
+- `reference/model/agenticdeepseek.md`
+- `reference/model/agenticark.md`
+- `reference/model/agenticqwen.md`
+
 ### Embedding -- text to vector
 
 | Provider | Package | Notes |
@@ -190,7 +197,7 @@ am, _ := agenticopenai.New(ctx, &agenticopenai.Config{
     APIKey: "your-key",
 })
 
-// Tools passed at call time via option (not via WithTools method)
+// Tools passed at call time via option for AgenticModel-interface code
 resp, err := am.Generate(ctx,
     []*schema.AgenticMessage{schema.UserAgenticMessage("Search for Go tutorials")},
     model.WithTools(toolInfos),
@@ -245,7 +252,7 @@ Implement `Info()` and `InvokableRun()` to create a custom tool.
 
 - Constructor signatures and Config struct names vary across implementations. Always read the provider's reference file in `reference/{type}/{impl}.md` before generating initialization code.
 - Use `BaseChatModel` (classic path) or `AgenticModel` (agentic path) based on the user's needs.
-- AgenticModel does NOT have a `WithTools` method. Tools are always passed via `model.WithTools(...)` option at call time.
+- `model.AgenticModel` does not add a `WithTools` method to the interface. Prefer `model.WithTools(...)` at call time for interface-oriented code.
 - For ADK agents, the `ChatModelAgentConfig.Model` field accepts `model.BaseModel[M]` -- both paths work seamlessly.
 - For RAG, ensure the same Embedder model is used for both indexing and retrieval.
 - See reference files for detailed per-component documentation.

--- a/skills/eino-component/SKILL.md
+++ b/skills/eino-component/SKILL.md
@@ -186,10 +186,10 @@ am, _ := agenticopenai.NewAgenticModel(ctx, &agenticopenai.AgenticModelConfig{
     APIKey: "your-key",
 })
 
-// Tools passed at call time (not via WithTools)
+// Tools passed at call time via option (not via WithTools method)
 resp, err := am.Generate(ctx,
     []*schema.AgenticMessage{schema.UserAgenticMessage("Search for Go tutorials")},
-    model.WithTools(toolInfos...),
+    model.WithTools(toolInfos),
 )
 
 // Response contains typed ContentBlocks

--- a/skills/eino-component/reference/callback/overview.md
+++ b/skills/eino-component/reference/callback/overview.md
@@ -8,10 +8,10 @@ Callback handlers observe component execution for tracing and monitoring.
 // github.com/cloudwego/eino/callbacks
 type Handler interface {
     OnStart(ctx context.Context, info *RunInfo, input CallbackInput) context.Context
-    OnEnd(ctx context.Context, info *RunInfo, output CallbackOutput)
-    OnError(ctx context.Context, info *RunInfo, err error)
+    OnEnd(ctx context.Context, info *RunInfo, output CallbackOutput) context.Context
+    OnError(ctx context.Context, info *RunInfo, err error) context.Context
     OnStartWithStreamInput(ctx context.Context, info *RunInfo, input *schema.StreamReader[CallbackInput]) context.Context
-    OnEndWithStreamOutput(ctx context.Context, info *RunInfo, output *schema.StreamReader[CallbackOutput])
+    OnEndWithStreamOutput(ctx context.Context, info *RunInfo, output *schema.StreamReader[CallbackOutput]) context.Context
 }
 ```
 

--- a/skills/eino-component/reference/document/pipeline.md
+++ b/skills/eino-component/reference/document/pipeline.md
@@ -56,7 +56,7 @@ docs, err := loader.Load(ctx, document.Source{URI: "https://example.com/page"})
 ```go
 import "github.com/cloudwego/eino-ext/components/document/loader/s3"
 
-loader, err := s3.NewLoader(ctx, &s3.LoaderConfig{
+loader, err := s3.NewS3Loader(ctx, &s3.LoaderConfig{
     Region: "us-east-1",
     Bucket: "my-bucket",
 })
@@ -89,7 +89,7 @@ parser, err := html.NewParser(ctx, &html.Config{
 ```go
 import "github.com/cloudwego/eino-ext/components/document/parser/pdf"
 
-parser, err := pdf.NewParser(ctx, &pdf.Config{})
+parser, err := pdf.NewPDFParser(ctx, &pdf.Config{})
 ```
 
 ## Transformers

--- a/skills/eino-component/reference/indexer/es8.md
+++ b/skills/eino-component/reference/indexer/es8.md
@@ -7,7 +7,7 @@ import esIndexer "github.com/cloudwego/eino-ext/components/indexer/es8"
 ## Configuration
 
 ```go
-esClient, _ := elasticsearch.NewTypedClient(elasticsearch.Config{
+esClient, _ := elasticsearch.NewClient(elasticsearch.Config{
     Addresses: []string{"http://localhost:9200"},
 })
 

--- a/skills/eino-component/reference/indexer/qdrant.md
+++ b/skills/eino-component/reference/indexer/qdrant.md
@@ -7,7 +7,7 @@ import qdrantIndexer "github.com/cloudwego/eino-ext/components/indexer/qdrant"
 ## Configuration
 
 ```go
-indexer, err := qdrantIndexer.NewIndexer(ctx, &qdrantIndexer.IndexerConfig{
+indexer, err := qdrantIndexer.NewIndexer(ctx, &qdrantIndexer.Config{
     Client:         qdrantClient,
     CollectionName: "my_collection",
     Embedding:      embedder,

--- a/skills/eino-component/reference/model/agenticark.md
+++ b/skills/eino-component/reference/model/agenticark.md
@@ -1,0 +1,108 @@
+<!--
+Copyright 2026 CloudWeGo Authors
+-->
+
+# Ark AgenticModel
+
+Use `agenticark` when you need the `model.AgenticModel` path backed by Volcengine Ark Responses API and `*schema.AgenticMessage`.
+
+```go
+import "github.com/cloudwego/eino-ext/components/model/agenticark"
+```
+
+## Configuration
+
+```go
+am, err := agenticark.New(ctx, &agenticark.Config{
+    APIKey: "your-key",    // Required unless AccessKey + SecretKey are set
+    Model:  "endpoint-id", // Required: Ark endpoint ID
+})
+```
+
+`agenticark.Config` fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Timeout` | `*time.Duration` | Optional; ignored when `HTTPClient` is set |
+| `HTTPClient` | `*http.Client` | Optional custom HTTP client |
+| `RetryTimes` | `*int` | Optional retry count |
+| `BaseURL` | `string` | Optional custom Ark endpoint |
+| `Region` | `string` | Optional region |
+| `APIKey` | `string` | Preferred authentication |
+| `AccessKey` | `string` | Alternative authentication, used with `SecretKey` |
+| `SecretKey` | `string` | Alternative authentication, used with `AccessKey` |
+| `Model` | `string` | Required model endpoint ID |
+| `MaxTokens` | `*int` | Optional maximum output tokens |
+| `Temperature` | `*float32` | Optional, range 0.0 to 2.0 |
+| `TopP` | `*float32` | Optional, range 0.0 to 1.0 |
+| `ServiceTier` | `*responses.ResponsesServiceTier_Enum` | Optional service tier |
+| `Text` | `*responses.ResponsesText` | Optional text output config |
+| `Thinking` | `*responses.ResponsesThinking` | Optional thinking mode config |
+| `Reasoning` | `*responses.ResponsesReasoning` | Optional reasoning config |
+| `EnablePassBackReasoning` | `*bool` | Optional; default true |
+| `MaxToolCalls` | `*int64` | Optional maximum tool calls |
+| `ParallelToolCalls` | `*bool` | Optional parallel tool call switch |
+| `ServerTools` | `[]*agenticark.ServerToolConfig` | Optional server-side tools |
+| `MCPTools` | `[]*responses.ToolMcp` | Optional MCP tools |
+| `Cache` | `*agenticark.CacheConfig` | Optional session-cache config |
+| `ContextManagement` | `*contextmanagement.ContextManagement` | Optional context management |
+| `CustomHeaders` | `map[string]string` | Optional request headers |
+
+`ServerToolConfig` supports `WebSearch`, `ImageProcess`, `DoubaoApp`, and `KnowledgeSearch`.
+
+## Call Options
+
+Provider-specific options:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    agenticark.WithThinking(thinking),
+    agenticark.WithReasoning(reasoning),
+    agenticark.WithMaxToolCalls(4),
+    agenticark.WithParallelToolCalls(true),
+    agenticark.WithServerTools(serverTools),
+    agenticark.WithMCPTools(mcpTools),
+    agenticark.WithCache(cacheOpt),
+    agenticark.WithContextManagement(contextManagement),
+    agenticark.WithCustomHeaders(map[string]string{"x-trace-id": traceID}),
+)
+```
+
+Available provider options: `WithReasoning`, `WithThinking`, `WithText`, `WithMaxToolCalls`, `WithParallelToolCalls`, `WithServerTools`, `WithMCPTools`, `WithCustomHeaders`, `WithCache`, `WithContextManagement`.
+
+Common model options also apply, including `model.WithModel`, `model.WithMaxTokens`, `model.WithTemperature`, `model.WithTopP`, `model.WithTools`, and `model.WithAgenticToolChoice`.
+
+## Cache
+
+Session cache is configured by `CacheConfig` or overridden per request with `WithCache`:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    agenticark.WithCache(&agenticark.CacheOption{
+        HeadPreviousResponseID: previousResponseID,
+        SessionCache: &agenticark.SessionCacheConfig{
+            EnableCache: true,
+            ExpireAtSec: expireAt,
+        },
+    }),
+)
+```
+
+`CreatePrefixCache(ctx, prefix, expireAtSec, opts...)` creates server-side prefix context and returns `*agenticark.CacheInfo`.
+
+## Tools
+
+For code that works against the `model.AgenticModel` interface, pass tools at call time:
+
+```go
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("use a function tool")},
+    model.WithTools(toolInfos),
+)
+```
+
+## Notes
+
+- `model.WithStop` and classic `model.WithToolChoice` are rejected by this implementation.
+- Use `model.WithAgenticToolChoice` for agentic tool-choice control.
+- When a cached previous response is used, function/server/MCP tool population and tool choice are skipped for that request.

--- a/skills/eino-component/reference/model/agenticdeepseek.md
+++ b/skills/eino-component/reference/model/agenticdeepseek.md
@@ -1,0 +1,78 @@
+<!--
+Copyright 2026 CloudWeGo Authors
+-->
+
+# DeepSeek AgenticModel
+
+Use `agenticdeepseek` when you need the `model.AgenticModel` path backed by DeepSeek's OpenAI-compatible API and `*schema.AgenticMessage`.
+
+```go
+import "github.com/cloudwego/eino-ext/components/model/agenticdeepseek"
+```
+
+## Configuration
+
+```go
+am, err := agenticdeepseek.New(ctx, &agenticdeepseek.Config{
+    APIKey: "your-key",        // Required
+    Model:  "deepseek-reasoner",
+})
+```
+
+`agenticdeepseek.Config` fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `APIKey` | `string` | Required |
+| `Timeout` | `time.Duration` | Optional; ignored when `HTTPClient` is set |
+| `HTTPClient` | `*http.Client` | Optional custom HTTP client |
+| `BaseURL` | `string` | Optional; default `https://api.deepseek.com` |
+| `Model` | `string` | Required model ID |
+| `MaxTokens` | `*int` | Optional maximum output tokens |
+| `Temperature` | `*float32` | Optional sampling temperature |
+| `TopP` | `*float32` | Optional nucleus sampling |
+| `Stop` | `[]string` | Optional stop sequences |
+| `PresencePenalty` | `*float32` | Optional presence penalty |
+| `ResponseFormatType` | `agenticdeepseek.ResponseFormatType` | Optional response format |
+| `FrequencyPenalty` | `*float32` | Optional frequency penalty |
+| `LogProbs` | `*bool` | Optional logprob output switch |
+| `TopLogProbs` | `*int` | Optional number of top logprobs |
+
+Response format constants:
+
+```go
+agenticdeepseek.ResponseFormatTypeText
+agenticdeepseek.ResponseFormatTypeJSONObject
+```
+
+## Call Options
+
+This implementation is built on `libs/acl/openai.AgenticClient`, so it primarily uses common model options:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    model.WithTemperature(0.6),
+    model.WithMaxTokens(2048),
+    model.WithTopP(0.9),
+    model.WithTools(toolInfos),
+)
+```
+
+Common options include `model.WithModel`, `model.WithMaxTokens`, `model.WithTemperature`, `model.WithTopP`, `model.WithStop`, `model.WithTools`, and `model.WithAgenticToolChoice`.
+
+## Tools
+
+For code that works against the `model.AgenticModel` interface, pass tools at call time:
+
+```go
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("solve with tools if needed")},
+    model.WithTools(toolInfos),
+)
+```
+
+## Notes
+
+- `New` returns an error when `config` is nil.
+- Response metadata extension is extracted from the underlying OpenAI-compatible response into `AgenticResponseMeta.Extension`.
+- Use `ResponseFormatTypeJSONObject` when the DeepSeek API should return JSON object output.

--- a/skills/eino-component/reference/model/agenticgemini.md
+++ b/skills/eino-component/reference/model/agenticgemini.md
@@ -1,0 +1,100 @@
+<!--
+Copyright 2026 CloudWeGo Authors
+-->
+
+# Gemini AgenticModel
+
+Use `agenticgemini` when you need the `model.AgenticModel` path backed by Google Gemini and `*schema.AgenticMessage`.
+
+```go
+import "github.com/cloudwego/eino-ext/components/model/agenticgemini"
+```
+
+## Configuration
+
+```go
+am, err := agenticgemini.NewAgenticModel(ctx, &agenticgemini.Config{
+    Client: genaiClient,       // Required
+    Model:  "gemini-2.0-flash",
+})
+```
+
+`agenticgemini.Config` fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Client` | `*genai.Client` | Required Gemini client |
+| `Model` | `string` | Model name |
+| `MaxTokens` | `*int` | Optional maximum output tokens |
+| `Temperature` | `*float32` | Optional, range 0.0 to 1.0 |
+| `TopP` | `*float32` | Optional, range 0.0 to 1.0 |
+| `TopK` | `*int32` | Optional top-k sampling |
+| `ResponseJSONSchema` | `*jsonschema.Schema` | Optional structured JSON schema |
+| `EnableCodeExecution` | `*genai.ToolCodeExecution` | Optional CodeExecution server tool |
+| `EnableGoogleSearch` | `*genai.GoogleSearch` | Optional GoogleSearch server tool |
+| `EnableGoogleSearchRetrieval` | `*genai.GoogleSearchRetrieval` | Optional GoogleSearchRetrieval server tool |
+| `EnableComputerUse` | `*genai.ComputerUse` | Optional ComputerUse server tool |
+| `EnableURLContext` | `*genai.URLContext` | Optional URLContext server tool |
+| `EnableFileSearch` | `*genai.FileSearch` | Optional FileSearch server tool |
+| `EnableGoogleMaps` | `*genai.GoogleMaps` | Optional GoogleMaps server tool |
+| `SafetySettings` | `[]*genai.SafetySetting` | Optional safety settings |
+| `ThinkingConfig` | `*genai.ThinkingConfig` | Optional thinking config |
+| `ResponseModalities` | `[]agenticgemini.ResponseModality` | Optional response modalities |
+| `MediaResolution` | `genai.MediaResolution` | Optional media resolution |
+| `Cache` | `*agenticgemini.CacheConfig` | Optional prefix-cache config |
+
+Response modalities: `ResponseModalityText`, `ResponseModalityImage`, `ResponseModalityAudio`.
+
+## Call Options
+
+Provider-specific options:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    agenticgemini.WithTopK(40),
+    agenticgemini.WithThinkingConfig(thinkingConfig),
+    agenticgemini.WithResponseJSONSchema(jsonSchema),
+    agenticgemini.WithResponseModalities([]agenticgemini.ResponseModality{
+        agenticgemini.ResponseModalityText,
+    }),
+    agenticgemini.WithCachedContentName("cachedContents/abc"),
+)
+```
+
+Available provider options: `WithTopK`, `WithResponseJSONSchema`, `WithThinkingConfig`, `WithResponseModalities`, `WithCachedContentName`.
+
+Common model options also apply, including `model.WithModel`, `model.WithMaxTokens`, `model.WithTemperature`, `model.WithTopP`, `model.WithTools`, and `model.WithAgenticToolChoice`.
+
+## Cache
+
+Prefix cache is created with `CreatePrefixCache`:
+
+```go
+cached, err := am.CreatePrefixCache(ctx, prefixMessages, model.WithTools(toolInfos))
+if err != nil {
+    return err
+}
+
+resp, err := am.Generate(ctx, messages,
+    agenticgemini.WithCachedContentName(cached.Name),
+)
+```
+
+`CacheConfig` supports `TTL` and `ExpireTime` when creating cached content.
+
+## Tools
+
+For code that works against the `model.AgenticModel` interface, pass tools at call time:
+
+```go
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("call a function if needed")},
+    model.WithTools(toolInfos),
+)
+```
+
+## Notes
+
+- `Generate` and `Stream` reject empty input with `gemini input is empty`.
+- Gemini server tools are configured through the `Enable*` fields on `Config`.
+- Tool choice should use `model.WithAgenticToolChoice`; avoid classic `model.WithToolChoice` for agentic messages.

--- a/skills/eino-component/reference/model/agenticopenai.md
+++ b/skills/eino-component/reference/model/agenticopenai.md
@@ -1,0 +1,89 @@
+<!--
+Copyright 2026 CloudWeGo Authors
+-->
+
+# OpenAI AgenticModel
+
+Use `agenticopenai` when you need the `model.AgenticModel` path backed by OpenAI Responses API and `*schema.AgenticMessage`.
+
+```go
+import "github.com/cloudwego/eino-ext/components/model/agenticopenai"
+```
+
+## Configuration
+
+```go
+am, err := agenticopenai.New(ctx, &agenticopenai.Config{
+    APIKey: "your-key", // Required
+    Model:  "gpt-4o",   // Required
+})
+```
+
+`agenticopenai.Config` fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ByAzure` | `bool` | Use Azure OpenAI authentication when true |
+| `BaseURL` | `string` | Optional custom endpoint |
+| `APIKey` | `string` | Required |
+| `Timeout` | `*time.Duration` | Optional request timeout |
+| `HTTPClient` | `*http.Client` | Optional custom HTTP client |
+| `MaxRetries` | `*int` | Optional SDK retry count |
+| `Model` | `string` | Required model ID |
+| `MaxTokens` | `*int` | Optional maximum output tokens |
+| `Temperature` | `*float32` | Optional, range 0.0 to 2.0 |
+| `TopP` | `*float32` | Optional, range 0.0 to 1.0 |
+| `ServiceTier` | `*responses.ResponseNewParamsServiceTier` | Optional service tier |
+| `Text` | `*responses.ResponseTextConfigParam` | Optional text output config |
+| `Reasoning` | `*responses.ReasoningParam` | Optional reasoning config |
+| `Store` | `*bool` | Optional server-side response storage |
+| `MaxToolCalls` | `*int` | Optional maximum tool calls |
+| `ParallelToolCalls` | `*bool` | Optional parallel tool call switch |
+| `Include` | `[]responses.ResponseIncludable` | Optional additional response fields |
+| `ServerTools` | `[]*agenticopenai.ServerToolConfig` | Optional hosted tools |
+| `MCPTools` | `[]*responses.ToolMcpParam` | Optional MCP tools |
+| `Truncation` | `*responses.ResponseNewParamsTruncation` | Optional truncation behavior |
+| `CustomHeaders` | `map[string]string` | Optional request headers |
+| `ExtraFields` | `map[string]any` | Optional raw JSON fields added to the request |
+
+`ServerToolConfig` supports `WebSearch`, `FileSearch`, `CodeInterpreter`, and `Shell`.
+
+## Call Options
+
+Provider-specific options:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    agenticopenai.WithReasoning(reasoning),
+    agenticopenai.WithMaxToolCalls(4),
+    agenticopenai.WithParallelToolCalls(true),
+    agenticopenai.WithServerTools(serverTools),
+    agenticopenai.WithMCPTools(mcpTools),
+    agenticopenai.WithPromptCacheKey("stable-prefix-key"),
+    agenticopenai.WithCustomHeaders(map[string]string{"x-trace-id": traceID}),
+    agenticopenai.WithExtraFields(map[string]any{"metadata": map[string]string{"env": "prod"}}),
+)
+```
+
+Available provider options: `WithStore`, `WithPromptCacheKey`, `WithReasoning`, `WithText`, `WithMaxToolCalls`, `WithParallelToolCalls`, `WithServerTools`, `WithMCPTools`, `WithCustomHeaders`, `WithExtraFields`, `WithTruncation`.
+
+Common model options also apply, including `model.WithModel`, `model.WithMaxTokens`, `model.WithTemperature`, `model.WithTopP`, `model.WithTools`, `model.WithDeferredTools`, `model.WithToolSearchTool`, and `model.WithAgenticToolChoice`.
+
+## Tools
+
+For code that works against the `model.AgenticModel` interface, pass tools at call time:
+
+```go
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("search the web")},
+    model.WithTools(toolInfos),
+)
+```
+
+Do not rely on concrete-only methods when documenting general AgenticModel usage.
+
+## Notes
+
+- `model.WithStop` and classic `model.WithToolChoice` are rejected by this implementation.
+- Use `model.WithAgenticToolChoice` for agentic tool-choice control.
+- `model.WithDeferredTools` automatically adds hosted tool search when no explicit tool-search tool is provided.

--- a/skills/eino-component/reference/model/agenticqwen.md
+++ b/skills/eino-component/reference/model/agenticqwen.md
@@ -1,0 +1,107 @@
+<!--
+Copyright 2026 CloudWeGo Authors
+-->
+
+# Qwen AgenticModel
+
+Use `agenticqwen` when you need the `model.AgenticModel` path backed by Qwen/DashScope's OpenAI-compatible API and `*schema.AgenticMessage`.
+
+```go
+import "github.com/cloudwego/eino-ext/components/model/agenticqwen"
+```
+
+## Configuration
+
+```go
+am, err := agenticqwen.New(ctx, &agenticqwen.Config{
+    APIKey: "your-key",      // Required
+    Model:  "qwen-plus",
+})
+```
+
+`agenticqwen.Config` fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `APIKey` | `string` | Required |
+| `Timeout` | `time.Duration` | Optional; ignored when `HTTPClient` is set |
+| `HTTPClient` | `*http.Client` | Optional custom HTTP client |
+| `BaseURL` | `string` | Optional; default `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` |
+| `Model` | `string` | Required model ID |
+| `MaxTokens` | `*int` | Optional maximum output tokens |
+| `Temperature` | `*float32` | Optional, range 0.0 to 2.0 |
+| `TopP` | `*float32` | Optional, range 0.0 to 1.0 |
+| `Stop` | `[]string` | Optional stop sequences |
+| `PresencePenalty` | `*float32` | Optional presence penalty |
+| `Seed` | `*int` | Optional deterministic sampling seed |
+| `FrequencyPenalty` | `*float32` | Optional frequency penalty |
+| `LogitBias` | `map[string]int` | Optional token bias map |
+| `User` | `*string` | Optional end-user identifier |
+| `EnableThinking` | `*bool` | Optional thinking mode switch |
+| `PreserveThinking` | `*bool` | Optional multi-turn thinking preservation |
+| `Modalities` | `[]agenticqwen.Modality` | Optional output modalities |
+| `Audio` | `*agenticqwen.AudioConfig` | Required when `Modalities` includes audio |
+
+Modality and audio constants:
+
+```go
+agenticqwen.ModalityText
+agenticqwen.ModalityAudio
+agenticqwen.AudioFormatWav
+agenticqwen.AudioVoiceCherry
+agenticqwen.AudioVoiceSerena
+agenticqwen.AudioVoiceEthan
+agenticqwen.AudioVoiceChelsie
+```
+
+## Call Options
+
+Provider-specific options:
+
+```go
+resp, err := am.Generate(ctx, messages,
+    agenticqwen.WithEnableThinking(true),
+    agenticqwen.WithPreserveThinking(true),
+    model.WithTools(toolInfos),
+)
+```
+
+Available provider options: `WithEnableThinking`, `WithPreserveThinking`.
+
+Common model options also apply, including `model.WithModel`, `model.WithMaxTokens`, `model.WithTemperature`, `model.WithTopP`, `model.WithStop`, `model.WithTools`, and `model.WithAgenticToolChoice`.
+
+## Audio Output
+
+For Qwen-Omni models that return audio, set both `Modalities` and `Audio`:
+
+```go
+am, err := agenticqwen.New(ctx, &agenticqwen.Config{
+    APIKey: "your-key",
+    Model:  "qwen-omni-turbo",
+    Modalities: []agenticqwen.Modality{
+        agenticqwen.ModalityText,
+        agenticqwen.ModalityAudio,
+    },
+    Audio: &agenticqwen.AudioConfig{
+        Format: agenticqwen.AudioFormatWav,
+        Voice:  agenticqwen.AudioVoiceCherry,
+    },
+})
+```
+
+## Tools
+
+For code that works against the `model.AgenticModel` interface, pass tools at call time:
+
+```go
+resp, err := am.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("use tools if needed")},
+    model.WithTools(toolInfos),
+)
+```
+
+## Notes
+
+- `New` returns an error when `config` is nil.
+- `EnableThinking` and `PreserveThinking` are encoded into provider-specific extra fields before calling the underlying OpenAI-compatible client.
+- Response metadata extension is extracted from the underlying OpenAI-compatible response into `AgenticResponseMeta.Extension`.

--- a/skills/eino-component/reference/model/openai.md
+++ b/skills/eino-component/reference/model/openai.md
@@ -11,8 +11,8 @@ chatModel, err := openai.NewChatModel(ctx, &openai.ChatModelConfig{
     APIKey:  "your-key",       // Required
     Model:   "gpt-4o",         // Required
     BaseURL: "",               // Optional, custom endpoint
-    Temperature:         ptrFloat32(0.7), // Optional, 0.0-2.0
-    MaxCompletionTokens: ptrInt(4096),    // Optional
+    Temperature:         func() *float32 { t := float32(0.7); return &t }(), // Optional, 0.0-2.0
+    MaxCompletionTokens: func() *int { t := 4096; return &t }(),    // Optional
     ReasoningEffort:     openai.ReasoningEffortLevelHigh, // Optional
 })
 ```

--- a/skills/eino-component/reference/model/overview.md
+++ b/skills/eino-component/reference/model/overview.md
@@ -1,15 +1,19 @@
-# ChatModel Overview
+# Model Overview
 
-All ChatModel implementations implement `ToolCallingChatModel` from `github.com/cloudwego/eino/components/model`.
+Eino has two model paths:
+- Classic ChatModel uses `*schema.Message`.
+- AgenticModel uses `*schema.AgenticMessage` and preserves native block-based content.
 
 ## Interfaces
 
 ```go
-type BaseChatModel interface {
-    Generate(ctx context.Context, input []*schema.Message, opts ...Option) (*schema.Message, error)
-    Stream(ctx context.Context, input []*schema.Message, opts ...Option) (
-        *schema.StreamReader[*schema.Message], error)
+type BaseModel[M any] interface {
+    Generate(ctx context.Context, input []M, opts ...Option) (M, error)
+    Stream(ctx context.Context, input []M, opts ...Option) (*schema.StreamReader[M], error)
 }
+
+type BaseChatModel = BaseModel[*schema.Message]
+type AgenticModel = BaseModel[*schema.AgenticMessage]
 
 type ToolCallingChatModel interface {
     BaseChatModel
@@ -68,3 +72,24 @@ chunks := make([]*schema.Message, 0)
 for { /* collect chunks */ }
 msg, err := schema.ConcatMessages(chunks)
 ```
+
+## AgenticModel
+
+AgenticModel does not add a tool-binding method to the interface. Pass tools at request time:
+
+```go
+resp, err := agenticModel.Generate(ctx,
+    []*schema.AgenticMessage{schema.UserAgenticMessage("use tools if needed")},
+    model.WithTools(toolInfos),
+)
+```
+
+Use provider-specific references for constructor and config details:
+
+| Provider | Reference |
+|----------|-----------|
+| OpenAI | `reference/model/agenticopenai.md` |
+| Gemini | `reference/model/agenticgemini.md` |
+| DeepSeek | `reference/model/agenticdeepseek.md` |
+| Ark | `reference/model/agenticark.md` |
+| Qwen | `reference/model/agenticqwen.md` |

--- a/skills/eino-component/reference/retriever/es8.md
+++ b/skills/eino-component/reference/retriever/es8.md
@@ -7,7 +7,7 @@ import "github.com/cloudwego/eino-ext/components/retriever/es8"
 ## Configuration
 
 ```go
-esClient, _ := elasticsearch.NewTypedClient(elasticsearch.Config{
+esClient, _ := elasticsearch.NewClient(elasticsearch.Config{
     Addresses: []string{"http://localhost:9200"},
 })
 

--- a/skills/eino-component/reference/retriever/qdrant.md
+++ b/skills/eino-component/reference/retriever/qdrant.md
@@ -1,0 +1,17 @@
+# Qdrant Retriever
+
+```
+import qdrantRetriever "github.com/cloudwego/eino-ext/components/retriever/qdrant"
+```
+
+## Configuration
+
+```go
+retriever, err := qdrantRetriever.NewRetriever(ctx, &qdrantRetriever.Config{
+    Client:         qdrantClient,
+    CollectionName: "my_collection",
+    Embedding:      embedder,
+})
+
+docs, err := retriever.Retrieve(ctx, "what is eino?")
+```

--- a/skills/eino-compose/SKILL.md
+++ b/skills/eino-compose/SKILL.md
@@ -110,6 +110,34 @@ sr, sw := schema.Pipe[T](capacity)
 // chunk, err := sr.Recv(); sr.Close()
 ```
 
+## AgenticToolsNode
+
+`AgenticToolsNode` is the agentic counterpart to `ToolsNode`. It operates on `*schema.AgenticMessage` instead of `*schema.Message`, extracting `FunctionToolCall` content blocks and returning `FunctionToolResult` content blocks.
+
+```go
+import "github.com/cloudwego/eino/compose"
+
+// Create from the same ToolsNodeConfig
+agenticToolsNode, err := compose.NewAgenticToolsNode(ctx, &compose.ToolsNodeConfig{
+    Tools: []tool.BaseTool{myTool1, myTool2},
+})
+
+// Use in Graph
+g := compose.NewGraph[*schema.AgenticMessage, []*schema.AgenticMessage]()
+g.AddAgenticToolsNode("tools", agenticToolsNode)
+
+// Use in Chain
+chain := compose.NewChain[*schema.AgenticMessage, []*schema.AgenticMessage]()
+chain.AppendAgenticToolsNode(agenticToolsNode)
+```
+
+Key differences from `ToolsNode`:
+- Input: `*schema.AgenticMessage` (reads `ContentBlockTypeFunctionToolCall` blocks)
+- Output: `[]*schema.AgenticMessage` (writes `ContentBlockTypeFunctionToolResult` blocks)
+- Supports multimodal tool results (text, image, audio, video, file)
+- Handles `ToolSearchFunctionToolResult` for dynamic tool discovery
+- Reuses the same `ToolsNodeConfig` -- all existing tools work unchanged
+
 ## Compile & Run
 
 ```go

--- a/skills/eino-compose/SKILL.md
+++ b/skills/eino-compose/SKILL.md
@@ -67,7 +67,7 @@ r, err := chain.Compile(ctx)
 out, err := r.Invoke(ctx, input)
 ```
 
-Append methods: `AppendChatModel`, `AppendChatTemplate`, `AppendToolsNode`, `AppendLambda`, `AppendGraph`, `AppendParallel`, `AppendBranch`, `AppendPassthrough`, `AppendRetriever`, `AppendEmbedding`, `AppendLoader`, `AppendIndexer`, `AppendDocumentTransformer`.
+Append methods: `AppendChatModel`, `AppendChatTemplate`, `AppendToolsNode`, `AppendAgenticToolsNode`, `AppendLambda`, `AppendGraph`, `AppendParallel`, `AppendBranch`, `AppendPassthrough`, `AppendRetriever`, `AppendEmbedding`, `AppendLoader`, `AppendIndexer`, `AppendDocumentTransformer`.
 
 ## Workflow Quick Reference
 

--- a/skills/eino-compose/reference/chain.md
+++ b/skills/eino-compose/reference/chain.md
@@ -18,6 +18,7 @@ All Append methods return `*Chain[I, O]` for method chaining:
 chain.AppendChatModel(node model.BaseChatModel, opts ...GraphAddNodeOpt) *Chain[I, O]
 chain.AppendChatTemplate(node prompt.ChatTemplate, opts ...GraphAddNodeOpt) *Chain[I, O]
 chain.AppendToolsNode(node *compose.ToolsNode, opts ...GraphAddNodeOpt) *Chain[I, O]
+chain.AppendAgenticToolsNode(node *compose.AgenticToolsNode, opts ...GraphAddNodeOpt) *Chain[I, O]
 chain.AppendLambda(node *compose.Lambda, opts ...GraphAddNodeOpt) *Chain[I, O]
 chain.AppendRetriever(node retriever.Retriever, opts ...GraphAddNodeOpt) *Chain[I, O]
 chain.AppendEmbedding(node embedding.Embedder, opts ...GraphAddNodeOpt) *Chain[I, O]

--- a/skills/eino-compose/reference/graph.md
+++ b/skills/eino-compose/reference/graph.md
@@ -184,7 +184,7 @@ g.Compile(ctx,
     compose.WithCheckPointStore(store),       // Enable checkpointing
     compose.WithInterruptBeforeNodes([]string{"node1"}),
     compose.WithInterruptAfterNodes([]string{"node2"}),
-    compose.WithEagerExecution(),             // DAG mode: run nodes as soon as ready
+    // compose.WithEagerExecution(), // Deprecated: Eager execution is automatically enabled by default when a node's trigger mode is set to AllPredecessor.
 )
 ```
 
@@ -193,7 +193,7 @@ g.Compile(ctx,
 A minimal ReAct loop: model → branch (has tool calls?) → tools → model cycle.
 
 ```go
-func buildReActGraph(ctx context.Context, cm model.ToolCallingChatModel) (compose.Runnable[map[string]any, *schema.Message], error) {
+func buildReActGraph(ctx context.Context, cm model.BaseChatModel) (compose.Runnable[map[string]any, *schema.Message], error) {
     // Create ChatTemplate inline
     tpl := prompt.FromMessages(schema.FString,
         schema.SystemMessage("You are a helpful assistant."),

--- a/skills/eino-compose/reference/graph.md
+++ b/skills/eino-compose/reference/graph.md
@@ -20,6 +20,7 @@ Every `Add*Node` method takes a string key, the component instance, and optional
 g.AddChatModelNode(key string, node model.BaseChatModel, opts ...GraphAddNodeOpt) error
 g.AddChatTemplateNode(key string, node prompt.ChatTemplate, opts ...GraphAddNodeOpt) error
 g.AddToolsNode(key string, node *compose.ToolsNode, opts ...GraphAddNodeOpt) error
+g.AddAgenticToolsNode(key string, node *compose.AgenticToolsNode, opts ...GraphAddNodeOpt) error
 g.AddRetrieverNode(key string, node retriever.Retriever, opts ...GraphAddNodeOpt) error
 g.AddEmbeddingNode(key string, node embedding.Embedder, opts ...GraphAddNodeOpt) error
 g.AddIndexerNode(key string, node indexer.Indexer, opts ...GraphAddNodeOpt) error

--- a/skills/eino-guide/SKILL.md
+++ b/skills/eino-guide/SKILL.md
@@ -53,7 +53,7 @@ High-level abstractions for building AI agents. Encapsulates the model-tool-loop
 | **Runner** | Executes agents, manages checkpoints, emits event streams |
 | **Middleware (Handlers)** | Intercept and extend agent behavior (filesystem, summarization, plan-task, etc.) |
 | **Interrupt/Resume** | Human-in-the-loop: pause agent, get user input, resume from checkpoint |
-| **AgentAsTool** | Wrap an agent as a tool callable by another agent |
+| **AgentTool** | Wrap an agent as a tool callable by another agent |
 
 -> Use `/eino-agent` for building agents, configuring middleware, runners, and human-in-the-loop.
 

--- a/skills/eino-guide/SKILL.md
+++ b/skills/eino-guide/SKILL.md
@@ -80,7 +80,7 @@ Shared data types used across all layers:
 | Package | Contains |
 |---------|----------|
 | `schema` | Message, Document, ToolInfo, StreamReader |
-| `components/model` | ChatModel interfaces |
+| `components/model` | ChatModel and AgenticModel interfaces |
 | `components/tool` | Tool interfaces (BaseTool, InvokableTool, StreamableTool, Enhanced variants) |
 | `components/embedding` | Embedder interface |
 | `components/retriever` | Retriever interface |
@@ -129,5 +129,5 @@ Shared data types used across all layers:
 1. Route to the appropriate skill (`/eino-component`, `/eino-compose`, `/eino-agent`) when the question is specific. Consult the "Choosing Your Approach" table.
 2. Always provide Go code examples using real import paths from `github.com/cloudwego/eino` and `github.com/cloudwego/eino-ext`.
 3. For component implementation details, always read the provider's reference file before generating code. Do not assume constructor or config naming conventions.
-4. Prefer ADK (ChatModelAgent + Runner) for agent use cases over manually building ReAct loops with compose graphs.
+4. Prefer ADK (ChatModelAgent + Runner) for agent use cases over manually building ReAct loops with compose graphs. For interactive multi-turn applications needing preemption and lifecycle management, recommend TurnLoop.
 5. When showing streaming code, always include `defer stream.Close()`.

--- a/skills/eino-guide/reference/quick-start.md
+++ b/skills/eino-guide/reference/quick-start.md
@@ -173,8 +173,19 @@ func main() {
                 log.Fatal(event.Err)
             }
             if event.Output != nil && event.Output.MessageOutput != nil {
-                msg := event.Output.MessageOutput.Message
-                if msg != nil {
+                if event.Output.MessageOutput.IsStreaming {
+                    stream := event.Output.MessageOutput.MessageStream
+                    // Note: In real applications, stream should be closed properly
+                    for {
+                        chunk, err := stream.Recv()
+                        if err != nil {
+                            break
+                        }
+                        content += chunk.Content
+                        fmt.Print(chunk.Content)
+                    }
+                    stream.Close()
+                } else if msg := event.Output.MessageOutput.Message; msg != nil {
                     content += msg.Content
                     fmt.Print(msg.Content)
                 }
@@ -225,13 +236,10 @@ func main() {
     }
 
     // Create ChatTemplate
-    tpl, err := prompt.FromMessages(schema.Jinja2,
-        schema.SystemMessage("You are a {{role}} expert."),
-        schema.UserMessage("{{query}}"),
+    tpl := prompt.FromMessages(schema.FString,
+        schema.SystemMessage("You are a {role} expert."),
+        schema.UserMessage("{query}"),
     )
-    if err != nil {
-        log.Fatal(err)
-    }
 
     // Build a Chain: template -> model
     chain, err := compose.NewChain[map[string]any, *schema.Message]().

--- a/skills/eino-guide/reference/runnable.md
+++ b/skills/eino-guide/reference/runnable.md
@@ -5,10 +5,10 @@ All compiled Graph, Chain, and Workflow produce a `Runnable[I, O]`. This is the 
 ```go
 // github.com/cloudwego/eino/compose
 type Runnable[I, O any] interface {
-    Invoke(ctx context.Context, input I, opts ...Option) (O, error)
-    Stream(ctx context.Context, input I, opts ...Option) (*schema.StreamReader[O], error)
-    Collect(ctx context.Context, input *schema.StreamReader[I], opts ...Option) (O, error)
-    Transform(ctx context.Context, input *schema.StreamReader[I], opts ...Option) (*schema.StreamReader[O], error)
+    Invoke(ctx context.Context, input I, opts ...Option) (output O, err error)
+    Stream(ctx context.Context, input I, opts ...Option) (output *schema.StreamReader[O], err error)
+    Collect(ctx context.Context, input *schema.StreamReader[I], opts ...Option) (output O, err error)
+    Transform(ctx context.Context, input *schema.StreamReader[I], opts ...Option) (output *schema.StreamReader[O], err error)
 }
 ```
 
@@ -43,9 +43,7 @@ Use `compose.WithCallbacks` and `compose.WithCallOption` to pass per-request con
 ```go
 result, err := compiled.Invoke(ctx, input,
     compose.WithCallbacks(handler),
-    compose.WithCallOption(compose.NewCallOption(
-        compose.WithNodeCallOption("ChatModel", model.WithTemperature(0.7)),
-    )),
+    compose.WithChatModelOption(model.WithTemperature(0.7)).DesignateNode("ChatModel"),
 )
 ```
 

--- a/skills/eino-guide/reference/schema.md
+++ b/skills/eino-guide/reference/schema.md
@@ -12,11 +12,13 @@ type Message struct {
     Content                  string              // text content
     UserInputMultiContent    []MessageInputPart  // multimodal input from user (images, audio, etc.)
     AssistantGenMultiContent []MessageOutputPart // multi-part output from model (e.g., reasoning + text, audio + text). When non-empty, prefer this over Content/ReasoningContent.
+    Name                     string              // message name
     ToolCalls                []ToolCall          // tool calls requested by model (assistant only)
     ToolCallID               string              // identifies which tool call this message responds to (tool only)
     ToolName                 string              // tool name (tool only)
-    ReasoningContent         string              // model's reasoning/thinking content
     ResponseMeta             *ResponseMeta       // model response metadata (token usage, finish reason, etc.)
+    ReasoningContent         string              // model's reasoning/thinking content
+    Extra                    map[string]any      // customized information for model implementation
 }
 ```
 
@@ -187,7 +189,7 @@ schema.NewParamsOneOfByParams(map[string]*schema.ParameterInfo{
 })
 
 // Option B: use raw JSON Schema
-schema.NewParamsOneOfByJSONSchema(jsonSchemaBytes)
+schema.NewParamsOneOfByJSONSchema(schemaObj)
 ```
 
 ## StreamReader[T]

--- a/skills/eino-guide/reference/schema.md
+++ b/skills/eino-guide/reference/schema.md
@@ -57,6 +57,100 @@ type FunctionCall struct {
 }
 ```
 
+## AgenticMessage
+
+Block-based message type for the agentic path, providing lossless multimodal representation aligned with OpenAI Responses, Claude Message, and Gemini APIs.
+
+```go
+type AgenticMessage struct {
+    Role          AgenticRoleType      // system, user, assistant
+    ContentBlocks []*ContentBlock      // ordered typed content blocks
+    ResponseMeta  *AgenticResponseMeta // token usage, provider extensions
+    Extra         map[string]any
+}
+```
+
+### Roles
+
+| Role | Constant | Purpose |
+|------|----------|---------|
+| System | `schema.AgenticRoleTypeSystem` | Instructions to the model |
+| User | `schema.AgenticRoleTypeUser` | User input and tool results |
+| Assistant | `schema.AgenticRoleTypeAssistant` | Model output |
+
+Note: Unlike classic Message, there is no Tool role. Tool results are ContentBlocks within a User message.
+
+### ContentBlock (Tagged Union)
+
+```go
+type ContentBlock struct {
+    Type ContentBlockType  // discriminator
+
+    // Populated based on Type:
+    Reasoning          *Reasoning
+    UserInputText      *UserInputText
+    UserInputImage     *UserInputImage
+    UserInputAudio     *UserInputAudio
+    UserInputVideo     *UserInputVideo
+    UserInputFile      *UserInputFile
+    AssistantGenText   *AssistantGenText
+    AssistantGenImage  *AssistantGenImage
+    AssistantGenAudio  *AssistantGenAudio
+    AssistantGenVideo  *AssistantGenVideo
+    FunctionToolCall   *FunctionToolCall
+    FunctionToolResult *FunctionToolResult
+    ServerToolCall     *ServerToolCall
+    ServerToolResult   *ServerToolResult
+    MCPToolCall        *MCPToolCall
+    MCPToolResult      *MCPToolResult
+    // ... and more
+}
+```
+
+### Key ContentBlock Types
+
+| Type | Description |
+|------|-------------|
+| `ContentBlockTypeReasoning` | Model's chain-of-thought (Text + encrypted Signature) |
+| `ContentBlockTypeUserInputText` | Text input from user |
+| `ContentBlockTypeUserInputImage` | Image (URL or base64) |
+| `ContentBlockTypeAssistantGenText` | Generated text output |
+| `ContentBlockTypeFunctionToolCall` | Tool call (Name + Arguments JSON) |
+| `ContentBlockTypeFunctionToolResult` | Tool result (multimodal: text/image/audio/video/file) |
+| `ContentBlockTypeServerToolCall` | Provider built-in tool call (e.g., web_search) |
+| `ContentBlockTypeMCPToolCall` | MCP protocol tool call |
+
+### Constructors
+
+```go
+schema.SystemAgenticMessage("You are a helpful assistant.")
+schema.UserAgenticMessage("Hello")
+
+// Type-safe content block construction
+block := schema.NewContentBlock(&schema.FunctionToolCall{
+    CallID: "call_1", Name: "search", Arguments: `{"q":"go"}`,
+})
+```
+
+### Streaming
+
+```go
+// Concatenate streaming chunks into a single message
+fullMsg, err := schema.ConcatAgenticMessages(chunks)
+```
+
+### AgenticMessage vs Message
+
+| Aspect | Message | AgenticMessage |
+|--------|---------|----------------|
+| Content model | String + MultiContent | `[]*ContentBlock` (typed union) |
+| Tool calls | `ToolCalls []ToolCall` on assistant | `FunctionToolCall` content blocks |
+| Tool results | Separate Tool-role message | `FunctionToolResult` block in user message |
+| MCP support | Not native | Native (`MCPToolCall`, `MCPToolResult`, approval flow) |
+| Server tools | Not native | Native (`ServerToolCall`, `ServerToolResult`) |
+| Reasoning | `ReasoningContent` string | `Reasoning` block with Text + Signature |
+| Multimodal results | Text only | Text, image, audio, video, file |
+
 ## Document
 
 Unit of data for RAG pipelines.


### PR DESCRIPTION
## Summary

Update all four ADK skills (`eino-agent`, `eino-component`, `eino-compose`, `eino-guide`) to document the v0.9 "agentic-runtime" release.

| Problem | Solution |
|---------|----------|
| Skills reference outdated v0.8 APIs (ToolCallingChatModel, no cancel/retry) | Rewrite eino-agent skill with generic MessageType, Cancel, Retry, Failover, TurnLoop |
| No documentation for AgenticModel providers | Add AgenticModel section to eino-component with 5 providers |
| AgenticToolsNode undocumented in compose | Add AgenticToolsNode section to eino-compose |
| Guide doesn't mention v0.9 concepts | Update eino-guide with AgenticMessage, TurnLoop, enhanced ChatModelAgent |

## Key Insight

The v0.9 ADK introduces a dual-path architecture (`*schema.Message` vs `*schema.AgenticMessage`) via a generic `MessageType` constraint. All skills needed updates to reflect that the ADK is now parameterized — the `Agent` interface, middleware, runner, and events are all generic types with convenience aliases for the classic path. The skill documentation deliberately shows both the generic typed APIs and the classic aliases to help users understand the system without forcing migration.

## Changes

### eino-agent (primary focus)
- **SKILL.md**: Complete rewrite — generic `TypedAgent[M]` interface, `model.BaseModel[M]`, Cancel mechanism (CancelMode, safe points), Model Retry (output-based ShouldRetry), Model Failover (GetFailoverModel), TurnLoop (push/preempt/idle/shutdown), Agents.md middleware
- **reference/chat-model-agent.md**: Updated config struct, added Cancel/Retry/Failover/WithAfterToolCallsHook/WithHistoryModifier sections
- **reference/middleware.md**: Typed interface with AfterAgent, WrapEnhanced* methods, Agents.md middleware, run-local state, event emission
- **reference/runner-and-events.md**: Typed events/input, cancel-aware handling, typed Runner for AgenticMessage, updated Agent interface (no ctx on Name/Description)

### eino-component
- **SKILL.md**: Added AgenticModel section (BaseModel[*schema.AgenticMessage] type alias), 5 providers (agenticopenai, agenticgemini, agenticdeepseek, agenticark, agenticqwen), usage example with model.WithTools at call time

### eino-compose
- **SKILL.md**: Added AgenticToolsNode section, AddAgenticToolsNode/AppendAgenticToolsNode in Graph/Chain references

### eino-guide
- **SKILL.md**: AgenticModel in component table, Cancel/Retry/Failover and TurnLoop in ADK table, schema.AgenticMessage in Schema section, new scenarios in "Choosing Your Approach"
- **reference/schema.md**: Full AgenticMessage documentation (struct, ContentBlock tagged union, key types, constructors, streaming, comparison table)

---

## 概要

更新全部四个 ADK skills（`eino-agent`、`eino-component`、`eino-compose`、`eino-guide`）以对齐 v0.9 "agentic-runtime" 版本的 API 变更。

| 问题 | 方案 |
|------|------|
| Skills 引用过时的 v0.8 API（ToolCallingChatModel、无 cancel/retry） | 重写 eino-agent skill，包含泛型 MessageType、Cancel、Retry、Failover、TurnLoop |
| 缺少 AgenticModel 提供者文档 | 在 eino-component 中新增 AgenticModel 章节，涵盖 5 个 provider |
| compose 中 AgenticToolsNode 无文档 | 在 eino-compose 中新增 AgenticToolsNode 章节 |
| Guide 未提及 v0.9 新概念 | 更新 eino-guide，新增 AgenticMessage、TurnLoop、增强版 ChatModelAgent |

## 核心洞察

v0.9 ADK 引入了双路径架构（`*schema.Message` vs `*schema.AgenticMessage`），通过泛型 `MessageType` 约束实现。所有 skill 都需要更新以反映 ADK 现在是参数化的——Agent 接口、中间件、Runner 和事件类型均为泛型类型，并提供经典路径的便捷别名。文档同时展示泛型 typed API 和经典别名，帮助用户理解系统而不强制迁移。
