### PR TITLE
feat(gemini): support response logprobs

### DIFF
--- a/components/model/gemini/README.md
+++ b/components/model/gemini/README.md
@@ -205,6 +205,17 @@ type Config struct {
 	// Cache controls prefix cache settings for the model.
 	// Optional. used to CreatePrefixCache for reused inputs.
 	Cache *CacheConfig
+
+	// ResponseLogprobs controls whether to return the log probabilities of the
+	// tokens chosen by the model at each step. When enabled, logprobs are
+	// populated in Message.ResponseMeta.LogProbs.
+	// Optional. Default: false.
+	ResponseLogprobs bool
+
+	// Logprobs specifies the number of top candidate tokens whose log
+	// probabilities are returned at each generation step.
+	// Optional. Only takes effect when ResponseLogprobs is true.
+	Logprobs *int32
 }
 
 // CacheConfig controls prefix cache settings for the model.
@@ -252,6 +263,40 @@ msg, err := cm.Generate(ctx, []*schema.Message{
 ```
 
 The example above shows how to create a prefix cache and reuse it in a follow-up call.
+
+## Logprobs
+
+Gemini can return the log probabilities of the tokens chosen at each generation step, plus the top-K candidate tokens at each step.
+
+- Enable via `Config.ResponseLogprobs = true` (or per-call `gemini.WithResponseLogprobs(true)`).
+- Configure the number of top candidates via `Config.Logprobs` (or per-call `gemini.WithLogprobs(k)`).
+- Results are populated in `message.ResponseMeta.LogProbs`:
+  - `LogProbs.Content[i].Token` / `LogProb` — chosen token at step `i`
+  - `LogProbs.Content[i].TopLogProbs` — top-K candidate tokens at step `i`
+
+```go
+topK := int32(5)
+cm, _ := gemini.NewChatModel(ctx, &gemini.Config{
+    Client:           client,
+    Model:            "gemini-2.0-flash",
+    ResponseLogprobs: true,
+    Logprobs:         &topK,
+})
+
+// Per-call override is also supported:
+msg, _ := cm.Generate(ctx, input,
+    gemini.WithResponseLogprobs(true),
+    gemini.WithLogprobs(3),
+)
+
+if lp := msg.ResponseMeta.LogProbs; lp != nil {
+    for _, item := range lp.Content {
+        fmt.Printf("token=%s logprob=%f\n", item.Token, item.LogProb)
+    }
+}
+```
+
+> Note: `Logprobs` only takes effect when `ResponseLogprobs` is true. To disable logprobs at call time, use `gemini.WithResponseLogprobs(false)`.
 
 ## Examples
 

--- a/components/model/gemini/README_zh.md
+++ b/components/model/gemini/README_zh.md
@@ -205,6 +205,13 @@ type Config struct {
 	// Cache controls prefix cache settings for the model.
 	// Optional. used to CreatePrefixCache for reused inputs.
 	Cache *CacheConfig
+
+	// 是否返回每一步生成 token 的 log probabilities。开启后结果填充到
+	// Message.ResponseMeta.LogProbs。可选，默认 false。
+	ResponseLogprobs bool
+
+	// 每一步返回 top-K 候选 token 的数量。仅在 ResponseLogprobs=true 时生效。
+	Logprobs *int32
 }
 
 // CacheConfig controls prefix cache settings for the model.
@@ -251,6 +258,40 @@ msg, err := cm.Generate(ctx, []*schema.Message{
 		},
 	}, gemini.WithCachedContentName(cacheInfo.Name))
 ```
+
+## Logprobs（token 概率）
+
+Gemini 可返回每一步生成 token 的对数概率，以及该步骤的 top-K 候选 token。
+
+- 通过 `Config.ResponseLogprobs = true`（或单次调用 `gemini.WithResponseLogprobs(true)`）开启。
+- 通过 `Config.Logprobs`（或单次调用 `gemini.WithLogprobs(k)`）配置 top-K 候选数量。
+- 结果在 `message.ResponseMeta.LogProbs`：
+  - `LogProbs.Content[i].Token` / `LogProb` —— 第 `i` 步选中的 token 与其对数概率
+  - `LogProbs.Content[i].TopLogProbs` —— 第 `i` 步的 top-K 候选 token
+
+```go
+topK := int32(5)
+cm, _ := gemini.NewChatModel(ctx, &gemini.Config{
+    Client:           client,
+    Model:            "gemini-2.0-flash",
+    ResponseLogprobs: true,
+    Logprobs:         &topK,
+})
+
+// 也可在单次调用时覆盖：
+msg, _ := cm.Generate(ctx, input,
+    gemini.WithResponseLogprobs(true),
+    gemini.WithLogprobs(3),
+)
+
+if lp := msg.ResponseMeta.LogProbs; lp != nil {
+    for _, item := range lp.Content {
+        fmt.Printf("token=%s logprob=%f\n", item.Token, item.LogProb)
+    }
+}
+```
+
+> 注意：`Logprobs` 仅在 `ResponseLogprobs=true` 时生效。若想在单次调用中关闭 logprobs，请使用 `gemini.WithResponseLogprobs(false)`。
 
 
 ## 示例

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -78,6 +78,8 @@ func NewChatModel(_ context.Context, cfg *Config) (*ChatModel, error) {
 		responseModalities:          cfg.ResponseModalities,
 		mediaResolution:             cfg.MediaResolution,
 		cache:                       cfg.Cache,
+		responseLogprobs:            cfg.ResponseLogprobs,
+		logprobs:                    cfg.Logprobs,
 	}, nil
 }
 
@@ -146,6 +148,17 @@ type Config struct {
 	// Cache controls prefix cache settings for the model.
 	// Optional. used to CreatePrefixCache for reused inputs.
 	Cache *CacheConfig
+
+	// ResponseLogprobs controls whether to return the log probabilities of the
+	// tokens that were chosen by the model at each step.
+	// When enabled, response logprobs are populated in Message.ResponseMeta.LogProbs.
+	// Optional. Default: false. Configure top-K candidates via Logprobs.
+	ResponseLogprobs bool
+
+	// Logprobs specifies the number of top candidate tokens to return the
+	// log probabilities for at each generation step.
+	// Optional. Only takes effect when ResponseLogprobs is true.
+	Logprobs *int32
 }
 
 // CacheConfig controls prefix cache settings for the model.
@@ -181,6 +194,8 @@ type ChatModel struct {
 	responseModalities          []GeminiResponseModality
 	mediaResolution             genai.MediaResolution
 	cache                       *CacheConfig
+	responseLogprobs            bool
+	logprobs                    *int32
 }
 
 func (cm *ChatModel) Generate(ctx context.Context, input []*schema.Message, opts ...model.Option) (message *schema.Message, err error) {
@@ -466,6 +481,7 @@ func (cm *ChatModel) genInputAndConf(input []*schema.Message, opts ...model.Opti
 		ResponseJSONSchema: cm.responseJSONSchema,
 		ResponseModalities: cm.responseModalities,
 		ImageConfig:        cm.imageConfig,
+		Logprobs:           cm.logprobs,
 	}, opts...)
 	conf := &model.Config{}
 
@@ -591,6 +607,14 @@ func (cm *ChatModel) genInputAndConf(input []*schema.Message, opts ...model.Opti
 		m.SystemInstruction = nil
 		m.Tools = nil
 		m.ToolConfig = nil
+	}
+
+	m.ResponseLogprobs = cm.responseLogprobs
+	if geminiOptions.ResponseLogprobs != nil {
+		m.ResponseLogprobs = *geminiOptions.ResponseLogprobs
+	}
+	if geminiOptions.Logprobs != nil {
+		m.Logprobs = geminiOptions.Logprobs
 	}
 
 	return conf.Model, nInput, m, conf, nil
@@ -1165,6 +1189,12 @@ func convCandidate(candidate *genai.Candidate) (*schema.Message, error) {
 		},
 	}
 
+	if candidate.LogprobsResult != nil {
+		if lp := convLogprobs(candidate.LogprobsResult); lp != nil {
+			result.ResponseMeta.LogProbs = lp
+		}
+	}
+
 	if candidate.GroundingMetadata != nil {
 		setGroundMetadata(result, candidate.GroundingMetadata)
 	}
@@ -1368,6 +1398,41 @@ func toGeminiRole(role schema.RoleType) string {
 }
 
 const typ = "Gemini"
+
+func convLogprobs(lp *genai.LogprobsResult) *schema.LogProbs {
+	if lp == nil || len(lp.ChosenCandidates) == 0 {
+		return nil
+	}
+	out := &schema.LogProbs{
+		Content: make([]schema.LogProb, 0, len(lp.ChosenCandidates)),
+	}
+	for i, chosen := range lp.ChosenCandidates {
+		if chosen == nil {
+			continue
+		}
+		item := schema.LogProb{
+			Token:   chosen.Token,
+			LogProb: float64(chosen.LogProbability),
+		}
+		if i < len(lp.TopCandidates) && lp.TopCandidates[i] != nil {
+			item.TopLogProbs = make([]schema.TopLogProb, 0, len(lp.TopCandidates[i].Candidates))
+			for _, c := range lp.TopCandidates[i].Candidates {
+				if c == nil {
+					continue
+				}
+				item.TopLogProbs = append(item.TopLogProbs, schema.TopLogProb{
+					Token:   c.Token,
+					LogProb: float64(c.LogProbability),
+				})
+			}
+		}
+		out.Content = append(out.Content, item)
+	}
+	if len(out.Content) == 0 {
+		return nil
+	}
+	return out
+}
 
 func (cm *ChatModel) GetType() string {
 	return typ

--- a/components/model/gemini/gemini_test.go
+++ b/components/model/gemini/gemini_test.go
@@ -1590,3 +1590,137 @@ func TestConvSchemaMessageToolCallOrder(t *testing.T) {
 		assert.Equal(t, "tool2", content.Parts[2].FunctionCall.Name)
 	})
 }
+
+func TestConvLogprobs(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		assert.Nil(t, convLogprobs(nil))
+	})
+
+	t.Run("empty chosen candidates", func(t *testing.T) {
+		assert.Nil(t, convLogprobs(&genai.LogprobsResult{}))
+	})
+
+	t.Run("all chosen candidates nil", func(t *testing.T) {
+		assert.Nil(t, convLogprobs(&genai.LogprobsResult{
+			ChosenCandidates: []*genai.LogprobsResultCandidate{nil, nil},
+		}))
+	})
+
+	t.Run("normal with top candidates", func(t *testing.T) {
+		lp := &genai.LogprobsResult{
+			ChosenCandidates: []*genai.LogprobsResultCandidate{
+				{Token: "hello", LogProbability: -0.1},
+				{Token: "world", LogProbability: -0.2},
+			},
+			TopCandidates: []*genai.LogprobsResultTopCandidates{
+				{Candidates: []*genai.LogprobsResultCandidate{
+					{Token: "hello", LogProbability: -0.1},
+					{Token: "hi", LogProbability: -1.5},
+				}},
+				{Candidates: []*genai.LogprobsResultCandidate{
+					{Token: "world", LogProbability: -0.2},
+				}},
+			},
+		}
+		got := convLogprobs(lp)
+		assert.NotNil(t, got)
+		assert.Len(t, got.Content, 2)
+		assert.Equal(t, "hello", got.Content[0].Token)
+		assert.InDelta(t, -0.1, got.Content[0].LogProb, 1e-6)
+		assert.Len(t, got.Content[0].TopLogProbs, 2)
+		assert.Equal(t, "hi", got.Content[0].TopLogProbs[1].Token)
+		assert.InDelta(t, -1.5, got.Content[0].TopLogProbs[1].LogProb, 1e-6)
+		assert.Len(t, got.Content[1].TopLogProbs, 1)
+	})
+
+	t.Run("top candidates length mismatch", func(t *testing.T) {
+		// chosen=2, top=1 — second chosen has empty TopLogProbs (no panic)
+		lp := &genai.LogprobsResult{
+			ChosenCandidates: []*genai.LogprobsResultCandidate{
+				{Token: "a", LogProbability: -0.1},
+				{Token: "b", LogProbability: -0.2},
+			},
+			TopCandidates: []*genai.LogprobsResultTopCandidates{
+				{Candidates: []*genai.LogprobsResultCandidate{{Token: "a", LogProbability: -0.1}}},
+			},
+		}
+		got := convLogprobs(lp)
+		assert.Len(t, got.Content, 2)
+		assert.Len(t, got.Content[0].TopLogProbs, 1)
+		assert.Empty(t, got.Content[1].TopLogProbs)
+	})
+
+	t.Run("top candidate entry nil and inner nil", func(t *testing.T) {
+		lp := &genai.LogprobsResult{
+			ChosenCandidates: []*genai.LogprobsResultCandidate{
+				{Token: "a", LogProbability: -0.1},
+			},
+			TopCandidates: []*genai.LogprobsResultTopCandidates{
+				{Candidates: []*genai.LogprobsResultCandidate{nil, {Token: "x", LogProbability: -0.5}}},
+			},
+		}
+		got := convLogprobs(lp)
+		assert.Len(t, got.Content, 1)
+		assert.Len(t, got.Content[0].TopLogProbs, 1)
+		assert.Equal(t, "x", got.Content[0].TopLogProbs[0].Token)
+	})
+}
+
+func TestLogprobsOptionsOverride(t *testing.T) {
+	ctx := context.Background()
+	five := int32(5)
+	cm, err := NewChatModel(ctx, &Config{
+		Client:           &genai.Client{Models: &genai.Models{}},
+		Model:            "gemini-x",
+		ResponseLogprobs: true,
+		Logprobs:         &five,
+	})
+	assert.NoError(t, err)
+
+	t.Run("config defaults applied", func(t *testing.T) {
+		_, _, m, _, err := cm.genInputAndConf([]*schema.Message{{Role: schema.User, Content: "hi"}})
+		assert.NoError(t, err)
+		assert.True(t, m.ResponseLogprobs)
+		assert.NotNil(t, m.Logprobs)
+		assert.Equal(t, int32(5), *m.Logprobs)
+	})
+
+	t.Run("option overrides response logprobs to false", func(t *testing.T) {
+		_, _, m, _, err := cm.genInputAndConf(
+			[]*schema.Message{{Role: schema.User, Content: "hi"}},
+			WithResponseLogprobs(false),
+		)
+		assert.NoError(t, err)
+		assert.False(t, m.ResponseLogprobs)
+	})
+
+	t.Run("option overrides logprobs top-K", func(t *testing.T) {
+		_, _, m, _, err := cm.genInputAndConf(
+			[]*schema.Message{{Role: schema.User, Content: "hi"}},
+			WithLogprobs(3),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, m.Logprobs)
+		assert.Equal(t, int32(3), *m.Logprobs)
+	})
+}
+
+func TestConvCandidateLogprobs(t *testing.T) {
+	candidate := &genai.Candidate{
+		Content: &genai.Content{
+			Role:  roleModel,
+			Parts: []*genai.Part{{Text: "hi"}},
+		},
+		LogprobsResult: &genai.LogprobsResult{
+			ChosenCandidates: []*genai.LogprobsResultCandidate{
+				{Token: "hi", LogProbability: -0.05},
+			},
+		},
+	}
+	msg, err := convCandidate(candidate)
+	assert.NoError(t, err)
+	assert.NotNil(t, msg.ResponseMeta)
+	assert.NotNil(t, msg.ResponseMeta.LogProbs)
+	assert.Len(t, msg.ResponseMeta.LogProbs.Content, 1)
+	assert.Equal(t, "hi", msg.ResponseMeta.LogProbs.Content[0].Token)
+}

--- a/components/model/gemini/option.go
+++ b/components/model/gemini/option.go
@@ -30,6 +30,8 @@ type options struct {
 	ResponseModalities []GeminiResponseModality
 	ImageConfig        *genai.ImageConfig
 	CachedContentName  string
+	ResponseLogprobs   *bool
+	Logprobs           *int32
 }
 
 func WithTopK(k int32) model.Option {
@@ -70,5 +72,22 @@ func WithCachedContentName(name string) model.Option {
 func WithImageConfig(cfg *genai.ImageConfig) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.ImageConfig = cfg
+	})
+}
+
+// WithResponseLogprobs sets whether to return the log probabilities of the
+// tokens chosen by the model at each step. This overrides Config.ResponseLogprobs.
+func WithResponseLogprobs(enable bool) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.ResponseLogprobs = &enable
+	})
+}
+
+// WithLogprobs sets the number of top candidate tokens to return the log
+// probabilities for at each generation step. Only takes effect when
+// ResponseLogprobs is enabled.
+func WithLogprobs(k int32) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.Logprobs = &k
 	})
 }


### PR DESCRIPTION
- Add ResponseLogprobs and Logprobs fields to Config and ChatModel
- Add WithResponseLogprobs and WithLogprobs options for per-call override
- Convert genai LogprobsResult to schema.LogProbs in response
- Add unit tests for conversion and option override behavior
- Update README with usage and field reference

