### PR TITLE
feat(agenticgemini): support image config

### DIFF
--- a/components/model/agenticgemini/README.md
+++ b/components/model/agenticgemini/README.md
@@ -149,6 +149,11 @@ type Config struct {
     SafetySettings []*genai.SafetySetting
     
     ThinkingConfig *genai.ThinkingConfig
+
+    // ImageConfig is the image generation configuration.
+    // Note: an error will be returned if this field is set for a model that does not support the configuration options.
+    // Optional.
+    ImageConfig *genai.ImageConfig
     
     // ResponseModalities specifies the modalities the model can return.
     // Optional.

--- a/components/model/agenticgemini/README.zh_CN.md
+++ b/components/model/agenticgemini/README.zh_CN.md
@@ -149,6 +149,11 @@ type Config struct {
     SafetySettings []*genai.SafetySetting
     
     ThinkingConfig *genai.ThinkingConfig
+
+    // ImageConfig 是图片生成配置
+    // 注意：如果模型不支持该配置选项，将会返回错误
+    // 可选。
+    ImageConfig *genai.ImageConfig
     
     // ResponseModalities 指定模型可以返回的模态类型
     // 可选。

--- a/components/model/agenticgemini/conv.go
+++ b/components/model/agenticgemini/conv.go
@@ -730,6 +730,7 @@ func (g *Gemini) genInputAndConf(input []*schema.AgenticMessage, opts ...model.O
 		TopK:               g.topK,
 		ResponseJSONSchema: g.responseJSONSchema,
 		ResponseModalities: g.responseModalities,
+		ImageConfig:        g.imageConfig,
 	}, opts...)
 	conf := &model.AgenticConfig{}
 
@@ -896,6 +897,10 @@ func (g *Gemini) genInputAndConf(input []*schema.AgenticMessage, opts ...model.O
 	m.ThinkingConfig = g.thinkingConfig
 	if geminiOptions.ThinkingConfig != nil {
 		m.ThinkingConfig = geminiOptions.ThinkingConfig
+	}
+
+	if geminiOptions.ImageConfig != nil {
+		m.ImageConfig = geminiOptions.ImageConfig
 	}
 
 	if len(geminiOptions.CachedContentName) > 0 {

--- a/components/model/agenticgemini/examples/image_generate/image_generate.go
+++ b/components/model/agenticgemini/examples/image_generate/image_generate.go
@@ -45,6 +45,11 @@ func main() {
 	cm, err := agenticgemini.NewAgenticModel(ctx, &agenticgemini.Config{
 		Client: client,
 		Model:  modelName,
+		// you can set the necessary parameters for image generation
+		ImageConfig: &genai.ImageConfig{
+			AspectRatio: "16:9",
+			ImageSize:   "1K",
+		},
 		ResponseModalities: []agenticgemini.ResponseModality{
 			agenticgemini.ResponseModalityText,
 			agenticgemini.ResponseModalityImage,

--- a/components/model/agenticgemini/gemini.go
+++ b/components/model/agenticgemini/gemini.go
@@ -95,6 +95,11 @@ type Config struct {
 
 	ThinkingConfig *genai.ThinkingConfig
 
+	// ImageConfig is the image generation configuration.
+	// Note: an error will be returned if this field is set for a model that does not support the configuration options.
+	// Optional.
+	ImageConfig *genai.ImageConfig
+
 	// ResponseModalities specifies the modalities the model can return.
 	// Optional.
 	ResponseModalities []ResponseModality
@@ -142,6 +147,7 @@ func NewAgenticModel(_ context.Context, cfg *Config) (*Gemini, error) {
 		enableGoogleMaps:            cfg.EnableGoogleMaps,
 		safetySettings:              cfg.SafetySettings,
 		thinkingConfig:              cfg.ThinkingConfig,
+		imageConfig:                 cfg.ImageConfig,
 		responseModalities:          cfg.ResponseModalities,
 		mediaResolution:             cfg.MediaResolution,
 		cache:                       cfg.Cache,
@@ -169,6 +175,7 @@ type Gemini struct {
 	enableGoogleMaps            *genai.GoogleMaps
 	safetySettings              []*genai.SafetySetting
 	thinkingConfig              *genai.ThinkingConfig
+	imageConfig                 *genai.ImageConfig
 	responseModalities          []ResponseModality
 	mediaResolution             genai.MediaResolution
 	cache                       *CacheConfig

--- a/components/model/agenticgemini/gemini_test.go
+++ b/components/model/agenticgemini/gemini_test.go
@@ -47,6 +47,7 @@ func TestNewAgenticModel(t *testing.T) {
 			},
 		},
 		ResponseModalities: []ResponseModality{ResponseModalityText, ResponseModalityImage},
+		ImageConfig:        &genai.ImageConfig{AspectRatio: "16:9", ImageSize: "1K"},
 		Cache: &CacheConfig{
 			TTL: time.Hour,
 		},
@@ -62,6 +63,8 @@ func TestNewAgenticModel(t *testing.T) {
 	assert.NotNil(t, model.enableCodeExecution)
 	assert.Len(t, model.safetySettings, 1)
 	assert.Len(t, model.responseModalities, 2)
+	assert.Equal(t, "16:9", model.imageConfig.AspectRatio)
+	assert.Equal(t, "1K", model.imageConfig.ImageSize)
 	assert.NotNil(t, model.cache)
 	assert.Equal(t, time.Hour, model.cache.TTL)
 
@@ -83,6 +86,10 @@ func TestGemini_GenInputAndConf(t *testing.T) {
 		model:       "gemini-pro",
 		temperature: ptrOf(float32(0.5)),
 		topP:        ptrOf(float32(0.9)),
+		imageConfig: &genai.ImageConfig{
+			AspectRatio: "1:1",
+			ImageSize:   "1K",
+		},
 	}
 
 	input := []*schema.AgenticMessage{
@@ -120,6 +127,16 @@ func TestGemini_GenInputAndConf(t *testing.T) {
 	assert.Equal(t, newModel, conf.Model)
 	assert.Equal(t, genai.FunctionCallingConfigModeAny, genaiConf.ToolConfig.FunctionCallingConfig.Mode)
 	assert.Equal(t, []string{"tool1"}, genaiConf.ToolConfig.FunctionCallingConfig.AllowedFunctionNames)
+	assert.Equal(t, "1:1", genaiConf.ImageConfig.AspectRatio)
+	assert.Equal(t, "1K", genaiConf.ImageConfig.ImageSize)
+
+	overrideImageConfig := &genai.ImageConfig{
+		AspectRatio: "16:9",
+		ImageSize:   "2K",
+	}
+	_, _, genaiConf, _, err = g.genInputAndConf(input, WithImageConfig(overrideImageConfig))
+	assert.NoError(t, err)
+	assert.Equal(t, overrideImageConfig, genaiConf.ImageConfig)
 }
 
 func TestGemini_Generate_Success(t *testing.T) {

--- a/components/model/agenticgemini/option.go
+++ b/components/model/agenticgemini/option.go
@@ -27,6 +27,7 @@ type options struct {
 	ResponseJSONSchema *jsonschema.Schema
 	ThinkingConfig     *genai.ThinkingConfig
 	ResponseModalities []ResponseModality
+	ImageConfig        *genai.ImageConfig
 
 	CachedContentName string
 }
@@ -52,6 +53,15 @@ func WithThinkingConfig(t *genai.ThinkingConfig) model.Option {
 func WithResponseModalities(m []ResponseModality) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.ResponseModalities = m
+	})
+}
+
+// WithImageConfig sets the image generation configuration.
+// Note: an error will be returned for a model that does not support the configuration options.
+// Optional.
+func WithImageConfig(cfg *genai.ImageConfig) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.ImageConfig = cfg
 	})
 }
 

--- a/components/model/agenticgemini/option_test.go
+++ b/components/model/agenticgemini/option_test.go
@@ -32,6 +32,7 @@ func TestSpecificOptions(t *testing.T) {
 		WithCachedContentName("name"),
 		WithThinkingConfig(&genai.ThinkingConfig{}),
 		WithResponseModalities([]ResponseModality{ResponseModalityText}),
+		WithImageConfig(&genai.ImageConfig{AspectRatio: "16:9"}),
 	)
 
 	assert.Equal(t, int32(2), *o.TopK)
@@ -39,4 +40,5 @@ func TestSpecificOptions(t *testing.T) {
 	assert.Equal(t, "name", o.CachedContentName)
 	assert.NotNil(t, o.ThinkingConfig)
 	assert.Len(t, o.ResponseModalities, 1)
+	assert.Equal(t, "16:9", o.ImageConfig.AspectRatio)
 }


### PR DESCRIPTION
## Summary
- add ImageConfig support to agenticgemini config and runtime options
- pass ImageConfig through to genai.GenerateContentConfig
- update image generation example and tests

## Validation
- go test ./... in components/model/agenticgemini
