### PR TITLE
feat(gemini): add UpdatePrefixCache for cached content TTL extension

### DIFF
--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 This component supports two caching strategies to improve latency and reduce API calls:
 
-- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Configure TTL and absolute expiry via `CacheConfig` (`TTL`, `ExpireTime`). When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
+- Explicit caching (prefix cache): Build a reusable context from the system instruction, tools, and messages. Use `CreatePrefixCache` to create the cache and pass its name with `gemini.WithCachedContentName(...)` in subsequent requests. Configure TTL and absolute expiry via `CacheConfig` (`TTL`, `ExpireTime`). Use `UpdatePrefixCache` with `gemini.WithPrefixCacheUpdateTTL(...)` or `gemini.WithPrefixCacheUpdateExpireTime(...)` to extend an existing cache without recreating it. When a cached content is used, the request omits system instruction and tools and relies on the cached prefix.
 - Implicit caching: Managed by Gemini itself. The service may reuse prior requests or responses automatically. Expiry and reuse are controlled by Gemini and cannot be configured.
 
 ```

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -220,7 +220,7 @@ type CacheConfig struct {
 
 该组件支持两种缓存策略以提高延迟并减少 API 调用：
 
-- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。通过 `CacheConfig`（`TTL`、`ExpireTime`）配置 TTL 和绝对到期时间。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
+- 显式缓存（前缀缓存）：从系统指令、工具和消息中构建可重用的上下文。使用 `CreatePrefixCache` 创建缓存，并在后续请求中使用 `gemini.WithCachedContentName(...)` 传递其名称。通过 `CacheConfig`（`TTL`、`ExpireTime`）配置 TTL 和绝对到期时间。使用 `UpdatePrefixCache` 配合 `gemini.WithPrefixCacheUpdateTTL(...)` 或 `gemini.WithPrefixCacheUpdateExpireTime(...)` 延长已有缓存而无需重建。当使用缓存内容时，请求会省略系统指令和工具，并依赖于缓存的前缀。
 - 隐式缓存：由 Gemini 自身管理。服务可能会自动重用先前的请求或响应。到期和重用由 Gemini 控制，无法配置。
 
 下面的示例展示了如何创建前缀缓存并在后续调用中重用它。

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -389,6 +389,49 @@ func (cm *ChatModel) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema
 	return cachedContent, nil
 }
 
+// UpdatePrefixCache updates TTL or expire time of an existing prefix cache.
+// See https://ai.google.dev/gemini-api/docs/caching#update-cache
+func (cm *ChatModel) UpdatePrefixCache(ctx context.Context, name string, opts ...model.Option) (*genai.CachedContent, error) {
+	if name == "" {
+		return nil, fmt.Errorf("UpdatePrefixCache: cache name is required")
+	}
+
+	ttl, expireTime := cm.resolvePrefixCacheUpdateConfig(opts...)
+	if ttl == 0 && expireTime.IsZero() {
+		return nil, fmt.Errorf("UpdatePrefixCache requires WithPrefixCacheUpdateTTL or WithPrefixCacheUpdateExpireTime")
+	}
+
+	cachedContent, err := cm.cli.Caches.Update(ctx, name, &genai.UpdateCachedContentConfig{
+		TTL:        ttl,
+		ExpireTime: expireTime,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update cache failed: %w", err)
+	}
+	return cachedContent, nil
+}
+
+func (cm *ChatModel) resolvePrefixCacheUpdateConfig(opts ...model.Option) (ttl time.Duration, expireTime time.Time) {
+	geminiOptions := model.GetImplSpecificOptions(&options{}, opts...)
+	if cm.cache != nil {
+		ttl = cm.cache.TTL
+		expireTime = cm.cache.ExpireTime
+	}
+	if geminiOptions.PrefixCacheUpdateTTL != nil {
+		ttl = *geminiOptions.PrefixCacheUpdateTTL
+		if geminiOptions.PrefixCacheUpdateExpireTime == nil {
+			expireTime = time.Time{}
+		}
+	}
+	if geminiOptions.PrefixCacheUpdateExpireTime != nil {
+		expireTime = *geminiOptions.PrefixCacheUpdateExpireTime
+		if geminiOptions.PrefixCacheUpdateTTL == nil {
+			ttl = 0
+		}
+	}
+	return ttl, expireTime
+}
+
 func populateToolChoice(m *genai.GenerateContentConfig, toolChoice *schema.ToolChoice, allowedToolNames []string) error {
 	if toolChoice == nil {
 		return nil

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1050,6 +1050,62 @@ func TestCreatePrefixCache(t *testing.T) {
 	})
 }
 
+func TestUpdatePrefixCache(t *testing.T) {
+	t.Run("update_ttl", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		var updateConfig *genai.UpdateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Update).
+			To(func(ctx context.Context, name string, config *genai.UpdateCachedContentConfig) (*genai.CachedContent, error) {
+				updateConfig = config
+				return &genai.CachedContent{Name: name}, nil
+			}).Build().Patch().UnPatch()
+
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateTTL(2*time.Hour))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, "cachedContents/abc", cache.Name)
+		assert.Equal(t, 2*time.Hour, updateConfig.TTL)
+		assert.True(t, updateConfig.ExpireTime.IsZero())
+	})
+
+	t.Run("update_expire_time", func(t *testing.T) {
+		ctx := context.Background()
+		configExpire := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		optionExpire := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		cm, err := NewChatModel(ctx, &Config{
+			Client: &genai.Client{Caches: &genai.Caches{}},
+			Model:  "test-model",
+			Cache:  &CacheConfig{TTL: time.Minute, ExpireTime: configExpire},
+		})
+		assert.Nil(t, err)
+
+		var updateConfig *genai.UpdateCachedContentConfig
+		defer mockey.Mock(genai.Caches.Update).
+			To(func(ctx context.Context, name string, config *genai.UpdateCachedContentConfig) (*genai.CachedContent, error) {
+				updateConfig = config
+				return &genai.CachedContent{Name: name, ExpireTime: config.ExpireTime}, nil
+			}).Build().Patch().UnPatch()
+
+		cache, err := cm.UpdatePrefixCache(ctx, "cachedContents/abc", WithPrefixCacheUpdateExpireTime(optionExpire))
+		assert.NoError(t, err)
+		assert.NotNil(t, cache)
+		assert.Equal(t, time.Duration(0), updateConfig.TTL)
+		assert.Equal(t, optionExpire, updateConfig.ExpireTime)
+	})
+
+	t.Run("missing_ttl_and_expire_time", func(t *testing.T) {
+		ctx := context.Background()
+		cm, err := NewChatModel(ctx, &Config{Client: &genai.Client{Caches: &genai.Caches{}}, Model: "test-model"})
+		assert.Nil(t, err)
+
+		_, err = cm.UpdatePrefixCache(ctx, "cachedContents/abc")
+		assert.Error(t, err)
+	})
+}
+
 func TestSpecialPart(t *testing.T) {
 	msg, err := convCandidate(&genai.Candidate{
 		Content: &genai.Content{

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -17,6 +17,8 @@
 package gemini
 
 import (
+	"time"
+
 	"github.com/eino-contrib/jsonschema"
 	"google.golang.org/genai"
 
@@ -24,12 +26,14 @@ import (
 )
 
 type options struct {
-	TopK               *int32
-	ResponseJSONSchema *jsonschema.Schema
-	ThinkingConfig     *genai.ThinkingConfig
-	ResponseModalities []GeminiResponseModality
-	ImageConfig        *genai.ImageConfig
-	CachedContentName  string
+	TopK                      *int32
+	ResponseJSONSchema        *jsonschema.Schema
+	ThinkingConfig            *genai.ThinkingConfig
+	ResponseModalities        []GeminiResponseModality
+	ImageConfig               *genai.ImageConfig
+	CachedContentName         string
+	PrefixCacheUpdateTTL      *time.Duration
+	PrefixCacheUpdateExpireTime *time.Time
 }
 
 func WithTopK(k int32) model.Option {
@@ -61,6 +65,22 @@ func WithResponseModalities(m []GeminiResponseModality) model.Option {
 func WithCachedContentName(name string) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.CachedContentName = name
+	})
+}
+
+// WithPrefixCacheUpdateTTL sets the TTL for UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.TTL for that UpdatePrefixCache invocation.
+func WithPrefixCacheUpdateTTL(ttl time.Duration) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheUpdateTTL = &ttl
+	})
+}
+
+// WithPrefixCacheUpdateExpireTime sets the absolute expiry for UpdatePrefixCache on this call.
+// When set, it overrides Config.Cache.ExpireTime for that UpdatePrefixCache invocation.
+func WithPrefixCacheUpdateExpireTime(expireTime time.Time) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.PrefixCacheUpdateExpireTime = &expireTime
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `ChatModel.UpdatePrefixCache(ctx, name, opts...)` wrapping `genai.Caches.Update`.
- Add call-time options `WithPrefixCacheUpdateTTL` and `WithPrefixCacheUpdateExpireTime` (same exclusive merge semantics as create-side options in #837).
- Fall back to `Config.Cache` when no update option is passed; require at least one resolved TTL or ExpireTime.

## Motivation
Gemini explicit caching supports PATCH to extend TTL without recreating cached content ([docs](https://ai.google.dev/gemini-api/docs/caching#update-cache)). This is useful for rolling prefix caches across chapter boundaries in long-running agents.

## API

```go
updated, err := cm.UpdatePrefixCache(ctx, cache.Name,
    gemini.WithPrefixCacheUpdateTTL(2*time.Hour))
```

## Test plan
- [x] `go test -run TestUpdatePrefixCache ./components/model/gemini/...`


Made with [Cursor](https://cursor.com)