### PR TITLE
feat(gemini): add WithPrefixCacheTTL for CreatePrefixCache

### DIFF
--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. Use `UpdatePrefixCache` with `gemini.WithPrefixCacheUpdateTTL(...)` or `gemini.WithPrefixCacheUpdateExpireTime(...)` to extend an existing cache without recreating it. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Configure TTL and absolute expiry via `CacheConfig` (`TTL`, `ExpireTime`). When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call TTL can override it with `gemini.WithPrefixCacheTTL(...)`. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. Use `UpdatePrefixCache` with the same options to extend an existing cache without recreating it. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. Use `UpdatePrefixCache` with the same options to extend an existing cache without recreating it. Use `DeletePrefixCache` to remove a cache manually. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call TTL can override it with `gemini.WithPrefixCacheTTL(...)`. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. Use `UpdatePrefixCache` with `gemini.WithPrefixCacheUpdateTTL(...)` or `gemini.WithPrefixCacheUpdateExpireTime(...)` to extend an existing cache without recreating it. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Default TTL can be set via `CacheConfig.TTL`; per-call overrides are available via `gemini.WithPrefixCacheTTL(...)` or `gemini.WithPrefixCacheExpireTime(...)`. Use `UpdatePrefixCache` with the same options to extend an existing cache without recreating it. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次调用也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。`UpdatePrefixCache` 使用相同 option 延长已有缓存而无需重建。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次调用也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。`UpdatePrefixCache` 使用相同 option 延长已有缓存而无需重建。`DeletePrefixCache` 可手动删除缓存。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 覆盖。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。使用 `UpdatePrefixCache` 配合 `gemini.WithPrefixCacheUpdateTTL(...)` 或 `gemini.WithPrefixCacheUpdateExpireTime(...)` 延长已有缓存而无需重建。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。通过 `CacheConfig`（`TTL`、`ExpireTime`）配置 TTL 和绝对到期时间。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 覆盖。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次创建也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。使用 `UpdatePrefixCache` 配合 `gemini.WithPrefixCacheUpdateTTL(...)` 或 `gemini.WithPrefixCacheUpdateExpireTime(...)` 延长已有缓存而无需重建。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。默认 TTL 可通过 `CacheConfig.TTL` 配置；单次调用也可用 `gemini.WithPrefixCacheTTL(...)` 或 `gemini.WithPrefixCacheExpireTime(...)` 覆盖。`UpdatePrefixCache` 使用相同 option 延长已有缓存而无需重建。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -403,6 +403,20 @@ func (cm *ChatModel) UpdatePrefixCache(ctx context.Context, name string, opts ..
 	return cachedContent, nil
 }
 
+// DeletePrefixCache deletes an existing prefix cache.
+// See https://ai.google.dev/gemini-api/docs/caching#delete-cache
+func (cm *ChatModel) DeletePrefixCache(ctx context.Context, name string) error {
+	if name == "" {
+		return fmt.Errorf("DeletePrefixCache: cache name is required")
+	}
+
+	_, err := cm.cli.Caches.Delete(ctx, name, &genai.DeleteCachedContentConfig{})
+	if err != nil {
+		return fmt.Errorf("delete cache failed: %w", err)
+	}
+	return nil
+}
+
 func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
 	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
 	if cm.cache != nil {

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -381,6 +381,28 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 	return cachedContent, nil
 }
 
+// UpdatePrefixCache updates TTL or expire time of an existing prefix cache.
+// See https://ai.google.dev/gemini-api/docs/caching#update-cache
+func (cm *ChatModel) UpdatePrefixCache(ctx context.Context, name string, opts ...model.Option) (*genai.CachedContent, error) {
+	if name == "" {
+		return nil, fmt.Errorf("UpdatePrefixCache: cache name is required")
+	}
+
+	ttl, expireTime := cm.resolvePrefixCacheUpdateConfig(opts...)
+	if ttl == 0 && expireTime.IsZero() {
+		return nil, fmt.Errorf("UpdatePrefixCache requires WithPrefixCacheUpdateTTL or WithPrefixCacheUpdateExpireTime")
+	}
+
+	cachedContent, err := cm.cli.Caches.Update(ctx, name, &genai.UpdateCachedContentConfig{
+		TTL:        ttl,
+		ExpireTime: expireTime,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update cache failed: %w", err)
+	}
+	return cachedContent, nil
+}
+
 func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
 	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
 	if cm.cache != nil {
@@ -396,6 +418,27 @@ func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Du
 	if geminiOptions.PrefixCacheExpireTime != nil {
 		expireTime = *geminiOptions.PrefixCacheExpireTime
 		if geminiOptions.PrefixCacheTTL == nil {
+			ttl = 0
+		}
+	}
+	return ttl, expireTime
+}
+
+func (cm *ChatModel) resolvePrefixCacheUpdateConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
+	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
+	if cm.cache != nil {
+		ttl = cm.cache.TTL
+		expireTime = cm.cache.ExpireTime
+	}
+	if geminiOptions.PrefixCacheUpdateTTL != nil {
+		ttl = *geminiOptions.PrefixCacheUpdateTTL
+		if geminiOptions.PrefixCacheUpdateExpireTime == nil {
+			expireTime = time.Time{}
+		}
+	}
+	if geminiOptions.PrefixCacheUpdateExpireTime != nil {
+		expireTime = *geminiOptions.PrefixCacheUpdateExpireTime
+		if geminiOptions.PrefixCacheUpdateTTL == nil {
 			ttl = 0
 		}
 	}

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -388,9 +388,9 @@ func (cm *ChatModel) UpdatePrefixCache(ctx context.Context, name string, opts ..
 		return nil, fmt.Errorf("UpdatePrefixCache: cache name is required")
 	}
 
-	ttl, expireTime := cm.resolvePrefixCacheUpdateConfig(opts...)
+	ttl, expireTime := cm.resolvePrefixCacheConfig(opts...)
 	if ttl == 0 && expireTime.IsZero() {
-		return nil, fmt.Errorf("UpdatePrefixCache requires WithPrefixCacheUpdateTTL or WithPrefixCacheUpdateExpireTime")
+		return nil, fmt.Errorf("UpdatePrefixCache requires WithPrefixCacheTTL or WithPrefixCacheExpireTime")
 	}
 
 	cachedContent, err := cm.cli.Caches.Update(ctx, name, &genai.UpdateCachedContentConfig{
@@ -418,27 +418,6 @@ func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Du
 	if geminiOptions.PrefixCacheExpireTime != nil {
 		expireTime = *geminiOptions.PrefixCacheExpireTime
 		if geminiOptions.PrefixCacheTTL == nil {
-			ttl = 0
-		}
-	}
-	return ttl, expireTime
-}
-
-func (cm *ChatModel) resolvePrefixCacheUpdateConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
-	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
-	if cm.cache != nil {
-		ttl = cm.cache.TTL
-		expireTime = cm.cache.ExpireTime
-	}
-	if geminiOptions.PrefixCacheUpdateTTL != nil {
-		ttl = *geminiOptions.PrefixCacheUpdateTTL
-		if geminiOptions.PrefixCacheUpdateExpireTime == nil {
-			expireTime = time.Time{}
-		}
-	}
-	if geminiOptions.PrefixCacheUpdateExpireTime != nil {
-		expireTime = *geminiOptions.PrefixCacheUpdateExpireTime
-		if geminiOptions.PrefixCacheUpdateTTL == nil {
 			ttl = 0
 		}
 	}

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -364,29 +364,32 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 		return nil, err
 	}
 
+	ttl, expireTime := cm.resolvePrefixCacheConfig(opts...)
+
 	cachedContent, err := cm.cli.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genaiConf.SystemInstruction,
 		Tools:             genaiConf.Tools,
 		ToolConfig:        genaiConf.ToolConfig,
-		TTL: func() time.Duration {
-			if cm.cache != nil {
-				return cm.cache.TTL
-			}
-			return 0
-		}(),
-		ExpireTime: func() time.Time {
-			if cm.cache != nil {
-				return cm.cache.ExpireTime
-			}
-			return time.Time{}
-		}(),
+		TTL:               ttl,
+		ExpireTime:        expireTime,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create cache failed: %w", err)
 	}
 
 	return cachedContent, nil
+}
+
+func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
+	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
+	if geminiOptions.PrefixCacheTTL != nil {
+		return *geminiOptions.PrefixCacheTTL, time.Time{}
+	}
+	if cm.cache != nil {
+		return cm.cache.TTL, cm.cache.ExpireTime
+	}
+	return 0, time.Time{}
 }
 
 func populateToolChoice(m *genai.GenerateContentConfig, toolChoice *schema.ToolChoice, allowedToolNames []string) error {

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -382,22 +382,24 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 }
 
 func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
-	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
+	defaults := &options{}
 	if cm.cache != nil {
-		ttl = cm.cache.TTL
-		expireTime = cm.cache.ExpireTime
-	}
-	if geminiOptions.PrefixCacheTTL != nil {
-		ttl = *geminiOptions.PrefixCacheTTL
-		if geminiOptions.PrefixCacheExpireTime == nil {
-			expireTime = time.Time{}
+		if cm.cache.TTL != 0 {
+			ttlDefault := cm.cache.TTL
+			defaults.PrefixCacheTTL = &ttlDefault
+		}
+		if !cm.cache.ExpireTime.IsZero() {
+			expireDefault := cm.cache.ExpireTime
+			defaults.PrefixCacheExpireTime = &expireDefault
 		}
 	}
-	if geminiOptions.PrefixCacheExpireTime != nil {
-		expireTime = *geminiOptions.PrefixCacheExpireTime
-		if geminiOptions.PrefixCacheTTL == nil {
-			ttl = 0
-		}
+
+	merged := model.GetImplSpecificOptions(defaults, opts...)
+	if merged.PrefixCacheTTL != nil {
+		ttl = *merged.PrefixCacheTTL
+	}
+	if merged.PrefixCacheExpireTime != nil {
+		expireTime = *merged.PrefixCacheExpireTime
 	}
 	return ttl, expireTime
 }

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -383,13 +383,23 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 
 func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
 	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
-	if geminiOptions.PrefixCacheTTL != nil {
-		return *geminiOptions.PrefixCacheTTL, time.Time{}
-	}
 	if cm.cache != nil {
-		return cm.cache.TTL, cm.cache.ExpireTime
+		ttl = cm.cache.TTL
+		expireTime = cm.cache.ExpireTime
 	}
-	return 0, time.Time{}
+	if geminiOptions.PrefixCacheTTL != nil {
+		ttl = *geminiOptions.PrefixCacheTTL
+		if geminiOptions.PrefixCacheExpireTime == nil {
+			expireTime = time.Time{}
+		}
+	}
+	if geminiOptions.PrefixCacheExpireTime != nil {
+		expireTime = *geminiOptions.PrefixCacheExpireTime
+		if geminiOptions.PrefixCacheTTL == nil {
+			ttl = 0
+		}
+	}
+	return ttl, expireTime
 }
 
 func populateToolChoice(m *genai.GenerateContentConfig, toolChoice *schema.ToolChoice, allowedToolNames []string) error {

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -382,24 +382,22 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 }
 
 func (cm *ChatModel) resolvePrefixCacheConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
-	defaults := &options{}
+	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
 	if cm.cache != nil {
-		if cm.cache.TTL != 0 {
-			ttlDefault := cm.cache.TTL
-			defaults.PrefixCacheTTL = &ttlDefault
-		}
-		if !cm.cache.ExpireTime.IsZero() {
-			expireDefault := cm.cache.ExpireTime
-			defaults.PrefixCacheExpireTime = &expireDefault
+		ttl = cm.cache.TTL
+		expireTime = cm.cache.ExpireTime
+	}
+	if geminiOptions.PrefixCacheTTL != nil {
+		ttl = *geminiOptions.PrefixCacheTTL
+		if geminiOptions.PrefixCacheExpireTime == nil {
+			expireTime = time.Time{}
 		}
 	}
-
-	merged := model.GetImplSpecificOptions(defaults, opts...)
-	if merged.PrefixCacheTTL != nil {
-		ttl = *merged.PrefixCacheTTL
-	}
-	if merged.PrefixCacheExpireTime != nil {
-		expireTime = *merged.PrefixCacheExpireTime
+	if geminiOptions.PrefixCacheExpireTime != nil {
+		expireTime = *geminiOptions.PrefixCacheExpireTime
+		if geminiOptions.PrefixCacheTTL == nil {
+			ttl = 0
+		}
 	}
 	return ttl, expireTime
 }

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1035,7 +1035,7 @@ func TestCreatePrefixCache(t *testing.T) {
 		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheExpireTime(optionExpire))
 		assert.NoError(t, err)
 		assert.NotNil(t, cache)
-		assert.Equal(t, time.Duration(0), cacheConfig.TTL)
+		assert.Equal(t, time.Minute, cacheConfig.TTL)
 		assert.Equal(t, optionExpire, cacheConfig.ExpireTime)
 	})
 

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1100,6 +1100,62 @@ func TestCreatePrefixCache(t *testing.T) {
 	})
 }
 
+func TestUpdatePrefixCache(t *testing.T) {
+	t.Run("update_ttl", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		var updateConfig *genai.UpdateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Update).
+			To(func(ctx context.Context, name string, config *genai.UpdateCachedContentConfig) (*genai.CachedContent, error) {
+				updateConfig = config
+				return &genai.CachedContent{Name: name}, nil
+			}).Build().Patch().UnPatch()
+
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateTTL(2*time.Hour))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, "cachedContents/abc", cache.Name)
+		assert.Equal(t, 2*time.Hour, updateConfig.TTL)
+		assert.True(t, updateConfig.ExpireTime.IsZero())
+	})
+
+	t.Run("update_expire_time", func(t *testing.T) {
+		ctx := context.Background()
+		configExpire := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		optionExpire := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		cm, err := NewChatModel(ctx, &Config{
+			Client: &genai.Client{Caches: &genai.Caches{}},
+			Model:  "test-model",
+			Cache:  &CacheConfig{TTL: time.Minute, ExpireTime: configExpire},
+		})
+		assert.Nil(t, err)
+
+		var updateConfig *genai.UpdateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Update).
+			To(func(ctx context.Context, name string, config *genai.UpdateCachedContentConfig) (*genai.CachedContent, error) {
+				updateConfig = config
+				return &genai.CachedContent{Name: name, ExpireTime: config.ExpireTime}, nil
+			}).Build().Patch().UnPatch()
+
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateExpireTime(optionExpire))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, time.Duration(0), updateConfig.TTL)
+		assert.Equal(t, optionExpire, updateConfig.ExpireTime)
+	})
+
+	t.Run("missing_ttl_and_expire_time", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		_, err = cm.UpdatePrefixCache(ctx, "cachedContents/abc")
+		assert.Error(t, err)
+	})
+}
+
 func TestSpecialPart(t *testing.T) {
 	msg, err := convCandidate(&genai.Candidate{
 		Content: &genai.Content{

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -989,56 +989,6 @@ func TestCreatePrefixCache(t *testing.T) {
 
 	})
 
-	t.Run("prefix_cache_ttl_option_overrides_config", func(t *testing.T) {
-		ctx := context.Background()
-		cm, err := NewChatModel(ctx, &Config{
-			Client: &genai.Client{Caches: &genai.Caches{}},
-			Model:  "test-model",
-			Cache:  &CacheConfig{TTL: time.Minute},
-		})
-		assert.Nil(t, err)
-
-		var cacheConfig *genai.CreateCachedContentConfig
-		defer mockey.Mock(genai.Caches.Create).
-			To(func(ctx context.Context, model string, config *genai.CreateCachedContentConfig) (*genai.CachedContent, error) {
-				cacheConfig = config
-				return &genai.CachedContent{Name: "cached/ttl_option"}, nil
-			}).Build().Patch().UnPatch()
-
-		prefixMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
-		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheTTL(2*time.Hour))
-		assert.NoError(t, err)
-		assert.NotNil(t, cache)
-		assert.Equal(t, 2*time.Hour, cacheConfig.TTL)
-		assert.True(t, cacheConfig.ExpireTime.IsZero())
-	})
-
-	t.Run("prefix_cache_expire_time_option_overrides_config", func(t *testing.T) {
-		ctx := context.Background()
-		configExpire := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-		optionExpire := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
-		cm, err := NewChatModel(ctx, &Config{
-			Client: &genai.Client{Caches: &genai.Caches{}},
-			Model:  "test-model",
-			Cache:  &CacheConfig{TTL: time.Minute, ExpireTime: configExpire},
-		})
-		assert.Nil(t, err)
-
-		var cacheConfig *genai.CreateCachedContentConfig
-		defer mockey.Mock(genai.Caches.Create).
-			To(func(ctx context.Context, model string, config *genai.CreateCachedContentConfig) (*genai.CachedContent, error) {
-				cacheConfig = config
-				return &genai.CachedContent{Name: "cached/expire_option"}, nil
-			}).Build().Patch().UnPatch()
-
-		prefixMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
-		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheExpireTime(optionExpire))
-		assert.NoError(t, err)
-		assert.NotNil(t, cache)
-		assert.Equal(t, time.Duration(0), cacheConfig.TTL)
-		assert.Equal(t, optionExpire, cacheConfig.ExpireTime)
-	})
-
 	t.Run("cache_and_generate", func(t *testing.T) {
 		ctx := context.Background()
 		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{
@@ -1113,7 +1063,7 @@ func TestUpdatePrefixCache(t *testing.T) {
 				return &genai.CachedContent{Name: name}, nil
 			}).Build().Patch().UnPatch()
 
-		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateTTL(2*time.Hour))
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheTTL(2*time.Hour))
 		assert.NoError(t, err)
 		assert.NotNil(t, cache)
 		assert.Equal(t, "cachedContents/abc", cache.Name)
@@ -1139,7 +1089,7 @@ func TestUpdatePrefixCache(t *testing.T) {
 				return &genai.CachedContent{Name: name, ExpireTime: config.ExpireTime}, nil
 			}).Build().Patch().UnPatch()
 
-		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateExpireTime(optionExpire))
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheExpireTime(optionExpire))
 		assert.NoError(t, err)
 		assert.NotNil(t, cache)
 		assert.Equal(t, time.Duration(0), updateConfig.TTL)

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1035,7 +1035,7 @@ func TestCreatePrefixCache(t *testing.T) {
 		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheExpireTime(optionExpire))
 		assert.NoError(t, err)
 		assert.NotNil(t, cache)
-		assert.Equal(t, time.Minute, cacheConfig.TTL)
+		assert.Equal(t, time.Duration(0), cacheConfig.TTL)
 		assert.Equal(t, optionExpire, cacheConfig.ExpireTime)
 	})
 

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1013,6 +1013,32 @@ func TestCreatePrefixCache(t *testing.T) {
 		assert.True(t, cacheConfig.ExpireTime.IsZero())
 	})
 
+	t.Run("prefix_cache_expire_time_option_overrides_config", func(t *testing.T) {
+		ctx := context.Background()
+		configExpire := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		optionExpire := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		cm, err := NewChatModel(ctx, &Config{
+			Client: &genai.Client{Caches: &genai.Caches{}},
+			Model:  "test-model",
+			Cache:  &CacheConfig{TTL: time.Minute, ExpireTime: configExpire},
+		})
+		assert.Nil(t, err)
+
+		var cacheConfig *genai.CreateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Create).
+			To(func(ctx context.Context, model string, config *genai.CreateCachedContentConfig) (*genai.CachedContent, error) {
+				cacheConfig = config
+				return &genai.CachedContent{Name: "cached/expire_option"}, nil
+			}).Build().Patch().UnPatch()
+
+		prefixMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
+		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheExpireTime(optionExpire))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, time.Duration(0), cacheConfig.TTL)
+		assert.Equal(t, optionExpire, cacheConfig.ExpireTime)
+	})
+
 	t.Run("cache_and_generate", func(t *testing.T) {
 		ctx := context.Background()
 		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -989,6 +989,30 @@ func TestCreatePrefixCache(t *testing.T) {
 
 	})
 
+	t.Run("prefix_cache_ttl_option_overrides_config", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{
+			Client: &genai.Client{Caches: &genai.Caches{}},
+			Model:  "test-model",
+			Cache:  &CacheConfig{TTL: time.Minute},
+		})
+		assert.Nil(t, err)
+
+		var cacheConfig *genai.CreateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Create).
+			To(func(ctx context.Context, model string, config *genai.CreateCachedContentConfig) (*genai.CachedContent, error) {
+				cacheConfig = config
+				return &genai.CachedContent{Name: "cached/ttl_option"}, nil
+			}).Build().Patch().UnPatch()
+
+		prefixMsgs := []*schema.Message{{Role: schema.User, Content: "hello"}}
+		cache, err := cm.CreatePrefixCache(ctx, prefixMsgs, WithPrefixCacheTTL(2*time.Hour))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, 2*time.Hour, cacheConfig.TTL)
+		assert.True(t, cacheConfig.ExpireTime.IsZero())
+	})
+
 	t.Run("cache_and_generate", func(t *testing.T) {
 		ctx := context.Background()
 		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1106,6 +1106,34 @@ func TestUpdatePrefixCache(t *testing.T) {
 	})
 }
 
+func TestDeletePrefixCache(t *testing.T) {
+	t.Run("delete", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		var deletedName string
+		defer mockey.Mock(genai.Caches.Delete).
+			To(func(ctx context.Context, name string, config *genai.DeleteCachedContentConfig) (*genai.DeleteCachedContentResponse, error) {
+				deletedName = name
+				return &genai.DeleteCachedContentResponse{}, nil
+			}).Build().Patch().UnPatch()
+
+		err = cm.DeletePrefixCache(ctx, "cachedContents/abc")
+		assert.NoError(t, err)
+		assert.Equal(t, "cachedContents/abc", deletedName)
+	})
+
+	t.Run("missing_name", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		err = cm.DeletePrefixCache(ctx, "")
+		assert.Error(t, err)
+	})
+}
+
 func TestSpecialPart(t *testing.T) {
 	msg, err := convCandidate(&genai.Candidate{
 		Content: &genai.Content{

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -76,26 +76,13 @@ func WithPrefixCacheTTL(ttl time.Duration) model.Option {
 	})
 }
 
-// WithPrefixCacheExpireTime sets the absolute expiry for CreatePrefixCache on this call.
-// When set, it overrides Config.Cache.ExpireTime for that CreatePrefixCache invocation.
+// WithPrefixCacheExpireTime sets the absolute expiry for CreatePrefixCache or UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.ExpireTime for that invocation.
 func WithPrefixCacheExpireTime(expireTime time.Time) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.PrefixCacheExpireTime = &expireTime
 	})
 }
-
-// WithPrefixCacheUpdateTTL sets the TTL for UpdatePrefixCache on this call.
-// When set, it overrides Config.Cache.TTL for that UpdatePrefixCache invocation.
-func WithPrefixCacheUpdateTTL(ttl time.Duration) model.Option {
-	return WithPrefixCacheTTL(ttl)
-}
-
-// WithPrefixCacheUpdateExpireTime sets the absolute expiry for UpdatePrefixCache on this call.
-// When set, it overrides Config.Cache.ExpireTime for that UpdatePrefixCache invocation.
-func WithPrefixCacheUpdateExpireTime(expireTime time.Time) model.Option {
-	return WithPrefixCacheExpireTime(expireTime)
-}
-
 // WithImageConfig sets the image generation configuration.
 // Note: an error will be returned for a model that does not support the configuration options.
 // Optional.

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -17,6 +17,8 @@
 package gemini
 
 import (
+	"time"
+
 	"github.com/eino-contrib/jsonschema"
 	"google.golang.org/genai"
 
@@ -30,6 +32,7 @@ type options struct {
 	ResponseModalities []GeminiResponseModality
 	ImageConfig        *genai.ImageConfig
 	CachedContentName  string
+	PrefixCacheTTL     *time.Duration
 }
 
 func WithTopK(k int32) model.Option {
@@ -61,6 +64,14 @@ func WithResponseModalities(m []GeminiResponseModality) model.Option {
 func WithCachedContentName(name string) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.CachedContentName = name
+	})
+}
+
+// WithPrefixCacheTTL sets the TTL for CreatePrefixCache on this call.
+// When set, it overrides Config.Cache.TTL for that CreatePrefixCache invocation.
+func WithPrefixCacheTTL(ttl time.Duration) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheTTL = &ttl
 	})
 }
 

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -26,14 +26,16 @@ import (
 )
 
 type options struct {
-	TopK               *int32
-	ResponseJSONSchema *jsonschema.Schema
-	ThinkingConfig     *genai.ThinkingConfig
-	ResponseModalities []GeminiResponseModality
-	ImageConfig        *genai.ImageConfig
-	CachedContentName       string
-	PrefixCacheTTL          *time.Duration
-	PrefixCacheExpireTime   *time.Time
+	TopK                        *int32
+	ResponseJSONSchema          *jsonschema.Schema
+	ThinkingConfig              *genai.ThinkingConfig
+	ResponseModalities          []GeminiResponseModality
+	ImageConfig                 *genai.ImageConfig
+	CachedContentName           string
+	PrefixCacheTTL              *time.Duration
+	PrefixCacheExpireTime       *time.Time
+	PrefixCacheUpdateTTL        *time.Duration
+	PrefixCacheUpdateExpireTime *time.Time
 }
 
 func WithTopK(k int32) model.Option {
@@ -81,6 +83,22 @@ func WithPrefixCacheTTL(ttl time.Duration) model.Option {
 func WithPrefixCacheExpireTime(expireTime time.Time) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.PrefixCacheExpireTime = &expireTime
+	})
+}
+
+// WithPrefixCacheUpdateTTL sets the TTL for UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.TTL for that UpdatePrefixCache invocation.
+func WithPrefixCacheUpdateTTL(ttl time.Duration) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheUpdateTTL = &ttl
+	})
+}
+
+// WithPrefixCacheUpdateExpireTime sets the absolute expiry for UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.ExpireTime for that UpdatePrefixCache invocation.
+func WithPrefixCacheUpdateExpireTime(expireTime time.Time) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheUpdateExpireTime = &expireTime
 	})
 }
 

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -32,10 +32,8 @@ type options struct {
 	ResponseModalities          []GeminiResponseModality
 	ImageConfig                 *genai.ImageConfig
 	CachedContentName           string
-	PrefixCacheTTL              *time.Duration
-	PrefixCacheExpireTime       *time.Time
-	PrefixCacheUpdateTTL        *time.Duration
-	PrefixCacheUpdateExpireTime *time.Time
+	PrefixCacheTTL        *time.Duration
+	PrefixCacheExpireTime *time.Time
 }
 
 func WithTopK(k int32) model.Option {
@@ -70,8 +68,8 @@ func WithCachedContentName(name string) model.Option {
 	})
 }
 
-// WithPrefixCacheTTL sets the TTL for CreatePrefixCache on this call.
-// When set, it overrides Config.Cache.TTL for that CreatePrefixCache invocation.
+// WithPrefixCacheTTL sets the TTL for CreatePrefixCache or UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.TTL for that invocation.
 func WithPrefixCacheTTL(ttl time.Duration) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.PrefixCacheTTL = &ttl
@@ -89,17 +87,13 @@ func WithPrefixCacheExpireTime(expireTime time.Time) model.Option {
 // WithPrefixCacheUpdateTTL sets the TTL for UpdatePrefixCache on this call.
 // When set, it overrides Config.Cache.TTL for that UpdatePrefixCache invocation.
 func WithPrefixCacheUpdateTTL(ttl time.Duration) model.Option {
-	return model.WrapImplSpecificOptFn(func(o *options) {
-		o.PrefixCacheUpdateTTL = &ttl
-	})
+	return WithPrefixCacheTTL(ttl)
 }
 
 // WithPrefixCacheUpdateExpireTime sets the absolute expiry for UpdatePrefixCache on this call.
 // When set, it overrides Config.Cache.ExpireTime for that UpdatePrefixCache invocation.
 func WithPrefixCacheUpdateExpireTime(expireTime time.Time) model.Option {
-	return model.WrapImplSpecificOptFn(func(o *options) {
-		o.PrefixCacheUpdateExpireTime = &expireTime
-	})
+	return WithPrefixCacheExpireTime(expireTime)
 }
 
 // WithImageConfig sets the image generation configuration.

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -31,8 +31,9 @@ type options struct {
 	ThinkingConfig     *genai.ThinkingConfig
 	ResponseModalities []GeminiResponseModality
 	ImageConfig        *genai.ImageConfig
-	CachedContentName  string
-	PrefixCacheTTL     *time.Duration
+	CachedContentName       string
+	PrefixCacheTTL          *time.Duration
+	PrefixCacheExpireTime   *time.Time
 }
 
 func WithTopK(k int32) model.Option {
@@ -72,6 +73,14 @@ func WithCachedContentName(name string) model.Option {
 func WithPrefixCacheTTL(ttl time.Duration) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.PrefixCacheTTL = &ttl
+	})
+}
+
+// WithPrefixCacheExpireTime sets the absolute expiry for CreatePrefixCache on this call.
+// When set, it overrides Config.Cache.ExpireTime for that CreatePrefixCache invocation.
+func WithPrefixCacheExpireTime(expireTime time.Time) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheExpireTime = &expireTime
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `gemini.WithPrefixCacheTTL(duration)` so callers can set prefix cache TTL per `CreatePrefixCache` invocation, similar to `openairesponse.WithPromptCacheRetention`.
- Extract `resolvePrefixCacheConfig` to merge call-time option with `Config.Cache` defaults (option takes precedence; clears `ExpireTime` when TTL option is set).
- Add unit test and update README.

## Motivation
Prefix cache TTL is often tied to a specific use case (e.g. chapter reviewer) rather than the shared chat model instance. Today TTL can only be configured at `NewChatModel` via `Config.Cache`, which forces all `CreatePrefixCache` calls on that model to share the same TTL.

## Test plan
- [x] `go test -run TestCreatePrefixCache ./components/model/gemini/...`


Made with [Cursor](https://cursor.com)