### PR TITLE
feat(agentic): support cache control for agenticclaude, agenticark, agenticopenai, and agenticgemini

### DIFF
--- a/components/model/agenticark/README.md
+++ b/components/model/agenticark/README.md
@@ -10,7 +10,7 @@ A Volcengine Ark model implementation for [Eino](https://github.com/cloudwego/ei
 - Support for responses api
 - Support for streaming responses
 - Support for tool calling (Function Tools, MCP Tools, Server Tools)
-- Support for Prefix Cache and Session Cache
+- Support for Prefix Cache and auto-caching for multi-turn conversations
 
 ## Installation
 
@@ -166,9 +166,13 @@ type Config struct {
     // Optional.
     MCPTools []*responses.ToolMcp
     
-    // Cache specifies response caching configuration for the session.
+    // EnableAutoCache controls whether auto-caching for multi-turn conversations is active for the model.
     // Optional.
-    Cache *CacheConfig
+    EnableAutoCache bool
+
+    // ExpireAtSec specifies the expiration Unix timestamp (in seconds) for auto caching or prefix cache.
+    // Optional.
+    ExpireAtSec *int64
     
     // ContextManagement specifies context management strategies to help the model utilize the context window effectively.
     // Supports clearing thinking blocks and tool call content.
@@ -183,6 +187,23 @@ type Config struct {
 ```
 
 ## Advanced Usage
+
+### Cache
+
+Use `EnableAutoCache` to enable auto-caching for multi-turn conversations. If a cached message becomes invalid, call `InvalidateMessageCaches` to temporarily skip it.
+
+For explicit prefix reuse, call `CreatePrefixCache` first and then pass the returned response ID with `WithHeadPreviousResponseID`.
+
+```go
+expireAtSec := time.Now().Add(time.Hour).Unix()
+
+am, err := agenticark.New(ctx, &agenticark.Config{
+	Model:           os.Getenv("ARK_MODEL_ID"),
+	APIKey:          os.Getenv("ARK_API_KEY"),
+	EnableAutoCache: true,
+	ExpireAtSec:     &expireAtSec,
+})
+```
 
 ### Tool Calling
 

--- a/components/model/agenticark/README.zh_CN.md
+++ b/components/model/agenticark/README.zh_CN.md
@@ -10,7 +10,7 @@
 - 支持 Responses API
 - 支持流式响应 (Streaming)
 - 支持工具调用 (Tools)，包括函数工具 (Function Tools)、MCP 工具 (MCP Tools) 和服务器工具 (Server Tools)
-- 支持前缀缓存 (Prefix Cache) 和会话缓存 (Session Cache)
+- 支持前缀缓存 (Prefix Cache) 和多轮对话自动缓存
 
 ## 安装
 
@@ -180,9 +180,13 @@ type Config struct {
     // 可选。
     MCPTools []*responses.ToolMcp
 
-    // Cache 指定模型的缓存配置。
+    // EnableAutoCache 控制是否开启多轮对话自动缓存。
     // 可选。
-    Cache *CacheConfig
+    EnableAutoCache bool
+
+    // ExpireAtSec 指定自动缓存或前缀缓存的过期 Unix 时间戳（秒）。
+    // 可选。
+    ExpireAtSec *int64
 
     // ContextManagement 指定上下文管理策略，帮助模型有效利用上下文窗口。
     // 支持清除思维链内容和工具调用内容。
@@ -195,6 +199,23 @@ type Config struct {
 ```
 
 ## 高级用法
+
+### 缓存
+
+使用 `EnableAutoCache` 开启多轮对话自动缓存。若某条缓存消息已经失效，可以调用 `InvalidateMessageCaches` 临时跳过该缓存。
+
+如果需要显式复用前缀缓存，可以先调用 `CreatePrefixCache`，再通过 `WithHeadPreviousResponseID` 传入返回的响应 ID。
+
+```go
+expireAtSec := time.Now().Add(time.Hour).Unix()
+
+am, err := agenticark.New(ctx, &agenticark.Config{
+	Model:           os.Getenv("ARK_MODEL_ID"),
+	APIKey:          os.Getenv("ARK_API_KEY"),
+	EnableAutoCache: true,
+	ExpireAtSec:     &expireAtSec,
+})
+```
 
 ### 工具调用 (Tool Calling)
 

--- a/components/model/agenticark/convertor.go
+++ b/components/model/agenticark/convertor.go
@@ -1274,8 +1274,6 @@ func toOutputMessage(resp *responses.ResponseObject) (msg *schema.AgenticMessage
 		ResponseMeta:  responseObjectToResponseMeta(resp),
 	}
 
-	msg = setSelfGenerated(msg)
-
 	return msg, nil
 }
 

--- a/components/model/agenticark/convertor_test.go
+++ b/components/model/agenticark/convertor_test.go
@@ -65,9 +65,11 @@ func TestToAssistantRoleInputItems(t *testing.T) {
 	}
 	setItemID(msg.ContentBlocks[1], "id-1")
 	setItemStatus(msg.ContentBlocks[1], responses.ItemStatus_completed.String())
-	setSelfGenerated(msg)
-
-	items, err := toAssistantRoleInputItems(msg)
+	msg.ResponseMeta = &schema.AgenticResponseMeta{
+			Extension: &ResponseMetaExtension{},
+		}
+		
+		items, err := toAssistantRoleInputItems(msg)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(items))
 	assert.Equal(t, responses.MessageRole_assistant, items[0].GetInputMessage().Role)

--- a/components/model/agenticark/event_convertor.go
+++ b/components/model/agenticark/event_convertor.go
@@ -292,8 +292,6 @@ func (s *callbackSender) send(meta *schema.AgenticResponseMeta, block *schema.Co
 		ResponseMeta: meta,
 	}
 
-	setSelfGenerated(msg)
-
 	if block != nil {
 		msg.ContentBlocks = []*schema.ContentBlock{block}
 	}
@@ -978,7 +976,7 @@ func (r *streamReceiver) doubaoAppOutputTextDeltaToContentBlock(ev *responses.Re
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 
@@ -1017,7 +1015,7 @@ func (r *streamReceiver) doubaoAppReasoningTextDeltaToContentBlock(ev *responses
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 
@@ -1042,7 +1040,7 @@ func (r *streamReceiver) doubaoAppSearchSearchingToContentBlock(ev *responses.Re
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 
@@ -1080,7 +1078,7 @@ func (r *streamReceiver) doubaoAppSearchCompletedToContentBlock(ev *responses.Re
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 
@@ -1105,7 +1103,7 @@ func (r *streamReceiver) doubaoAppReasoningSearchSearchingToContentBlock(ev *res
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 
@@ -1143,7 +1141,7 @@ func (r *streamReceiver) doubaoAppReasoningSearchCompletedToContentBlock(ev *res
 	}
 
 	block := schema.NewContentBlockChunk(&schema.ServerToolResult{
-		Name:   string(ServerToolNameDoubaoApp),
+		Name:    string(ServerToolNameDoubaoApp),
 		Content: &ServerToolResult{DoubaoApp: result},
 	}, meta)
 

--- a/components/model/agenticark/examples/prefix_cache/main.go
+++ b/components/model/agenticark/examples/prefix_cache/main.go
@@ -73,9 +73,8 @@ func main() {
 			},
 		}),
 		model.WithTools(functionTools),
+		agenticark.WithExpireAtSec(time.Now().Add(10 * time.Minute).Unix()),
 	}
-
-	expireAtSec := time.Now().Add(10 * time.Minute).Unix()
 
 	prefix := []*schema.AgenticMessage{
 		schema.SystemAgenticMessage(`Once upon a time, in a quaint little village surrounded by vast green forests and blooming meadows, there lived a spirited young girl known as Little Red Riding Hood. She earned her name from the vibrant red cape that her beloved grandmother had sewn for her, a gift that she cherished deeply. This cape was more than just a piece of clothing; it was a symbol of the bond between her and her grandmother, who lived on the other side of the great woods, near a sparkling brook that bubbled merrily all year round.
@@ -142,21 +141,16 @@ func main() {
 	}
 
 	// create response prefix cache, note: more than 1024 tokens are required, otherwise the prefix cache cannot be created
-	cacheInfo, err := am.CreatePrefixCache(ctx, prefix, &expireAtSec, opts...)
+	cacheInfo, err := am.CreatePrefixCache(ctx, prefix, opts...)
 	if err != nil {
 		log.Fatalf("CreatePrefixCache failed, err=%v", err)
-	}
-
-	// use cache information in subsequent requests
-	cacheOpt := &agenticark.CacheOption{
-		HeadPreviousResponseID: &cacheInfo.ResponseID,
 	}
 
 	input := []*schema.AgenticMessage{
 		schema.UserAgenticMessage("What is the main idea expressed above？"),
 	}
 
-	opts = append(opts, agenticark.WithCache(cacheOpt))
+	opts = append(opts, agenticark.WithHeadPreviousResponseID(cacheInfo.ResponseID))
 	outMsg, err := am.Generate(ctx, input, opts...)
 	if err != nil {
 		log.Fatalf("Generate failed, err=%v", err)

--- a/components/model/agenticark/extension.go
+++ b/components/model/agenticark/extension.go
@@ -150,13 +150,6 @@ func getResponseMeta(meta *schema.AgenticResponseMeta) *ResponseMetaExtension {
 	if ext, ok := meta.Extension.(*ResponseMetaExtension); ok {
 		return ext
 	}
-	if m, ok := meta.Extension.(map[string]any); ok {
-		ext := &ResponseMetaExtension{}
-		if err := mapstructure.Decode(m, ext); err != nil {
-			return nil
-		}
-		return ext
-	}
 	return nil
 }
 

--- a/components/model/agenticark/extension_test.go
+++ b/components/model/agenticark/extension_test.go
@@ -41,40 +41,13 @@ func TestGetResponseMeta(t *testing.T) {
 	assert.Equal(t, "id", ext.ID)
 	assert.Equal(t, ResponseStatus("ok"), ext.Status)
 
-	// map[string]any conversion
 	metaFromMap := &schema.AgenticResponseMeta{
 		Extension: map[string]any{
 			"id":     "id-from-map",
 			"status": "completed",
 		},
 	}
-	extFromMap := getResponseMeta(metaFromMap)
-	assert.NotNil(t, extFromMap)
-	assert.Equal(t, "id-from-map", extFromMap.ID)
-	assert.Equal(t, ResponseStatus("completed"), extFromMap.Status)
-
-	// map[string]any with nested fields
-	metaFromMapNested := &schema.AgenticResponseMeta{
-		Extension: map[string]any{
-			"id":     "id-nested",
-			"status": "failed",
-			"error": map[string]any{
-				"code":    "ERR001",
-				"message": "something went wrong",
-			},
-			"incomplete_details": map[string]any{
-				"reason": "timeout",
-			},
-		},
-	}
-	extFromMapNested := getResponseMeta(metaFromMapNested)
-	assert.NotNil(t, extFromMapNested)
-	assert.Equal(t, "id-nested", extFromMapNested.ID)
-	assert.NotNil(t, extFromMapNested.Error)
-	assert.Equal(t, "ERR001", extFromMapNested.Error.Code)
-	assert.Equal(t, "something went wrong", extFromMapNested.Error.Message)
-	assert.NotNil(t, extFromMapNested.IncompleteDetails)
-	assert.Equal(t, "timeout", extFromMapNested.IncompleteDetails.Reason)
+	assert.Nil(t, getResponseMeta(metaFromMap))
 
 	// wrong type returns nil
 	metaWrongType := &schema.AgenticResponseMeta{

--- a/components/model/agenticark/message_extra.go
+++ b/components/model/agenticark/message_extra.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	arkGeneratedKey = "ark-generated"
+	keyOfResponseAutoCached = "_eino_ext_agenticark_auto_cached"
 )
 
 // allowedNonSelfGeneratedBlockTypes defines the whitelist of ContentBlockTypes
@@ -51,18 +51,26 @@ func isAllowedNonSelfGeneratedBlockType(blockType schema.ContentBlockType) bool 
 	return allowedNonSelfGeneratedBlockTypes[blockType]
 }
 
-func setSelfGenerated(msg *schema.AgenticMessage) *schema.AgenticMessage {
+func isSelfGeneratedMessage(msg *schema.AgenticMessage) bool {
+	return msg != nil && msg.ResponseMeta != nil && getResponseMeta(msg.ResponseMeta) != nil
+}
+
+func setAutoCached(msg *schema.AgenticMessage) *schema.AgenticMessage {
 	if msg.Extra == nil {
 		msg.Extra = map[string]any{}
 	}
-	msg.Extra[arkGeneratedKey] = true
+	msg.Extra[keyOfResponseAutoCached] = true
 	return msg
 }
 
-func isSelfGeneratedMessage(msg *schema.AgenticMessage) bool {
-	if msg == nil || msg.Extra == nil {
-		return false
+// InvalidateMessageCaches temporarily disables caching for the specified messages.
+// When a message is modified or model is switched, Ark invalidates caches for that message and all subsequent ones.
+// Call this to mark those message caches as invalid temporarily.
+func InvalidateMessageCaches(messages []*schema.AgenticMessage) error {
+	for _, msg := range messages {
+		if msg.Extra != nil {
+			delete(msg.Extra, keyOfResponseAutoCached)
+		}
 	}
-	v, ok := msg.Extra[arkGeneratedKey].(bool)
-	return ok && v
+	return nil
 }

--- a/components/model/agenticark/model.go
+++ b/components/model/agenticark/model.go
@@ -135,9 +135,17 @@ type Config struct {
 	// Optional.
 	MCPTools []*responses.ToolMcp
 
-	// Cache specifies response caching configuration for the session.
+	// EnableAutoCache controls whether auto-caching for multi-turn conversations is active for the model.
+	// When enabled, conversation turns are stored, and the model automatically maintains context
+	// by locating the most recent cached message in the input (via Response ID in ResponseMeta).
+	// This cached message and all preceding inputs are excluded from the request.
+	// If the cached message becomes invalid, you can call [InvalidateMessageCaches] to temporarily invalidate the cache.
 	// Optional.
-	Cache *CacheConfig
+	EnableAutoCache bool
+
+	// ExpireAtSec specifies the expiration Unix timestamp (in seconds) for auto caching or prefix cache.
+	// Optional.
+	ExpireAtSec *int64
 
 	// ContextManagement specifies context management strategies to help the model utilize the context window effectively.
 	// Supports clearing thinking blocks and tool call content.
@@ -148,23 +156,6 @@ type Config struct {
 	// CustomHeaders allows passing additional metadata or authentication information.
 	// Optional.
 	CustomHeaders map[string]string
-}
-
-type CacheConfig struct {
-	// SessionCache can be overridden by [WithCache].
-	// Optional.
-	SessionCache *SessionCacheConfig
-}
-
-type SessionCacheConfig struct {
-	// EnableCache controls whether session caching is active.
-	// When enabled, conversation turns are stored, and the model automatically maintains context
-	// by locating the most recent cached message in the input (via Response ID in ResponseMeta).
-	// This cached message and all preceding inputs are excluded from the request.
-	// The detected Response ID takes precedence over HeadPreviousResponseID.
-	EnableCache bool
-
-	ExpireAtSec int64
 }
 
 type ServerToolConfig struct {
@@ -230,7 +221,8 @@ func buildClient(config *Config) (*Model, error) {
 		parallelToolCalls:       config.ParallelToolCalls,
 		serverTools:             config.ServerTools,
 		mcpTools:                config.MCPTools,
-		cache:                   config.Cache,
+		enableAutoCache:         config.EnableAutoCache,
+		expireAtSec:             config.ExpireAtSec,
 		contextManagement:       config.ContextManagement,
 		customHeaders:           config.CustomHeaders,
 	}
@@ -257,7 +249,8 @@ type Model struct {
 	serverTools       []*ServerToolConfig
 	mcpTools          []*responses.ToolMcp
 
-	cache                   *CacheConfig
+	enableAutoCache         bool
+	expireAtSec             *int64
 	contextManagement       *contextmanagement.ContextManagement
 	enablePassBackReasoning *bool
 	customHeaders           map[string]string
@@ -305,6 +298,10 @@ func (m *Model) Generate(ctx context.Context, input []*schema.AgenticMessage, op
 	outMsg, err = toOutputMessage(responseObject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert output to message: %w", err)
+	}
+
+	if m.enableAutoCache {
+		setAutoCached(outMsg)
 	}
 
 	callbacks.OnEnd(ctx, &model.AgenticCallbackOutput{
@@ -386,6 +383,9 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 			if s.Message == nil {
 				return nil, schema.ErrNoValue
 			}
+			if m.enableAutoCache {
+				setAutoCached(s.Message)
+			}
 			return s.Message, nil
 		},
 	)
@@ -419,7 +419,7 @@ func (m *Model) IsCallbacksEnabled() bool {
 }
 
 type CacheInfo struct {
-	// ResponseID return by ResponsesAPI, it's specifies the id of prefix that can be used with [WithCache.HeadPreviousResponseID] option.
+	// ResponseID return by ResponsesAPI, it's specifies the id of prefix that can be used with [WithHeadPreviousResponseID] option.
 	ResponseID string
 	// Usage specifies the token usage of prefix
 	Usage schema.TokenUsage
@@ -432,7 +432,9 @@ type CacheInfo struct {
 // Parameters:
 //   - ctx: The context for the request
 //   - prefix: Initial messages to be cached as prefix context
-//   - expireAtSec: Expiration Unix timestamp (in seconds) for the cached prefix. Defaults to 3 days from now if not specified.
+//
+// The expiration Unix timestamp (in seconds) for the cached prefix can be set via
+// [WithExpireAtSec] option or the ExpireAtSec field in Config. Defaults to 3 days from now if not specified.
 //
 // Returns:
 //   - info: Information about the created prefix cache, including the context ID and token usage
@@ -442,8 +444,18 @@ type CacheInfo struct {
 //
 // Note:
 //   - It is unavailable for doubao models of version 1.6 and above.
-func (m *Model) CreatePrefixCache(ctx context.Context, prefix []*schema.AgenticMessage, expireAtSec *int64,
+func (m *Model) CreatePrefixCache(ctx context.Context, prefix []*schema.AgenticMessage,
 	opts ...model.Option) (info *CacheInfo, err error) {
+
+	options, specOptions, err := m.getOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get options: %w", err)
+	}
+
+	expireAtSec := m.expireAtSec
+	if specOptions.expireAtSec != nil {
+		expireAtSec = specOptions.expireAtSec
+	}
 
 	responseReq := &responses.ResponsesRequest{
 		Model:    m.model,
@@ -453,11 +465,6 @@ func (m *Model) CreatePrefixCache(ctx context.Context, prefix []*schema.AgenticM
 			Type:   responses.CacheType_enabled.Enum(),
 			Prefix: ptrOf(true),
 		},
-	}
-
-	options, specOptions, err := m.getOptions(opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get options: %w", err)
 	}
 
 	err = m.prePopulateConfig(responseReq, options, specOptions)
@@ -487,7 +494,9 @@ func (m *Model) CreatePrefixCache(ctx context.Context, prefix []*schema.AgenticM
 
 	info = &CacheInfo{
 		ResponseID: responseObj.Id,
-		Usage:      *toTokenUsage(responseObj),
+	}
+	if usage := toTokenUsage(responseObj); usage != nil {
+		info.Usage = *usage
 	}
 
 	return info, nil
@@ -695,39 +704,16 @@ func (m *Model) populateCache(in []*schema.AgenticMessage, responseReq *response
 	arkOpts *arkOptions) ([]*schema.AgenticMessage, error) {
 
 	var (
-		store              = false
-		enableCache        = false
-		hasSessionCacheCfg = false
-		expireAtSec        *int64
-		headRespID         *string
+		enableCache = m.enableAutoCache
+		headRespID  = arkOpts.headPreviousResponseID
+		expireAtSec *int64
 	)
 
-	if m.cache != nil {
-		if sCache := m.cache.SessionCache; sCache != nil {
-			hasSessionCacheCfg = true
-			if sCache.EnableCache {
-				store = true
-				enableCache = true
-			}
-			expireAtSec = &sCache.ExpireAtSec
-		}
+	if m.expireAtSec != nil {
+		expireAtSec = m.expireAtSec
 	}
-
-	if cacheOpt := arkOpts.cache; cacheOpt != nil {
-		headRespID = cacheOpt.HeadPreviousResponseID
-
-		if sCacheOpt := cacheOpt.SessionCache; sCacheOpt != nil {
-			hasSessionCacheCfg = true
-			expireAtSec = &sCacheOpt.ExpireAtSec
-
-			if sCacheOpt.EnableCache {
-				store = true
-				enableCache = true
-			} else {
-				store = false
-				enableCache = false
-			}
-		}
+	if arkOpts.expireAtSec != nil {
+		expireAtSec = arkOpts.expireAtSec
 	}
 
 	var (
@@ -740,12 +726,18 @@ func (m *Model) populateCache(in []*schema.AgenticMessage, responseReq *response
 	if enableCache {
 		for i := len(in) - 1; i >= 0; i-- {
 			msg := in[i]
+			if msg.Extra == nil {
+				continue
+			}
+			if isAutoCached, ok := msg.Extra[keyOfResponseAutoCached].(bool); !ok || !isAutoCached {
+				continue
+			}
 			if msg.ResponseMeta == nil {
 				continue
 			}
 
 			extensions := getResponseMeta(msg.ResponseMeta)
-			if extensions == nil || ptrFromOrZero(extensions.ExpireAt) <= now {
+			if extensions == nil || extensions.ID == "" || ptrFromOrZero(extensions.ExpireAt) <= now {
 				continue
 			}
 
@@ -764,25 +756,20 @@ func (m *Model) populateCache(in []*schema.AgenticMessage, responseReq *response
 	}
 
 	// ResponseID has a higher priority than HeadPreviousResponseID
-	if preRespID == nil {
+	if preRespID == nil || *preRespID == "" {
 		preRespID = headRespID
 	}
 
 	responseReq.PreviousResponseId = preRespID
-	responseReq.Store = &store
+	responseReq.Store = &enableCache
 
 	if expireAtSec != nil {
 		responseReq.ExpireAt = expireAtSec
 	}
 
-	if hasSessionCacheCfg {
+	if enableCache {
 		responseReq.Caching = &responses.ResponsesCaching{
-			Type: func() *responses.CacheType_Enum {
-				if enableCache {
-					return responses.CacheType_enabled.Enum()
-				}
-				return responses.CacheType_disabled.Enum()
-			}(),
+			Type: responses.CacheType_enabled.Enum(),
 		}
 	}
 

--- a/components/model/agenticark/model_test.go
+++ b/components/model/agenticark/model_test.go
@@ -234,7 +234,7 @@ func TestModelCreatePrefixCache(t *testing.T) {
 			},
 		}, nil).Build()
 
-		info, err := m.CreatePrefixCache(ctx, prefix, ptrOf(int64(3600)))
+		info, err := m.CreatePrefixCache(ctx, prefix, WithExpireAtSec(int64(3600)))
 		assert.NoError(t, err)
 		assert.NotNil(t, info)
 		assert.Equal(t, "rid", info.ResponseID)
@@ -366,12 +366,8 @@ func TestModelPopulateCache(t *testing.T) {
 		})
 
 		mockey.PatchConvey("session cache enabled in model", func() {
-			m.cache = &CacheConfig{
-				SessionCache: &SessionCacheConfig{
-					EnableCache: true,
-					ExpireAtSec: 3600,
-				},
-			}
+			m.enableAutoCache = true
+			m.expireAtSec = ptrOf(int64(3600))
 			in := []*schema.AgenticMessage{{Role: schema.AgenticRoleTypeUser}}
 			_, err := m.populateCache(in, req, specOpts)
 			assert.NoError(t, err)
@@ -380,12 +376,8 @@ func TestModelPopulateCache(t *testing.T) {
 		})
 
 		mockey.PatchConvey("response id in messages", func() {
-			m.cache = &CacheConfig{
-				SessionCache: &SessionCacheConfig{
-					EnableCache: true,
-					ExpireAtSec: 3600,
-				},
-			}
+			m.enableAutoCache = true
+			m.expireAtSec = ptrOf(int64(3600))
 
 			// Mock time.Now to control expiration check
 			mockey.Mock(time.Now).Return(time.Unix(1000, 0)).Build()
@@ -393,6 +385,9 @@ func TestModelPopulateCache(t *testing.T) {
 			in := []*schema.AgenticMessage{
 				{
 					Role: schema.AgenticRoleTypeAssistant,
+					Extra: map[string]any{
+						keyOfResponseAutoCached: true,
+					},
 					ResponseMeta: &schema.AgenticResponseMeta{
 						Extension: &ResponseMetaExtension{
 							ID:       "rid",
@@ -410,16 +405,15 @@ func TestModelPopulateCache(t *testing.T) {
 		})
 
 		mockey.PatchConvey("response id in messages - no incremental input", func() {
-			m.cache = &CacheConfig{
-				SessionCache: &SessionCacheConfig{
-					EnableCache: true,
-					ExpireAtSec: 3600,
-				},
-			}
+			m.enableAutoCache = true
+			m.expireAtSec = ptrOf(int64(3600))
 			mockey.Mock(time.Now).Return(time.Unix(1000, 0)).Build()
 			in := []*schema.AgenticMessage{
 				{
 					Role: schema.AgenticRoleTypeAssistant,
+					Extra: map[string]any{
+						keyOfResponseAutoCached: true,
+					},
 					ResponseMeta: &schema.AgenticResponseMeta{
 						Extension: &ResponseMetaExtension{
 							ID:       "rid",

--- a/components/model/agenticark/option.go
+++ b/components/model/agenticark/option.go
@@ -34,20 +34,21 @@ type arkOptions struct {
 
 	contextManagement *contextmanagement.ContextManagement
 	customHeaders     map[string]string
-	cache             *CacheOption
+
+	headPreviousResponseID *string
+	expireAtSec            *int64
 }
 
-type CacheOption struct {
-	// HeadPreviousResponseID is a response ID from a previous ResponsesAPI call.
-	// This ID links the current request to a previous conversation context, enabling
-	// features like conversation continuation and prefix caching.
-	// The referenced response must be cached before use.
-	// Optional.
-	HeadPreviousResponseID *string
-
-	// SessionCache is the configuration of ResponsesAPI session cache.
-	// Optional.
-	SessionCache *SessionCacheConfig
+// WithHeadPreviousResponseID sets a response ID from a previous ResponsesAPI call.
+// This ID links the current request to a previous conversation context, enabling
+// features like conversation continuation and prefix caching.
+// In populateCache, an auto-discovered response ID from input messages takes
+// priority over this option.
+// The referenced response must be cached before use.
+func WithHeadPreviousResponseID(id string) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
+		o.headPreviousResponseID = &id
+	})
 }
 
 func WithReasoning(reasoning *responses.ResponsesReasoning) model.Option {
@@ -98,14 +99,16 @@ func WithCustomHeaders(headers map[string]string) model.Option {
 	})
 }
 
-func WithCache(option *CacheOption) model.Option {
-	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
-		o.cache = option
-	})
-}
-
 func WithContextManagement(cm *contextmanagement.ContextManagement) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
 		o.contextManagement = cm
+	})
+}
+
+// WithExpireAtSec sets the expiration Unix timestamp (in seconds) for auto caching or prefix cache.
+// This option overrides the ExpireAtSec field in Config.
+func WithExpireAtSec(expireAtSec int64) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *arkOptions) {
+		o.expireAtSec = &expireAtSec
 	})
 }

--- a/components/model/agenticark/option_test.go
+++ b/components/model/agenticark/option_test.go
@@ -86,9 +86,10 @@ func TestWithCustomHeaders(t *testing.T) {
 	assert.Equal(t, headers, got.customHeaders)
 }
 
-func TestWithCache(t *testing.T) {
+func TestWithHeadPreviousResponseID(t *testing.T) {
 	base := &arkOptions{}
-	cache := &CacheOption{}
-	got := model.GetImplSpecificOptions(base, WithCache(cache))
-	assert.Same(t, cache, got.cache)
+	got := model.GetImplSpecificOptions(base, WithHeadPreviousResponseID("resp_123"))
+	if assert.NotNil(t, got.headPreviousResponseID) {
+		assert.Equal(t, "resp_123", *got.headPreviousResponseID)
+	}
 }

--- a/components/model/agenticclaude/README.md
+++ b/components/model/agenticclaude/README.md
@@ -10,6 +10,7 @@ An Anthropic Claude model implementation for [Eino](https://github.com/cloudwego
 - Support for Anthropic Messages API
 - Support for streaming responses
 - Support for tool calling (Function Tools, Deferred Tools, Client Tool Search, Server Tools)
+- Support for prompt caching
 - Support for AWS Bedrock and Google Vertex AI
 
 ## Installation
@@ -146,10 +147,35 @@ type Config struct {
     // ExtraFields specifies additional fields that will be directly added to the HTTP request body.
     // Optional.
     ExtraFields map[string]any
+
+    // CacheControl configures automatic prompt caching behavior.
+    // When non-nil, automatically applies a cache_control marker to the last
+    // cacheable block in the request.
+    // Optional.
+    CacheControl *anthropic.CacheControlEphemeralParam
 }
 ```
 
 ## Advanced Usage
+
+### Cache
+
+Use `CacheControl` to enable auto-caching for multi-turn conversations. When set (non-nil), the API automatically applies a cache_control marker to the last cacheable block in the request.
+
+For fine-grained control, use `SetContentBlockCacheControl` or `SetToolInfoCacheControl` to manually place cache breakpoints on specific blocks or tools.
+
+```go
+cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+cacheCtrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+
+am, err := agenticclaude.New(ctx, &agenticclaude.Config{
+    BaseURL:      os.Getenv("CLAUDE_BASE_URL"),
+    Model:        os.Getenv("CLAUDE_MODEL"),
+    APIKey:       os.Getenv("CLAUDE_API_KEY"),
+    MaxTokens:    4096,
+    CacheControl: &cacheCtrl,
+})
+```
 
 ### Tool Calling
 

--- a/components/model/agenticclaude/README_zh.md
+++ b/components/model/agenticclaude/README_zh.md
@@ -10,6 +10,7 @@
 - 支持 Anthropic Messages API
 - 支持流式响应
 - 支持工具调用（函数工具、延迟加载工具、客户端工具搜索、Server Tool）
+- 支持 Prompt 缓存
 - 支持 AWS Bedrock 和 Google Vertex AI
 
 ## 安装
@@ -146,10 +147,35 @@ type Config struct {
     // ExtraFields specifies additional fields that will be directly added to the HTTP request body.
     // Optional.
     ExtraFields map[string]any
+
+    // CacheControl configures automatic prompt caching behavior.
+    // When non-nil, automatically applies a cache_control marker to the last
+    // cacheable block in the request.
+    // Optional.
+    CacheControl *anthropic.CacheControlEphemeralParam
 }
 ```
 
 ## Advanced Usage
+
+### Cache
+
+使用 `CacheControl` 为多轮对话启用自动缓存。设置后（非 nil），API 会自动在请求中最后一个可缓存的 block 上应用 cache_control 标记。
+
+如需细粒度控制，可使用 `SetContentBlockCacheControl` 或 `SetToolInfoCacheControl` 手动在特定的 block 或 tool 上放置缓存断点。
+
+```go
+cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+cacheCtrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+
+am, err := agenticclaude.New(ctx, &agenticclaude.Config{
+    BaseURL:      os.Getenv("CLAUDE_BASE_URL"),
+    Model:        os.Getenv("CLAUDE_MODEL"),
+    APIKey:       os.Getenv("CLAUDE_API_KEY"),
+    MaxTokens:    4096,
+    CacheControl: &cacheCtrl,
+})
+```
 
 ### Tool Calling
 

--- a/components/model/agenticclaude/content_block_extra.go
+++ b/components/model/agenticclaude/content_block_extra.go
@@ -23,16 +23,17 @@ import (
 )
 
 const (
-	extraKeyWebSearchToolResultCaller = "_claude_web_search_tool_result_caller"
-	extraKeyWebFetchToolResultCaller  = "_claude_web_fetch_tool_result_caller"
+	keyOfWebSearchToolResultCaller = "_agenticclaude_web_search_tool_result_caller"
+	keyOfWebFetchToolResultCaller  = "_agenticclaude_web_fetch_tool_result_caller"
+	keyOfCacheControlTTL           = "_agenticclaude_cache_control_ttl"
 )
 
 func setWebSearchResultCaller(block *schema.ContentBlock, caller anthropic.WebSearchToolResultBlockCallerUnion) {
-	setContentBlockExtraValue(block, extraKeyWebSearchToolResultCaller, caller.RawJSON())
+	setContentBlockExtraValue(block, keyOfWebSearchToolResultCaller, caller.RawJSON())
 }
 
 func toWebSearchResultCallerParam(block *schema.ContentBlock) (param anthropic.WebSearchToolResultBlockParamCallerUnion, err error) {
-	caller, ok := getContentBlockExtraValue[string](block, extraKeyWebSearchToolResultCaller)
+	caller, ok := getContentBlockExtraValue[string](block, keyOfWebSearchToolResultCaller)
 	if !ok || caller == "" {
 		return param, nil
 	}
@@ -40,11 +41,11 @@ func toWebSearchResultCallerParam(block *schema.ContentBlock) (param anthropic.W
 }
 
 func setWebFetchResultCaller(block *schema.ContentBlock, caller anthropic.WebFetchToolResultBlockCallerUnion) {
-	setContentBlockExtraValue(block, extraKeyWebFetchToolResultCaller, caller.RawJSON())
+	setContentBlockExtraValue(block, keyOfWebFetchToolResultCaller, caller.RawJSON())
 }
 
 func toWebFetchResultCallerParam(block *schema.ContentBlock) (param anthropic.WebFetchToolResultBlockParamCallerUnion, err error) {
-	caller, ok := getContentBlockExtraValue[string](block, extraKeyWebFetchToolResultCaller)
+	caller, ok := getContentBlockExtraValue[string](block, keyOfWebFetchToolResultCaller)
 	if !ok || caller == "" {
 		return param, nil
 	}
@@ -71,4 +72,91 @@ func getContentBlockExtraValue[T any](block *schema.ContentBlock, key string) (T
 		return zero, false
 	}
 	return value, true
+}
+
+func copyExtra(src map[string]any) map[string]any {
+	if src == nil {
+		return map[string]any{}
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// SetToolInfoCacheControl sets a cache control on a tool info.
+// When a manual control is set, the top-level auto-cache will not override it.
+func SetToolInfoCacheControl(toolInfo *schema.ToolInfo, ctrl *anthropic.CacheControlEphemeralParam) *schema.ToolInfo {
+	if toolInfo == nil {
+		return nil
+	}
+	if ctrl == nil {
+		return toolInfo
+	}
+	ti := *toolInfo
+	ti.Extra = copyExtra(toolInfo.Extra)
+	ti.Extra[keyOfCacheControlTTL] = string(ctrl.TTL)
+	return &ti
+}
+
+func hasCacheControlOnToolInfo(toolInfo *schema.ToolInfo) bool {
+	if toolInfo == nil || toolInfo.Extra == nil {
+		return false
+	}
+	_, ok := toolInfo.Extra[keyOfCacheControlTTL]
+	return ok
+}
+
+func getToolInfoCacheControl(toolInfo *schema.ToolInfo) *anthropic.CacheControlEphemeralParam {
+	if toolInfo == nil || toolInfo.Extra == nil {
+		return nil
+	}
+	ttl, ok := toolInfo.Extra[keyOfCacheControlTTL].(string)
+	if !ok {
+		return nil
+	}
+	p := anthropic.NewCacheControlEphemeralParam()
+	if ttl != "" {
+		p.TTL = anthropic.CacheControlEphemeralTTL(ttl)
+	}
+	return &p
+}
+
+// SetContentBlockCacheControl sets a cache control on a content block.
+// When a manual control is set, the top-level auto-cache will not override it.
+func SetContentBlockCacheControl(block *schema.ContentBlock, ctrl *anthropic.CacheControlEphemeralParam) *schema.ContentBlock {
+	if block == nil {
+		return nil
+	}
+	if ctrl == nil {
+		return block
+	}
+	b := *block
+	b.Extra = copyExtra(block.Extra)
+	b.Extra[keyOfCacheControlTTL] = string(ctrl.TTL)
+	return &b
+}
+
+func hasCacheControlOnContentBlock(block *schema.ContentBlock) bool {
+	if block == nil || block.Extra == nil {
+		return false
+	}
+	_, ok := block.Extra[keyOfCacheControlTTL]
+	return ok
+}
+
+func getContentBlockCacheControl(block *schema.ContentBlock) *anthropic.CacheControlEphemeralParam {
+	if block == nil || block.Extra == nil {
+		return nil
+	}
+	ttl, ok := block.Extra[keyOfCacheControlTTL].(string)
+	if !ok {
+		return nil
+	}
+	p := anthropic.NewCacheControlEphemeralParam()
+	if ttl != "" {
+		p.TTL = anthropic.CacheControlEphemeralTTL(ttl)
+	}
+	return &p
 }

--- a/components/model/agenticclaude/content_block_extra_test.go
+++ b/components/model/agenticclaude/content_block_extra_test.go
@@ -78,7 +78,7 @@ func TestResultCallerRoundTrip(t *testing.T) {
 
 func TestResultCallerDecodeError(t *testing.T) {
 	block := &schema.ContentBlock{Extra: map[string]any{
-		extraKeyWebSearchToolResultCaller: "{",
+		keyOfWebSearchToolResultCaller: "{",
 	}}
 
 	_, err := toWebSearchResultCallerParam(block)

--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -76,9 +76,13 @@ func toSystemBlocks(msg *schema.AgenticMessage) ([]anthropic.TextBlockParam, err
 		if block.Type != schema.ContentBlockTypeUserInputText {
 			return nil, fmt.Errorf("system message only supports text blocks, got %q", block.Type)
 		}
-		blockParams = append(blockParams, anthropic.TextBlockParam{
+		textBlock := anthropic.TextBlockParam{
 			Text: block.UserInputText.Text,
-		})
+		}
+		if hasCacheControlOnContentBlock(block) {
+			textBlock.CacheControl = *getContentBlockCacheControl(block)
+		}
+		blockParams = append(blockParams, textBlock)
 	}
 
 	return blockParams, nil
@@ -107,6 +111,10 @@ func toUserMessageParam(msg *schema.AgenticMessage) (msgParam anthropic.MessageP
 
 		if err != nil {
 			return anthropic.MessageParam{}, err
+		}
+
+		if hasCacheControlOnContentBlock(block) {
+			*blockParam.GetCacheControl() = *getContentBlockCacheControl(block)
 		}
 
 		blockParams = append(blockParams, blockParam)
@@ -141,6 +149,10 @@ func toAssistantMessageParam(msg *schema.AgenticMessage) (msgParam anthropic.Mes
 
 		if err != nil {
 			return anthropic.MessageParam{}, err
+		}
+
+		if hasCacheControlOnContentBlock(block) {
+			*blockParam.GetCacheControl() = *getContentBlockCacheControl(block)
 		}
 
 		blockParams = append(blockParams, blockParam)
@@ -431,17 +443,19 @@ func toFunctionTools(functionTools []*schema.ToolInfo) ([]anthropic.ToolUnionPar
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert tool %q parameters to JSON schema: %w", tool.Name, err)
 		}
-		tools = append(tools, anthropic.ToolUnionParam{
-			OfTool: &anthropic.ToolParam{
-				Type:        anthropic.ToolTypeCustom,
-				Name:        tool.Name,
-				Description: newClaudeStrOpt(tool.Desc),
-				InputSchema: anthropic.ToolInputSchemaParam{
-					Properties: s.Properties,
-					Required:   s.Required,
-				},
+		toolParam := &anthropic.ToolParam{
+			Type:        anthropic.ToolTypeCustom,
+			Name:        tool.Name,
+			Description: newClaudeStrOpt(tool.Desc),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Properties: s.Properties,
+				Required:   s.Required,
 			},
-		})
+		}
+		if hasCacheControlOnToolInfo(tool) {
+			toolParam.CacheControl = *getToolInfoCacheControl(tool)
+		}
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: toolParam})
 	}
 	return tools, nil
 }

--- a/components/model/agenticclaude/examples/cache/main.go
+++ b/components/model/agenticclaude/examples/cache/main.go
@@ -22,27 +22,24 @@ import (
 	"io"
 	"log"
 	"os"
-	"time"
 
-	"github.com/cloudwego/eino-ext/components/model/agenticark"
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/cloudwego/eino-ext/components/model/agenticclaude"
 	"github.com/cloudwego/eino/schema"
-	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 )
 
 func main() {
 	ctx := context.Background()
 
-	expireAtSec := time.Now().Add(10 * time.Minute).Unix()
+	cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+	cacheCtrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
 
-	// Get ARK_API_KEY and ARK_MODEL_ID: https://www.volcengine.com/docs/82379/1399008
-	am, err := agenticark.New(ctx, &agenticark.Config{
-		APIKey: os.Getenv("ARK_API_KEY"),
-		Model:  os.Getenv("ARK_MODEL_ID"),
-		Thinking: &responses.ResponsesThinking{
-			Type: responses.ThinkingType_disabled.Enum(),
-		},
-		EnableAutoCache: true,
-		ExpireAtSec:     &expireAtSec,
+	am, err := agenticclaude.New(ctx, &agenticclaude.Config{
+		BaseURL:      os.Getenv("CLAUDE_BASE_URL"),
+		Model:        os.Getenv("CLAUDE_MODEL"),
+		APIKey:       os.Getenv("CLAUDE_API_KEY"),
+		MaxTokens:    4096,
+		CacheControl: &cacheCtrl,
 	})
 	if err != nil {
 		log.Fatalf("failed to create chat model, err=%v", err)

--- a/components/model/agenticclaude/model.go
+++ b/components/model/agenticclaude/model.go
@@ -103,6 +103,12 @@ type Config struct {
 	// This allows for vendor-specific or future parameters not yet explicitly supported.
 	// Optional.
 	ExtraFields map[string]any
+
+	// CacheControl configures automatic prompt caching behavior.
+	// When non-nil, automatically applies a cache_control marker to the last
+	// cacheable block in the request.
+	// Optional.
+	CacheControl *anthropic.CacheControlEphemeralParam
 }
 
 type GoogleVertexAIConfig struct {
@@ -158,6 +164,7 @@ type Model struct {
 	customHeaders          map[string]string
 	extraFields            map[string]any
 	thinking               *anthropic.ThinkingConfigParamUnion
+	cacheControl           *anthropic.CacheControlEphemeralParam
 }
 
 type ServerToolConfig struct {
@@ -210,6 +217,7 @@ func New(ctx context.Context, cfg *Config) (*Model, error) {
 		customHeaders:          cfg.CustomHeaders,
 		extraFields:            cfg.ExtraFields,
 		thinking:               cfg.Thinking,
+		cacheControl:           cfg.CacheControl,
 	}, nil
 }
 
@@ -442,6 +450,10 @@ func (m *Model) genRequestAndOptions(input []*schema.AgenticMessage, options *mo
 
 	if err = m.populateToolChoice(req, options); err != nil {
 		return nil, nil, err
+	}
+
+	if m.cacheControl != nil {
+		req.CacheControl = *m.cacheControl
 	}
 
 	reqOpts = appendCustomHeaders(reqOpts, specOptions.serverTools, specOptions.customHeaders)

--- a/components/model/agenticclaude/model_test.go
+++ b/components/model/agenticclaude/model_test.go
@@ -619,3 +619,197 @@ func testToolInfo(name string) *schema.ToolInfo {
 		ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&jsonschema.Schema{Type: "object"}),
 	}
 }
+
+func TestCacheControl(t *testing.T) {
+	t.Run("cacheControl nil does not set req.CacheControl", func(t *testing.T) {
+		m := &Model{}
+		if m.cacheControl != nil {
+			t.Fatalf("cacheControl should be nil")
+		}
+	})
+
+	t.Run("cacheControl non-nil is stored", func(t *testing.T) {
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+		m := &Model{cacheControl: &ctrl}
+		if m.cacheControl == nil {
+			t.Fatalf("cacheControl should be non-nil")
+		}
+		if m.cacheControl.TTL != anthropic.CacheControlEphemeralTTLTTL1h {
+			t.Fatalf("cacheControl.TTL = %q, want \"1h\"", m.cacheControl.TTL)
+		}
+	})
+}
+
+func TestSetContentBlockCacheControl(t *testing.T) {
+	t.Run("set and read", func(t *testing.T) {
+		block := schema.NewContentBlock(&schema.UserInputText{Text: "hello"})
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+		block = SetContentBlockCacheControl(block, &ctrl)
+
+		if !hasCacheControlOnContentBlock(block) {
+			t.Fatalf("block should have cache control set")
+		}
+		got := getContentBlockCacheControl(block)
+		if got == nil || got.TTL != anthropic.CacheControlEphemeralTTLTTL1h {
+			t.Fatalf("getContentBlockCacheControl() = %#v", got)
+		}
+	})
+
+	t.Run("nil ctrl does nothing", func(t *testing.T) {
+		block := schema.NewContentBlock(&schema.UserInputText{Text: "hello"})
+		block = SetContentBlockCacheControl(block, nil)
+
+		if hasCacheControlOnContentBlock(block) {
+			t.Fatalf("block should not have cache control set with nil ctrl")
+		}
+	})
+
+	t.Run("nil block is safe", func(t *testing.T) {
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		SetContentBlockCacheControl(nil, &ctrl)
+	})
+}
+
+func TestSetToolInfoCacheControl(t *testing.T) {
+	t.Run("set and read", func(t *testing.T) {
+		toolInfo := &schema.ToolInfo{Name: "fn", Desc: "desc"}
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+		toolInfo = SetToolInfoCacheControl(toolInfo, &ctrl)
+
+		if !hasCacheControlOnToolInfo(toolInfo) {
+			t.Fatalf("tool should have cache control set")
+		}
+		got := getToolInfoCacheControl(toolInfo)
+		if got == nil || got.TTL != anthropic.CacheControlEphemeralTTLTTL1h {
+			t.Fatalf("getToolInfoCacheControl() = %#v", got)
+		}
+	})
+
+	t.Run("nil ctrl does nothing", func(t *testing.T) {
+		toolInfo := &schema.ToolInfo{Name: "fn", Desc: "desc"}
+		toolInfo = SetToolInfoCacheControl(toolInfo, nil)
+
+		if hasCacheControlOnToolInfo(toolInfo) {
+			t.Fatalf("tool should not have cache control set with nil ctrl")
+		}
+	})
+
+	t.Run("nil toolInfo is safe", func(t *testing.T) {
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		SetToolInfoCacheControl(nil, &ctrl)
+	})
+
+	t.Run("propagated to tool param in toFunctionTools", func(t *testing.T) {
+		toolInfo := testToolInfo("fn")
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+		toolInfo = SetToolInfoCacheControl(toolInfo, &ctrl)
+
+		tools, err := toFunctionTools([]*schema.ToolInfo{toolInfo})
+		if err != nil {
+			t.Fatalf("toFunctionTools() error = %v", err)
+		}
+		if tools[0].OfTool.CacheControl.Type != "ephemeral" {
+			t.Fatalf("tool param cache_control.type = %q, want \"ephemeral\"", tools[0].OfTool.CacheControl.Type)
+		}
+		if tools[0].OfTool.CacheControl.TTL != "5m" {
+			t.Fatalf("tool param cache_control.ttl = %q, want \"5m\"", tools[0].OfTool.CacheControl.TTL)
+		}
+	})
+
+	t.Run("tool without cache control has no cache_control in param", func(t *testing.T) {
+		toolInfo := testToolInfo("fn")
+
+		tools, err := toFunctionTools([]*schema.ToolInfo{toolInfo})
+		if err != nil {
+			t.Fatalf("toFunctionTools() error = %v", err)
+		}
+		if tools[0].OfTool.CacheControl.Type != "" {
+			t.Fatalf("tool param should not have cache_control, got type=%q", tools[0].OfTool.CacheControl.Type)
+		}
+	})
+}
+
+func TestManualCacheControlInConvertors(t *testing.T) {
+	t.Run("toSystemBlocks propagates manual cache control", func(t *testing.T) {
+		block := schema.NewContentBlock(&schema.UserInputText{Text: "sys"})
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+		block = SetContentBlockCacheControl(block, &ctrl)
+		msg := &schema.AgenticMessage{
+			Role:          schema.AgenticRoleTypeSystem,
+			ContentBlocks: []*schema.ContentBlock{block},
+		}
+
+		blocks, err := toSystemBlocks(msg)
+		if err != nil {
+			t.Fatalf("toSystemBlocks() error = %v", err)
+		}
+		if blocks[0].CacheControl.Type != "ephemeral" {
+			t.Fatalf("system block cache_control.type = %q, want \"ephemeral\"", blocks[0].CacheControl.Type)
+		}
+		if blocks[0].CacheControl.TTL != "1h" {
+			t.Fatalf("system block cache_control.ttl = %q, want \"1h\"", blocks[0].CacheControl.TTL)
+		}
+	})
+
+	t.Run("toUserMessageParam propagates manual cache control", func(t *testing.T) {
+		block := schema.NewContentBlock(&schema.UserInputText{Text: "hello"})
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		ctrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+		block = SetContentBlockCacheControl(block, &ctrl)
+		msg := &schema.AgenticMessage{
+			Role:          schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{block},
+		}
+
+		param, err := toUserMessageParam(msg)
+		if err != nil {
+			t.Fatalf("toUserMessageParam() error = %v", err)
+		}
+		if param.Content[0].OfText.CacheControl.Type != "ephemeral" {
+			t.Fatalf("user block cache_control.type = %q, want \"ephemeral\"", param.Content[0].OfText.CacheControl.Type)
+		}
+		if param.Content[0].OfText.CacheControl.TTL != "5m" {
+			t.Fatalf("user block cache_control.ttl = %q, want \"5m\"", param.Content[0].OfText.CacheControl.TTL)
+		}
+	})
+
+	t.Run("toAssistantMessageParam propagates manual cache control", func(t *testing.T) {
+		block := schema.NewContentBlock(&schema.AssistantGenText{Text: "hi"})
+		ctrl := anthropic.NewCacheControlEphemeralParam()
+		block = SetContentBlockCacheControl(block, &ctrl)
+		msg := &schema.AgenticMessage{
+			Role:          schema.AgenticRoleTypeAssistant,
+			ContentBlocks: []*schema.ContentBlock{block},
+		}
+
+		param, err := toAssistantMessageParam(msg)
+		if err != nil {
+			t.Fatalf("toAssistantMessageParam() error = %v", err)
+		}
+		if param.Content[0].OfText.CacheControl.Type != "ephemeral" {
+			t.Fatalf("assistant block cache_control.type = %q, want \"ephemeral\"", param.Content[0].OfText.CacheControl.Type)
+		}
+	})
+
+	t.Run("blocks without manual cache control are not affected", func(t *testing.T) {
+		msg := &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.UserInputText{Text: "hello"}),
+			},
+		}
+
+		param, err := toUserMessageParam(msg)
+		if err != nil {
+			t.Fatalf("toUserMessageParam() error = %v", err)
+		}
+		if param.Content[0].OfText.CacheControl.Type != "" {
+			t.Fatalf("block should not have cache_control, got type=%q", param.Content[0].OfText.CacheControl.Type)
+		}
+	})
+}

--- a/components/model/agenticgemini/README.md
+++ b/components/model/agenticgemini/README.md
@@ -161,9 +161,13 @@ type Config struct {
     
     MediaResolution genai.MediaResolution
     
-    // Cache controls prefix cache settings for the model.
-    // Optional. used to CreatePrefixCache for reused inputs.
-    Cache *CacheConfig
+    // CacheTTL specifies how long prefix cache resources remain valid (now + TTL).
+    // Optional.
+    CacheTTL time.Duration
+
+    // CacheExpireTime sets the absolute expiration timestamp for prefix cache resources.
+    // Optional.
+    CacheExpireTime time.Time
 }
 ```
 

--- a/components/model/agenticgemini/README.zh_CN.md
+++ b/components/model/agenticgemini/README.zh_CN.md
@@ -161,9 +161,13 @@ type Config struct {
     
     MediaResolution genai.MediaResolution
     
-    // Cache 控制模型的前缀缓存设置
-    // 可选。用于为重复使用的输入创建前缀缓存
-    Cache *CacheConfig
+    // CacheTTL 指定前缀缓存资源的有效时长（now + TTL）。
+    // 可选。
+    CacheTTL time.Duration
+
+    // CacheExpireTime 设置前缀缓存资源的绝对过期时间戳。
+    // 可选。
+    CacheExpireTime time.Time
 }
 ```
 

--- a/components/model/agenticgemini/conv.go
+++ b/components/model/agenticgemini/conv.go
@@ -361,8 +361,6 @@ func convAgenticResponse(resp *genai.GenerateContentResponse, lastType schema.Co
 		}
 	}
 
-	message = setSelfGenerated(message)
-
 	return message, nil
 }
 

--- a/components/model/agenticgemini/conv_test.go
+++ b/components/model/agenticgemini/conv_test.go
@@ -98,7 +98,9 @@ func TestConvAgenticMessage_Text(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.message = setSelfGenerated(tt.message)
+			tt.message.ResponseMeta = &schema.AgenticResponseMeta{
+				GeminiExtension: &gemini_schema.ResponseMetaExtension{},
+			}
 			content, err := convAgenticMessage(tt.message)
 			tt.validate(t, content, err)
 		})
@@ -450,7 +452,9 @@ func TestConvAgenticMessage_Tools(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.message = setSelfGenerated(tt.message)
+			tt.message.ResponseMeta = &schema.AgenticResponseMeta{
+				GeminiExtension: &gemini_schema.ResponseMetaExtension{},
+			}
 			content, err := convAgenticMessage(tt.message)
 			tt.validate(t, content, err)
 		})
@@ -839,6 +843,7 @@ func TestConvAgenticResponse(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, message.ResponseMeta)
 				assert.NotNil(t, message.ResponseMeta.TokenUsage)
+				assert.NotNil(t, message.ResponseMeta.GeminiExtension)
 				assert.Equal(t, 10, message.ResponseMeta.TokenUsage.PromptTokens)
 				assert.Equal(t, 20, message.ResponseMeta.TokenUsage.CompletionTokens)
 				assert.Equal(t, 30, message.ResponseMeta.TokenUsage.TotalTokens)

--- a/components/model/agenticgemini/message_extra.go
+++ b/components/model/agenticgemini/message_extra.go
@@ -20,10 +20,6 @@ import (
 	"github.com/cloudwego/eino/schema"
 )
 
-const (
-	geminiGeneratedKey = "gemini-generated"
-)
-
 // allowedNonSelfGeneratedBlockTypes defines the whitelist of ContentBlockTypes
 // that can be processed when a message is NOT self-generated (i.e., from other models).
 // These types are model-agnostic and have standardized fields without model-specific extensions.
@@ -51,18 +47,6 @@ func isAllowedNonSelfGeneratedBlockType(blockType schema.ContentBlockType) bool 
 	return allowedNonSelfGeneratedBlockTypes[blockType]
 }
 
-func setSelfGenerated(msg *schema.AgenticMessage) *schema.AgenticMessage {
-	if msg.Extra == nil {
-		msg.Extra = map[string]any{}
-	}
-	msg.Extra[geminiGeneratedKey] = true
-	return msg
-}
-
 func isSelfGeneratedMessage(msg *schema.AgenticMessage) bool {
-	if msg == nil || msg.Extra == nil {
-		return false
-	}
-	v, ok := msg.Extra[geminiGeneratedKey].(bool)
-	return ok && v
+	return msg != nil && msg.ResponseMeta != nil && msg.ResponseMeta.GeminiExtension != nil
 }

--- a/components/model/agenticgemini/model.go
+++ b/components/model/agenticgemini/model.go
@@ -106,17 +106,13 @@ type Config struct {
 
 	MediaResolution genai.MediaResolution
 
-	// Cache controls prefix cache settings for the model.
-	// Optional. used to CreatePrefixCache for reused inputs.
-	Cache *CacheConfig
-}
+	// CacheTTL specifies how long prefix cache resources remain valid (now + TTL).
+	// Optional.
+	CacheTTL time.Duration
 
-// CacheConfig controls prefix cache settings for the model.
-type CacheConfig struct {
-	// TTL specifies how long cached resources remain valid (now + TTL).
-	TTL time.Duration `json:"ttl,omitempty"`
-	// ExpireTime sets the absolute expiration timestamp for cached resources.
-	ExpireTime time.Time `json:"expireTime,omitempty"`
+	// CacheExpireTime sets the absolute expiration timestamp for prefix cache resources.
+	// Optional.
+	CacheExpireTime time.Time
 }
 
 type ResponseModality string
@@ -150,7 +146,8 @@ func NewAgenticModel(_ context.Context, cfg *Config) (*Gemini, error) {
 		imageConfig:                 cfg.ImageConfig,
 		responseModalities:          cfg.ResponseModalities,
 		mediaResolution:             cfg.MediaResolution,
-		cache:                       cfg.Cache,
+		cacheTTL:                    cfg.CacheTTL,
+		cacheExpireTime:             cfg.CacheExpireTime,
 	}, nil
 }
 
@@ -178,7 +175,8 @@ type Gemini struct {
 	imageConfig                 *genai.ImageConfig
 	responseModalities          []ResponseModality
 	mediaResolution             genai.MediaResolution
-	cache                       *CacheConfig
+	cacheTTL                    time.Duration
+	cacheExpireTime             time.Time
 }
 
 // CreatePrefixCache assembles inputs the same as Generate/Stream and writes
@@ -201,18 +199,8 @@ func (g *Gemini) CreatePrefixCache(ctx context.Context, prefixMsgs []*schema.Age
 		SystemInstruction: genaiConf.SystemInstruction,
 		Tools:             genaiConf.Tools,
 		ToolConfig:        genaiConf.ToolConfig,
-		TTL: func() time.Duration {
-			if g.cache != nil {
-				return g.cache.TTL
-			}
-			return 0
-		}(),
-		ExpireTime: func() time.Time {
-			if g.cache != nil {
-				return g.cache.ExpireTime
-			}
-			return time.Time{}
-		}(),
+		TTL:               g.cacheTTL,
+		ExpireTime:        g.cacheExpireTime,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create cache failed: %w", err)

--- a/components/model/agenticgemini/model_test.go
+++ b/components/model/agenticgemini/model_test.go
@@ -48,9 +48,7 @@ func TestNewAgenticModel(t *testing.T) {
 		},
 		ResponseModalities: []ResponseModality{ResponseModalityText, ResponseModalityImage},
 		ImageConfig:        &genai.ImageConfig{AspectRatio: "16:9", ImageSize: "1K"},
-		Cache: &CacheConfig{
-			TTL: time.Hour,
-		},
+		CacheTTL: time.Hour,
 	}
 	model, err := NewAgenticModel(context.Background(), config)
 	assert.NoError(t, err)
@@ -63,10 +61,9 @@ func TestNewAgenticModel(t *testing.T) {
 	assert.NotNil(t, model.enableCodeExecution)
 	assert.Len(t, model.safetySettings, 1)
 	assert.Len(t, model.responseModalities, 2)
+	assert.Equal(t, time.Hour, model.cacheTTL)
 	assert.Equal(t, "16:9", model.imageConfig.AspectRatio)
 	assert.Equal(t, "1K", model.imageConfig.ImageSize)
-	assert.NotNil(t, model.cache)
-	assert.Equal(t, time.Hour, model.cache.TTL)
 
 	assert.Equal(t, "Gemini", model.GetType())
 	assert.True(t, model.IsCallbacksEnabled())

--- a/components/model/agenticopenai/README.md
+++ b/components/model/agenticopenai/README.md
@@ -10,6 +10,7 @@ An OpenAI model implementation for [Eino](https://github.com/cloudwego/eino) tha
 - Support for responses api
 - Support for streaming responses
 - Support for tool calling (Function Tools, MCP Tools, Server Tools)
+- Support for auto-caching for multi-turn conversations
 - Support for Azure OpenAI
 
 ## Installation
@@ -183,6 +184,14 @@ type Config struct {
     // MCPTools specifies Model Context Protocol tools available to the model.
     // Optional.
     MCPTools []*responses.ToolMcpParam
+
+    // EnableAutoCache controls whether auto-caching for multi-turn conversations is active for the model.
+    // Optional.
+    EnableAutoCache bool
+
+    // PromptCacheRetention specifies the retention policy for the prompt cache.
+    // Optional.
+    PromptCacheRetention *PromptCacheRetention
     
     // CustomHeaders specifies custom HTTP headers to include in API requests.
     // CustomHeaders allows passing additional metadata or authentication information.
@@ -196,7 +205,31 @@ type Config struct {
 }
 ```
 
+Available `PromptCacheRetention` constants:
+
+```go
+const (
+    PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
+    PromptCacheRetention24H      PromptCacheRetention = "24h"
+)
+```
+
 ## Advanced Usage
+
+### Cache
+
+Use `EnableAutoCache` to enable auto-caching for multi-turn conversations. If a cached message becomes invalid, call `InvalidateMessageCaches` to temporarily skip it.
+
+```go
+retention := agenticopenai.PromptCacheRetention24H
+
+am, err := agenticopenai.New(ctx, &agenticopenai.Config{
+	Model:                os.Getenv("OPENAI_MODEL_ID"),
+	APIKey:               os.Getenv("OPENAI_API_KEY"),
+	EnableAutoCache:      true,
+	PromptCacheRetention: &retention,
+})
+```
 
 ### Tool Calling
 

--- a/components/model/agenticopenai/README.zh_CN.md
+++ b/components/model/agenticopenai/README.zh_CN.md
@@ -10,6 +10,7 @@
 - 支持 Responses API
 - 支持流式响应 (Streaming)
 - 支持工具调用 (Tools)，包括函数工具 (Function Tools)、MCP 工具 (MCP Tools) 和服务器工具 (Server Tools)
+- 支持多轮对话自动缓存
 - 支持 Azure OpenAI
 
 ## 安装
@@ -184,6 +185,14 @@ type Config struct {
 	// 可选。
 	MCPTools []*responses.ToolMcpParam
 
+	// EnableAutoCache 控制是否开启多轮对话自动缓存。
+	// 可选。
+	EnableAutoCache bool
+
+	// PromptCacheRetention 指定 prompt cache 的保留策略。
+	// 可选。
+	PromptCacheRetention *PromptCacheRetention
+
 	// CustomHeaders 指定 API 请求中包含的自定义 HTTP 标头。
 	// CustomHeaders 允许传递额外的元数据或身份验证信息。
 	// 可选。
@@ -196,7 +205,31 @@ type Config struct {
 }
 ```
 
+可用的 `PromptCacheRetention` 常量：
+
+```go
+const (
+	PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
+	PromptCacheRetention24H      PromptCacheRetention = "24h"
+)
+```
+
 ## 高级用法
+
+### 缓存
+
+使用 `EnableAutoCache` 开启多轮对话自动缓存。若某条缓存消息已经失效，可以调用 `InvalidateMessageCaches` 临时跳过该缓存。
+
+```go
+retention := agenticopenai.PromptCacheRetention24H
+
+am, err := agenticopenai.New(ctx, &agenticopenai.Config{
+	Model:                os.Getenv("OPENAI_MODEL_ID"),
+	APIKey:               os.Getenv("OPENAI_API_KEY"),
+	EnableAutoCache:      true,
+	PromptCacheRetention: &retention,
+})
+```
 
 ### 工具调用 (Tool Calling)
 

--- a/components/model/agenticopenai/consts.go
+++ b/components/model/agenticopenai/consts.go
@@ -28,6 +28,13 @@ const (
 	ServerToolNameShell           ServerToolName = "shell"
 )
 
+type PromptCacheRetention string
+
+const (
+	PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
+	PromptCacheRetention24H      PromptCacheRetention = "24h"
+)
+
 type WebSearchAction string
 
 const (

--- a/components/model/agenticopenai/convertor.go
+++ b/components/model/agenticopenai/convertor.go
@@ -1588,8 +1588,6 @@ func toOutputMessage(resp *responses.Response, options *model.Options) (msg *sch
 		ResponseMeta:  responseObjectToResponseMeta(resp),
 	}
 
-	msg = setSelfGenerated(msg)
-
 	return msg, nil
 }
 

--- a/components/model/agenticopenai/convertor_test.go
+++ b/components/model/agenticopenai/convertor_test.go
@@ -228,7 +228,9 @@ func TestToAssistantRoleInputItems(t *testing.T) {
 		setItemStatus(mcpRes, "completed")
 		msg.ContentBlocks = append(msg.ContentBlocks, mcpRes)
 
-		msg = setSelfGenerated(msg)
+		msg.ResponseMeta = &schema.AgenticResponseMeta{
+			OpenAIExtension: &openaischema.ResponseMetaExtension{},
+		}
 
 		items, err := toAssistantRoleInputItems(msg)
 		assert.NoError(t, err)

--- a/components/model/agenticopenai/event_convertor.go
+++ b/components/model/agenticopenai/event_convertor.go
@@ -250,8 +250,6 @@ func (s *callbackSender) send(meta *schema.AgenticResponseMeta, block *schema.Co
 		ResponseMeta: meta,
 	}
 
-	msg = setSelfGenerated(msg)
-
 	if block != nil {
 		msg.ContentBlocks = []*schema.ContentBlock{block}
 	}

--- a/components/model/agenticopenai/examples/session_cache/main.go
+++ b/components/model/agenticopenai/examples/session_cache/main.go
@@ -22,27 +22,20 @@ import (
 	"io"
 	"log"
 	"os"
-	"time"
 
-	"github.com/cloudwego/eino-ext/components/model/agenticark"
+	"github.com/cloudwego/eino-ext/components/model/agenticopenai"
 	"github.com/cloudwego/eino/schema"
-	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 )
 
 func main() {
 	ctx := context.Background()
 
-	expireAtSec := time.Now().Add(10 * time.Minute).Unix()
-
-	// Get ARK_API_KEY and ARK_MODEL_ID: https://www.volcengine.com/docs/82379/1399008
-	am, err := agenticark.New(ctx, &agenticark.Config{
-		APIKey: os.Getenv("ARK_API_KEY"),
-		Model:  os.Getenv("ARK_MODEL_ID"),
-		Thinking: &responses.ResponsesThinking{
-			Type: responses.ThinkingType_disabled.Enum(),
-		},
+	// Get OPENAI_API_KEY and OPENAI_MODEL_ID
+	am, err := agenticopenai.New(ctx, &agenticopenai.Config{
+		BaseURL:         "https://api.openai.com/v1",
+		APIKey:          os.Getenv("OPENAI_API_KEY"),
+		Model:           os.Getenv("OPENAI_MODEL_ID"),
 		EnableAutoCache: true,
-		ExpireAtSec:     &expireAtSec,
 	})
 	if err != nil {
 		log.Fatalf("failed to create chat model, err=%v", err)

--- a/components/model/agenticopenai/message_extra.go
+++ b/components/model/agenticopenai/message_extra.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	openaiGeneratedKey = "openai-generated"
+	keyOfResponseAutoCached = "_eino_ext_agenticopenai_auto_cached"
 )
 
 // allowedNonSelfGeneratedBlockTypes defines the whitelist of ContentBlockTypes
@@ -43,6 +43,7 @@ var allowedNonSelfGeneratedBlockTypes = map[schema.ContentBlockType]bool{
 	// Function Tool types - user-defined tools, cross-model compatible
 	schema.ContentBlockTypeFunctionToolCall:   true,
 	schema.ContentBlockTypeFunctionToolResult: true,
+	schema.ContentBlockTypeToolSearchResult:   true,
 }
 
 // isAllowedNonSelfGeneratedBlockType checks if a ContentBlockType is in the whitelist
@@ -51,18 +52,26 @@ func isAllowedNonSelfGeneratedBlockType(blockType schema.ContentBlockType) bool 
 	return allowedNonSelfGeneratedBlockTypes[blockType]
 }
 
-func setSelfGenerated(msg *schema.AgenticMessage) *schema.AgenticMessage {
+func isSelfGeneratedMessage(msg *schema.AgenticMessage) bool {
+	return msg != nil && msg.ResponseMeta != nil && msg.ResponseMeta.OpenAIExtension != nil
+}
+
+func setAutoCached(msg *schema.AgenticMessage) *schema.AgenticMessage {
 	if msg.Extra == nil {
 		msg.Extra = map[string]any{}
 	}
-	msg.Extra[openaiGeneratedKey] = true
+	msg.Extra[keyOfResponseAutoCached] = true
 	return msg
 }
 
-func isSelfGeneratedMessage(msg *schema.AgenticMessage) bool {
-	if msg == nil || msg.Extra == nil {
-		return false
+// InvalidateMessageCaches temporarily disables caching for the specified messages.
+// When a message is modified or model is switched, OPENAI invalidates caches for that message and all subsequent ones.
+// Call this to mark those message caches as invalid temporarily.
+func InvalidateMessageCaches(messages []*schema.AgenticMessage) error {
+	for _, msg := range messages {
+		if msg.Extra != nil {
+			delete(msg.Extra, keyOfResponseAutoCached)
+		}
 	}
-	v, ok := msg.Extra[openaiGeneratedKey].(bool)
-	return ok && v
+	return nil
 }

--- a/components/model/agenticopenai/model.go
+++ b/components/model/agenticopenai/model.go
@@ -123,6 +123,19 @@ type Config struct {
 	// Optional.
 	Truncation *responses.ResponseNewParamsTruncation
 
+	// EnableAutoCache controls whether auto-caching for multi-turn conversations is active for the model.
+	// When enabled, conversation turns are stored, and the model automatically maintains context
+	// by locating the most recent cached message in the input (via Response ID in ResponseMeta).
+	// This cached message and all preceding inputs are excluded from the request.
+	// If the cached message becomes invalid, you can call InvalidateMessageCaches to temporarily invalidate the cache.
+	// Unless store is set to false explicitly for a request, auto-cache forces Store to true.
+	// Optional.
+	EnableAutoCache bool
+
+	// PromptCacheRetention specifies the retention policy for the prompt cache.
+	// Optional.
+	PromptCacheRetention *PromptCacheRetention
+
 	// CustomHeaders specifies custom HTTP headers to include in API requests.
 	// CustomHeaders allows passing additional metadata or authentication information.
 	// Optional.
@@ -180,23 +193,25 @@ func buildClient(config *Config) (*Model, error) {
 	client := responses.NewResponseService(opts...)
 
 	cm := &Model{
-		cli:               client,
-		model:             config.Model,
-		maxTokens:         config.MaxTokens,
-		temperature:       config.Temperature,
-		topP:              config.TopP,
-		serviceTier:       config.ServiceTier,
-		text:              config.Text,
-		reasoning:         config.Reasoning,
-		store:             config.Store,
-		maxToolCalls:      config.MaxToolCalls,
-		parallelToolCalls: config.ParallelToolCalls,
-		include:           config.Include,
-		serverTools:       config.ServerTools,
-		mcpTools:          config.MCPTools,
-		truncation:        config.Truncation,
-		customHeader:      config.CustomHeaders,
-		extraFields:       config.ExtraFields,
+		cli:                  client,
+		model:                config.Model,
+		maxTokens:            config.MaxTokens,
+		temperature:          config.Temperature,
+		topP:                 config.TopP,
+		serviceTier:          config.ServiceTier,
+		text:                 config.Text,
+		reasoning:            config.Reasoning,
+		store:                config.Store,
+		maxToolCalls:         config.MaxToolCalls,
+		parallelToolCalls:    config.ParallelToolCalls,
+		include:              config.Include,
+		serverTools:          config.ServerTools,
+		mcpTools:             config.MCPTools,
+		truncation:           config.Truncation,
+		enableAutoCache:      config.EnableAutoCache,
+		promptCacheRetention: config.PromptCacheRetention,
+		customHeader:         config.CustomHeaders,
+		extraFields:          config.ExtraFields,
 	}
 
 	return cm, nil
@@ -205,20 +220,22 @@ func buildClient(config *Config) (*Model, error) {
 type Model struct {
 	cli responses.ResponseService
 
-	model             string
-	maxTokens         *int
-	temperature       *float32
-	topP              *float32
-	serviceTier       *responses.ResponseNewParamsServiceTier
-	text              *responses.ResponseTextConfigParam
-	reasoning         *responses.ReasoningParam
-	store             *bool
-	maxToolCalls      *int
-	parallelToolCalls *bool
-	include           []responses.ResponseIncludable
-	serverTools       []*ServerToolConfig
-	mcpTools          []*responses.ToolMcpParam
-	truncation        *responses.ResponseNewParamsTruncation
+	model                string
+	maxTokens            *int
+	temperature          *float32
+	topP                 *float32
+	serviceTier          *responses.ResponseNewParamsServiceTier
+	text                 *responses.ResponseTextConfigParam
+	reasoning            *responses.ReasoningParam
+	store                *bool
+	maxToolCalls         *int
+	parallelToolCalls    *bool
+	include              []responses.ResponseIncludable
+	serverTools          []*ServerToolConfig
+	mcpTools             []*responses.ToolMcpParam
+	truncation           *responses.ResponseNewParamsTruncation
+	enableAutoCache      bool
+	promptCacheRetention *PromptCacheRetention
 
 	customHeader map[string]string
 	extraFields  map[string]any
@@ -263,6 +280,10 @@ func (m *Model) Generate(ctx context.Context, input []*schema.AgenticMessage, op
 		return nil, fmt.Errorf("failed to convert output to message: %w", err)
 	}
 
+	if m.enableAutoCache {
+		setAutoCached(outMsg)
+	}
+
 	callbacks.OnEnd(ctx, &model.AgenticCallbackOutput{
 		Message:    outMsg,
 		Config:     config,
@@ -302,6 +323,9 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 	}()
 
 	respStreamReader := m.cli.NewStreaming(ctx, *req, reqOpts...)
+	if err = respStreamReader.Err(); err != nil {
+		return nil, fmt.Errorf("failed to create streaming response: %w", err)
+	}
 
 	sr, sw := schema.Pipe[*model.AgenticCallbackOutput](1)
 
@@ -335,6 +359,9 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 			if s.Message == nil {
 				return nil, schema.ErrNoValue
 			}
+			if m.enableAutoCache {
+				setAutoCached(s.Message)
+			}
 			return s.Message, nil
 		},
 	)
@@ -348,13 +375,6 @@ func (m *Model) GetType() string {
 
 func (m *Model) IsCallbacksEnabled() bool {
 	return true
-}
-
-type CacheInfo struct {
-	// ResponseID return by ResponsesAPI, it's specifies the id of prefix that can be used with [WithCache.HeadPreviousResponseID] option.
-	ResponseID string
-	// Usage specifies the token usage of prefix
-	Usage schema.TokenUsage
 }
 
 func toCallbackConfig(req *responses.ResponseNewParams) *model.AgenticConfig {
@@ -522,6 +542,11 @@ func (m *Model) genRequestAndOptions(in []*schema.AgenticMessage, options *model
 		return req, nil, fmt.Errorf("failed to pre-populate config: %w", err)
 	}
 
+	in, err = m.populateCache(in, req, specOptions)
+	if err != nil {
+		return req, nil, fmt.Errorf("failed to populate cache: %w", err)
+	}
+
 	err = m.populateInput(in, req)
 	if err != nil {
 		return req, nil, fmt.Errorf("failed to populate input: %w", err)
@@ -556,6 +581,9 @@ func (m *Model) prePopulateConfig(responseReq *responses.ResponseNewParams, opti
 		responseReq.ServiceTier = *m.serviceTier
 	}
 	responseReq.Include = m.include
+	if m.promptCacheRetention != nil {
+		responseReq.PromptCacheRetention = responses.ResponseNewParamsPromptCacheRetention(*m.promptCacheRetention)
+	}
 
 	// options configuration
 	if options.TopP != nil {
@@ -591,6 +619,66 @@ func (m *Model) prePopulateConfig(responseReq *responses.ResponseNewParams, opti
 	}
 
 	return nil
+}
+
+// populateCache resolves the PreviousResponseID for cache continuation.
+// Priority: auto-discovered response ID in messages > WithHeadPreviousResponseID option > none.
+// When enableAutoCache is true and an explicit WithStore(false) is not set, Store is forced to true.
+func (m *Model) populateCache(in []*schema.AgenticMessage, responseReq *responses.ResponseNewParams,
+	specOpts *openaiOptions) ([]*schema.AgenticMessage, error) {
+
+	var (
+		enableCache = m.enableAutoCache
+		headRespID  = specOpts.headPreviousResponseID
+	)
+
+	var (
+		preRespID *string
+		inputIdx  int
+	)
+
+	if enableCache {
+		for i := len(in) - 1; i >= 0; i-- {
+			msg := in[i]
+			if msg.Extra == nil {
+				continue
+			}
+			if isAutoCached, ok := msg.Extra[keyOfResponseAutoCached].(bool); !ok || !isAutoCached {
+				continue
+			}
+			if msg.ResponseMeta == nil || msg.ResponseMeta.OpenAIExtension == nil {
+				continue
+			}
+			if msg.ResponseMeta.OpenAIExtension.ID == "" {
+				continue
+			}
+			inputIdx = i
+			preRespID = &msg.ResponseMeta.OpenAIExtension.ID
+			break
+		}
+	}
+
+	if preRespID != nil {
+		if inputIdx+1 >= len(in) {
+			return in, fmt.Errorf("incremental input not found after response ID")
+		}
+		in = in[inputIdx+1:]
+	}
+
+	// ResponseID has a higher priority than HeadPreviousResponseID
+	if preRespID == nil || *preRespID == "" {
+		preRespID = headRespID
+	}
+
+	if preRespID != nil && *preRespID != "" {
+		responseReq.PreviousResponseID = param.NewOpt(*preRespID)
+	}
+
+	if enableCache && specOpts.store == nil {
+		responseReq.Store = param.NewOpt(true)
+	}
+
+	return in, nil
 }
 
 func (m *Model) populateInput(in []*schema.AgenticMessage, responseReq *responses.ResponseNewParams) (err error) {

--- a/components/model/agenticopenai/option.go
+++ b/components/model/agenticopenai/option.go
@@ -22,19 +22,32 @@ import (
 )
 
 type openaiOptions struct {
-	reasoning         *responses.ReasoningParam
-	maxToolCalls      *int
-	parallelToolCalls *bool
-	text              *responses.ResponseTextConfigParam
-	store             *bool
-	promptCacheKey    *string
-	truncation        *responses.ResponseNewParamsTruncation
+	reasoning              *responses.ReasoningParam
+	maxToolCalls           *int
+	parallelToolCalls      *bool
+	text                   *responses.ResponseTextConfigParam
+	store                  *bool
+	promptCacheKey         *string
+	headPreviousResponseID *string
+	truncation             *responses.ResponseNewParamsTruncation
 
 	serverTools []*ServerToolConfig
 	mcpTools    []*responses.ToolMcpParam
 
 	customHeaders map[string]string
 	extraFields   map[string]any
+}
+
+// WithHeadPreviousResponseID sets a response ID from a previous ResponsesAPI call.
+// This ID links the current request to a previous conversation context, enabling
+// features like conversation continuation and prefix caching.
+// In populateCache, an auto-discovered response ID from input messages takes
+// priority over this option.
+// The referenced response must be cached before use.
+func WithHeadPreviousResponseID(id string) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *openaiOptions) {
+		o.headPreviousResponseID = &id
+	})
 }
 
 func WithStore(store bool) model.Option {


### PR DESCRIPTION
## Summary

Add prompt caching support to the agentic model packages. `agenticclaude` uses the Anthropic API's top-level `cache_control` field to automatically apply a cache_control marker to the last cacheable block in the request. `agenticark` and `agenticopenai` use response-ID-based session caching with auto-cache markers on responses. `agenticgemini` nests cache expiration configuration under `CacheExpiration` for a clearer API.

### Breaking Changes

1. `agenticark.WithCache(option *CacheOption)` removed — use `Config.EnableAutoCache` for session caching and `WithHeadPreviousResponseID(id)` for manual response ID linking
2. `agenticark.CreatePrefixCache` no longer accepts `expireAtSec *int64` parameter — use `Config.ExpireAtSec` or `WithExpireAtSec` option instead
3. `agenticgemini.CacheConfig` struct removed — use `Config.CacheExpiration` instead

### API Changes

1. **Added**: `agenticclaude.Config.CacheControl *anthropic.CacheControlEphemeralParam` — top-level cache control
2. **Added**: `agenticclaude.SetContentBlockCacheControl(block, ctrl) *schema.ContentBlock`
3. **Added**: `agenticclaude.SetToolInfoCacheControl(toolInfo, ctrl) *schema.ToolInfo`
4. **Added**: `agenticopenai.Config.EnableAutoCache`, `agenticopenai.InvalidateMessageCaches`, `agenticopenai.WithHeadPreviousResponseID`
5. **Added**: `agenticark.Config.EnableAutoCache`, `agenticark.Config.ExpireAtSec`, `agenticark.InvalidateMessageCaches`, `agenticark.WithHeadPreviousResponseID`, `agenticark.WithExpireAtSec`
6. **Added**: `agenticgemini.Config.CacheExpiration`, `agenticgemini.CacheExpiration`

### Key Changes

1. `agenticclaude` uses `*anthropic.CacheControlEphemeralParam` directly from the SDK as its cache config — when non-nil, the API server handles applying it to the last cacheable block; manual per-block control via `SetContentBlockCacheControl`/`SetToolInfoCacheControl` is also supported
2. `agenticark`/`agenticopenai` auto-cache marks responses and uses the last cached response ID as prefix; `InvalidateMessageCaches` clears those markers
3. `agenticark.CreatePrefixCache` reads expiration from `Config.ExpireAtSec`, overridable per-request via `WithExpireAtSec` option
4. `agenticgemini` nests cache expiration into `Config.CacheExpiration`; exactly one of `TTL` or `ExpireTime` may be set; `gemini.go` is renamed to `model.go`