### PR TITLE
feat(acp): backend improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ output/*
 # Data files
 *.jsonl
 *.csv
+
+*.local.md

--- a/acp/README.md
+++ b/acp/README.md
@@ -80,13 +80,18 @@ for su, err := range einoacp.AgentEventToSessionUpdate(event, opt) {
 Creates a `ChatModelAgentMiddleware` that bridges ACP client-side capabilities to eino's filesystem tools.
 
 ```go
-func NewClientToolsMiddleware(
-    ctx context.Context,
-    sessionID acpproto.SessionID,
-    capabilities *acpproto.ClientCapabilities,
-    conn *acpconn.AgentConnection,
-) (adk.ChatModelAgentMiddleware, error)
+func NewClientToolsMiddleware(ctx context.Context, cfg *Config) (adk.ChatModelAgentMiddleware, error)
 ```
+
+`Config` fields:
+
+| Field | Description |
+|---|---|
+| `SessionID` | ACP session ID (required) |
+| `Conn` | Agent-side ACP connection (required) |
+| `Capabilities` | Client capability set from initialization (required) |
+| `UseTerminalForFileTools` | Enable terminal-backed ls/glob/grep/edit (requires terminal capability) |
+| `Logger` | Optional structured logger; defaults to `slog.Default()` |
 
 Tools are enabled based on client-advertised capabilities:
 
@@ -95,12 +100,15 @@ Tools are enabled based on client-advertised capabilities:
 | `fs.readTextFile` | `read_file` |
 | `fs.writeTextFile` | `write_file` |
 | `terminal` | Shell command execution |
+| `terminal` + `UseTerminalForFileTools` | `ls`, `glob`, `grep`, `edit` |
 
 ```go
 if clientCapabilities != nil {
-    middleware, err := einoacp.NewClientToolsMiddleware(
-        ctx, sessionID, clientCapabilities, conn,
-    )
+    middleware, err := einoacp.NewClientToolsMiddleware(ctx, &einoacp.Config{
+        SessionID:    sessionID,
+        Conn:         conn,
+        Capabilities: clientCapabilities,
+    })
     if err != nil {
         return err
     }

--- a/acp/README_zh.md
+++ b/acp/README_zh.md
@@ -103,13 +103,18 @@ for su, err := range einoacp.AgentEventToSessionUpdate(event, opt) {
 创建一个 `ChatModelAgentMiddleware`，将 ACP 客户端能力桥接到 eino 的文件系统工具。根据客户端声明的能力自动启用对应工具，未支持的工具会被禁用。
 
 ```go
-func NewClientToolsMiddleware(
-    ctx context.Context,
-    sessionID acpproto.SessionID,
-    capabilities *acpproto.ClientCapabilities,
-    conn *acpconn.AgentConnection,
-) (adk.ChatModelAgentMiddleware, error)
+func NewClientToolsMiddleware(ctx context.Context, cfg *Config) (adk.ChatModelAgentMiddleware, error)
 ```
+
+`Config` 字段说明：
+
+| 字段 | 说明 |
+|---|---|
+| `SessionID` | ACP 会话 ID（必填） |
+| `Conn` | Agent 侧的 ACP 连接（必填） |
+| `Capabilities` | 初始化阶段从客户端获取的能力集（必填） |
+| `UseTerminalForFileTools` | 启用基于终端实现的 ls/glob/grep/edit（需要客户端支持 terminal 能力） |
+| `Logger` | 可选的结构化日志记录器，默认使用 `slog.Default()` |
 
 能力与工具的对应关系：
 
@@ -118,6 +123,7 @@ func NewClientToolsMiddleware(
 | `fs.readTextFile` | `read_file` | 通过 ACP 连接读取客户端文件 |
 | `fs.writeTextFile` | `write_file` | 通过 ACP 连接写入客户端文件 |
 | `terminal` | Shell 命令执行 | 通过 ACP 连接在客户端创建终端并执行命令 |
+| `terminal` + `UseTerminalForFileTools` | `ls`、`glob`、`grep`、`edit` | 通过终端命令在客户端实现文件系统工具 |
 
 #### 使用示例
 
@@ -125,9 +131,11 @@ func NewClientToolsMiddleware(
 
 ```go
 if clientCapabilities != nil {
-    middleware, err := einoacp.NewClientToolsMiddleware(
-        ctx, sessionID, clientCapabilities, conn,
-    )
+    middleware, err := einoacp.NewClientToolsMiddleware(ctx, &einoacp.Config{
+        SessionID:    sessionID,
+        Conn:         conn,
+        Capabilities: clientCapabilities,
+    })
     if err != nil {
         return err
     }

--- a/acp/backend.go
+++ b/acp/backend.go
@@ -66,7 +66,7 @@ const (
 	// in memory. Files larger than this are rejected to prevent OOM.
 	maxEditFileSize = 32 * 1024 * 1024 // 32 MiB
 
-	// rgJSONMaxFailedRatio is the maximum ratio of unparseable lines in `rg --json`
+	// rgJSONMaxFailedRatio is the maximum ratio of unparsable lines in `rg --json`
 	// output before we treat the entire result as an error. This guards against
 	// incompatible rg versions that emit non-JSON output while still tolerating
 	// occasional malformed lines (e.g. from binary file matches or locale issues).
@@ -844,7 +844,7 @@ func parsePosixGrepOutput(out string) []filesystem.GrepMatch {
 // substring matching :<positive-integer><sep> before the real line number.
 //
 // Known limitation: if the path itself contains a `:N:` or `:N-` pattern where
-// N is a positive integer (e.g. "prefix:1:rest.go"), the parser will mis-split.
+// N is a positive integer (e.g. "prefix:1:rest.go"), the parser will split incorrectly.
 // POSIX grep has no NUL-delimited output mode (`-Z` is GNU-only), so this is
 // an inherent best-effort trade-off.
 func parsePosixGrepLine(line string) (filePath string, lineno int, content string, ok bool) {

--- a/acp/backend.go
+++ b/acp/backend.go
@@ -18,43 +18,120 @@ package einoacp
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"path"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/cloudwego/eino/adk"
 	"github.com/cloudwego/eino/adk/filesystem"
 	mfs "github.com/cloudwego/eino/adk/middlewares/filesystem"
 	acpproto "github.com/eino-contrib/acp"
-	acpconn "github.com/eino-contrib/acp/conn"
 )
+
+// Sentinel errors for structured error handling by callers.
+var (
+	// ErrShellNonZeroExit is returned when a shell command exits with a non-zero code.
+	ErrShellNonZeroExit = errors.New("acp.shell: non-zero exit")
+	// ErrCapabilityMissing is returned when the client does not advertise the required capability.
+	ErrCapabilityMissing = errors.New("acp: client capability not supported")
+	// ErrOldStringNotFound is returned when Edit cannot locate the oldString in the file.
+	ErrOldStringNotFound = errors.New("acp.edit: oldString not found")
+	// ErrAmbiguousReplace is returned when multiple occurrences exist but ReplaceAll is false.
+	ErrAmbiguousReplace = errors.New("acp.edit: ambiguous replacement (set ReplaceAll)")
+	// ErrFileTooLarge is returned when Edit is attempted on a file exceeding maxEditFileSize.
+	ErrFileTooLarge = errors.New("acp.edit: file too large for in-memory edit")
+)
+
+const (
+	// releaseTerminalTimeout is how long we wait for ReleaseTerminal after the
+	// command finishes (using a background context so cancellation won't prevent cleanup).
+	releaseTerminalTimeout = 5 * time.Second
+
+	// maxLogCommandLen is the maximum length of a command string included in log messages.
+	maxLogCommandLen = 200
+
+	// findMaxDepth is the -maxdepth value passed to `find` in GlobInfo.
+	findMaxDepth = 20
+
+	// maxEditFileSize is the maximum file size (in bytes) that Edit will process
+	// in memory. Files larger than this are rejected to prevent OOM.
+	maxEditFileSize = 32 * 1024 * 1024 // 32 MiB
+
+	// rgJSONMaxFailedRatio is the maximum ratio of unparseable lines in `rg --json`
+	// output before we treat the entire result as an error. This guards against
+	// incompatible rg versions that emit non-JSON output while still tolerating
+	// occasional malformed lines (e.g. from binary file matches or locale issues).
+	rgJSONMaxFailedRatio = 0.5
+)
+
+// ACPConn is the minimal interface for ACP client-side RPC calls used by
+// Backend and shell. It is satisfied by *acpconn.AgentConnection (from the
+// github.com/eino-contrib/acp/conn package). Callers may provide alternative
+// implementations for testing or proxying.
+type ACPConn interface {
+	ReadTextFile(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error)
+	WriteTextFile(ctx context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error)
+	CreateTerminal(ctx context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error)
+	WaitForTerminalExit(ctx context.Context, req acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error)
+	TerminalOutput(ctx context.Context, req acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error)
+	ReleaseTerminal(ctx context.Context, req acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error)
+}
 
 // Config configures NewClientToolsMiddleware.
 type Config struct {
 	// SessionID is the ACP session the middleware will operate on. Required.
 	SessionID acpproto.SessionID
 	// Conn is the agent-side ACP connection used to issue client requests. Required.
-	Conn *acpconn.AgentConnection
+	// Any implementation of ACPConn is accepted; *conn.AgentConnection (from
+	// github.com/eino-contrib/acp/conn) satisfies this interface and is the
+	// typical production choice.
+	Conn ACPConn
 	// Capabilities is the client capability set advertised during initialization.
 	// Required: tools are enabled based on what the client supports.
 	Capabilities *acpproto.ClientCapabilities
 
 	// UseTerminalForFileTools enables terminal-backed implementations of the
-	// ls, glob, grep, and edit tools. It only takes effect when the client
+	// ls, glob, and grep tools. It only takes effect when the client
 	// also advertises the terminal capability; otherwise those tools stay
 	// disabled because the ACP protocol does not expose corresponding
 	// filesystem methods.
 	//
+	// Note: edit always requires fs capability (ReadTextFile + WriteTextFile).
+	//
 	// Implementation: ls runs `ls -1A`, glob enumerates with `find` and matches
-	// in-process via doublestar, grep shells out to ripgrep (`rg`), and edit
-	// runs an inline `python3` script that reads, replaces, and rewrites the
-	// file in one shot. Old/new strings are passed base64-encoded so they round-
-	// trip safely through argv. If `rg` or `python3` is missing on the client
-	// side, the corresponding tool calls will fail.
+	// in-process via doublestar, grep prefers ripgrep (`rg --json`) and
+	// transparently falls back to POSIX `grep -RnE` when `rg` is not
+	// installed on the client side.
 	UseTerminalForFileTools bool
+
+	// Logger is an optional structured logger for non-fatal diagnostics (e.g.
+	// ReleaseTerminal failures). If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+func (c *Config) validate() error {
+	if c == nil {
+		return errors.New("acp.NewClientToolsMiddleware: cfg is required")
+	}
+	if c.Conn == nil {
+		return errors.New("acp.NewClientToolsMiddleware: cfg.Conn is required")
+	}
+	if c.SessionID == "" {
+		return errors.New("acp.NewClientToolsMiddleware: cfg.SessionID is required")
+	}
+	if c.Capabilities == nil {
+		return errors.New("acp.NewClientToolsMiddleware: cfg.Capabilities is required")
+	}
+	return nil
 }
 
 // NewClientToolsMiddleware creates a ChatModelAgentMiddleware that bridges ACP client-side capabilities
@@ -64,17 +141,11 @@ type Config struct {
 // default; they become available when cfg.UseTerminalForFileTools is true and the client advertises
 // the terminal capability — in which case they run as shell commands.
 func NewClientToolsMiddleware(ctx context.Context, cfg *Config) (adk.ChatModelAgentMiddleware, error) {
-	if cfg == nil {
-		return nil, errors.New("acp.NewClientToolsMiddleware: cfg is required")
-	}
-	if cfg.Conn == nil {
-		return nil, errors.New("acp.NewClientToolsMiddleware: cfg.Conn is required")
-	}
-	if cfg.SessionID == "" {
-		return nil, errors.New("acp.NewClientToolsMiddleware: cfg.SessionID is required")
+	b, err := NewBackend(cfg)
+	if err != nil {
+		return nil, err
 	}
 
-	b := &backend{conn: cfg.Conn, sessionID: cfg.SessionID}
 	config := &mfs.MiddlewareConfig{
 		Backend:             b,
 		LsToolConfig:        &mfs.ToolConfig{Disable: true},
@@ -84,33 +155,39 @@ func NewClientToolsMiddleware(ctx context.Context, cfg *Config) (adk.ChatModelAg
 		GlobToolConfig:      &mfs.ToolConfig{Disable: true},
 		GrepToolConfig:      &mfs.ToolConfig{Disable: true},
 	}
-	if cfg.Capabilities != nil {
-		if cfg.Capabilities.Terminal {
-			sh := &shell{conn: cfg.Conn, sessionID: cfg.SessionID}
-			config.Shell = sh
-			if cfg.UseTerminalForFileTools {
-				b.shell = sh
-				config.LsToolConfig = nil
-				config.GlobToolConfig = nil
-				config.GrepToolConfig = nil
-				config.EditFileToolConfig = nil
-			}
+
+	if cfg.Capabilities.Terminal {
+		// The Shell field is independent of UseTerminalForFileTools: even if
+		// callers don't want fs tools backed by terminal, the shell tool
+		// itself is still exposed when the client supports it.
+		logger := cfg.Logger
+		if logger == nil {
+			logger = slog.Default()
 		}
-		if cfg.Capabilities.FS != nil {
-			if cfg.Capabilities.FS.WriteTextFile {
-				config.WriteFileToolConfig = nil
-			}
-			if cfg.Capabilities.FS.ReadTextFile {
-				config.ReadFileToolConfig = nil
-			}
+		config.Shell = &shell{conn: cfg.Conn, sessionID: cfg.SessionID, logger: logger}
+		if cfg.UseTerminalForFileTools {
+			config.LsToolConfig = nil
+			config.GlobToolConfig = nil
+			config.GrepToolConfig = nil
 		}
 	}
+	if b.hasReadFS {
+		config.ReadFileToolConfig = nil
+	}
+	if b.hasWriteFS {
+		config.WriteFileToolConfig = nil
+	}
+	if b.hasReadFS && b.hasWriteFS {
+		config.EditFileToolConfig = nil
+	}
+
 	return mfs.New(ctx, config)
 }
 
 type shell struct {
-	conn      *acpconn.AgentConnection
+	conn      ACPConn
 	sessionID acpproto.SessionID
+	logger    *slog.Logger
 }
 
 func (s *shell) Execute(ctx context.Context, input *filesystem.ExecuteRequest) (*filesystem.ExecuteResponse, error) {
@@ -128,10 +205,21 @@ func (s *shell) Execute(ctx context.Context, input *filesystem.ExecuteRequest) (
 		return nil, fmt.Errorf("acp.createTerminal session=%s: %w", s.sessionID, err)
 	}
 	defer func() {
-		_, _ = s.conn.ReleaseTerminal(ctx, acpproto.ReleaseTerminalRequest{
+		// Use a background context so that ReleaseTerminal still succeeds even
+		// when the caller's ctx has been cancelled (e.g. user stop / timeout).
+		bg, bgCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTerminalTimeout)
+		defer bgCancel()
+		if _, rerr := s.conn.ReleaseTerminal(bg, acpproto.ReleaseTerminalRequest{
 			SessionID:  s.sessionID,
 			TerminalID: createResp.TerminalID,
-		})
+		}); rerr != nil {
+			cmd := input.Command
+			if len(cmd) > maxLogCommandLen {
+				cmd = cmd[:maxLogCommandLen] + "..."
+			}
+			s.logger.WarnContext(ctx, "acp.releaseTerminal failed",
+				"session", s.sessionID, "terminal", createResp.TerminalID, "command", cmd, "err", rerr)
+		}
 	}()
 
 	waitResp, err := s.conn.WaitForTerminalExit(ctx, acpproto.WaitForTerminalExitRequest{
@@ -171,13 +259,69 @@ func (s *shell) Execute(ctx context.Context, input *filesystem.ExecuteRequest) (
 	return ret, nil
 }
 
-type backend struct {
-	conn      *acpconn.AgentConnection
-	sessionID acpproto.SessionID
-	shell     *shell
+// Backend implements the mfs.Backend interface on top of an ACP agent
+// connection, bridging filesystem and shell tool calls to ACP client-side
+// capabilities (read_text_file / write_text_file / terminal). It is exported
+// so callers that build their own filesystem middleware (instead of using
+// NewClientToolsMiddleware) can plug it directly into mfs.MiddlewareConfig.
+type Backend struct {
+	conn       ACPConn
+	sessionID  acpproto.SessionID
+	shell      *shell
+	hasReadFS  bool
+	hasWriteFS bool
+
+	// rgState stores the ripgrep probe result as an atomic int32 (rgProbeState).
+	// Probing uses rgOnce-style synchronization: the first goroutine to find
+	// state==unprobed wins the "probe race" via CAS and executes the RPC;
+	// concurrent goroutines that arrive during probing fall back to POSIX grep
+	// rather than blocking. Once determined, the result is cached permanently
+	// (available/unavailable). Transient transport errors leave state as unprobed
+	// so the next caller retries.
+	rgState atomic.Int32
+
+	// rgProbeMu serializes concurrent probe attempts so only one RPC flies at
+	// a time. Goroutines that can't acquire it immediately return false (POSIX
+	// fallback) rather than blocking.
+	rgProbeMu sync.Mutex
 }
 
-func (b *backend) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesystem.FileContent, error) {
+// NewBackend constructs a Backend from the same Config used by
+// NewClientToolsMiddleware. The returned Backend reflects the capabilities
+// advertised by the client:
+//
+//   - Read/Write are enabled when cfg.Capabilities.FS.ReadTextFile /
+//     WriteTextFile are set; otherwise calling them returns an error from the
+//     underlying ACP RPC.
+//   - LsInfo/GlobInfo/GrepRaw (terminal-backed implementations) are only
+//     functional when cfg.Capabilities.Terminal is true AND
+//     cfg.UseTerminalForFileTools is set; otherwise they return an error.
+//   - Edit requires both ReadTextFile and WriteTextFile fs capabilities;
+//     it performs a read-modify-write cycle via the fs API.
+func NewBackend(cfg *Config) (*Backend, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	b := &Backend{conn: cfg.Conn, sessionID: cfg.SessionID}
+
+	if cfg.Capabilities.Terminal && cfg.UseTerminalForFileTools {
+		b.shell = &shell{conn: cfg.Conn, sessionID: cfg.SessionID, logger: logger}
+	}
+	if cfg.Capabilities.FS != nil {
+		b.hasReadFS = cfg.Capabilities.FS.ReadTextFile
+		b.hasWriteFS = cfg.Capabilities.FS.WriteTextFile
+	}
+
+	return b, nil
+}
+
+func (b *Backend) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesystem.FileContent, error) {
 	var limit, line *int64
 	if req.Limit != 0 {
 		tmp := int64(req.Limit)
@@ -199,7 +343,7 @@ func (b *backend) Read(ctx context.Context, req *filesystem.ReadRequest) (*files
 	return &filesystem.FileContent{Content: resp.Content}, nil
 }
 
-func (b *backend) Write(ctx context.Context, req *filesystem.WriteRequest) error {
+func (b *Backend) Write(ctx context.Context, req *filesystem.WriteRequest) error {
 	_, err := b.conn.WriteTextFile(ctx, acpproto.WriteTextFileRequest{
 		Content:   req.Content,
 		Path:      req.FilePath,
@@ -211,33 +355,107 @@ func (b *backend) Write(ctx context.Context, req *filesystem.WriteRequest) error
 	return nil
 }
 
-func (b *backend) LsInfo(ctx context.Context, req *filesystem.LsInfoRequest) ([]filesystem.FileInfo, error) {
+func (b *Backend) LsInfo(ctx context.Context, req *filesystem.LsInfoRequest) ([]filesystem.FileInfo, error) {
 	if b.shell == nil {
-		return nil, fmt.Errorf("acp client does not support ls info")
+		return nil, fmt.Errorf("%w: ls info", ErrCapabilityMissing)
 	}
-	path := req.Path
-	if path == "" {
-		path = "."
+	dir := req.Path
+	if dir == "" {
+		dir = "."
 	}
-	out, err := b.runShell(ctx, "ls -1A -- "+shellQuote(path))
+	quotedDir, err := shellQuote(dir)
 	if err != nil {
-		return nil, fmt.Errorf("acp.shell ls path=%s: %w", path, err)
+		return nil, fmt.Errorf("acp.shell ls path=%s: %w", dir, err)
+	}
+	result, err := b.runShell(ctx, "ls -1Ap -- "+quotedDir)
+	if err != nil {
+		return nil, fmt.Errorf("acp.shell ls path=%s: %w", dir, err)
+	}
+	if result.Truncated {
+		b.shell.logger.WarnContext(ctx, "acp.shell ls: output truncated, returning partial results", "path", dir)
 	}
 	var infos []filesystem.FileInfo
-	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+	for _, line := range strings.Split(strings.TrimRight(result.Output, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
-		infos = append(infos, filesystem.FileInfo{Path: line})
+		info := filesystem.FileInfo{}
+		if strings.HasSuffix(line, "/") {
+			info.Path = strings.TrimSuffix(line, "/")
+			info.IsDir = true
+		} else {
+			info.Path = line
+		}
+		infos = append(infos, info)
 	}
 	return infos, nil
 }
 
-func (b *backend) GrepRaw(ctx context.Context, req *filesystem.GrepRequest) ([]filesystem.GrepMatch, error) {
+func (b *Backend) GrepRaw(ctx context.Context, req *filesystem.GrepRequest) ([]filesystem.GrepMatch, error) {
 	if b.shell == nil {
-		return nil, fmt.Errorf("acp client does not support grep raw")
+		return nil, fmt.Errorf("%w: grep raw", ErrCapabilityMissing)
 	}
-	args := []string{"rg", "--line-number", "--no-heading", "--color=never"}
+	if b.detectRipgrep(ctx) {
+		return b.grepWithRipgrep(ctx, req)
+	}
+	return b.grepWithPosix(ctx, req)
+}
+
+// rgProbeState represents the three-state probe result for ripgrep availability.
+type rgProbeState = int32
+
+const (
+	rgUnprobed    rgProbeState = iota // not yet probed
+	rgAvailable                       // rg is installed
+	rgUnavailable                     // rg is confirmed not installed
+)
+
+// detectRipgrep probes for ripgrep availability on the client side using
+// `command -v rg`. The result is cached once determined definitively (rg found
+// or confirmed absent). If the probe fails due to a transient transport error
+// (e.g. ctx cancelled), the state remains "unprobed" so the next call retries.
+//
+// Concurrency: uses a non-blocking TryLock so that concurrent grep calls don't
+// serialize behind a slow probe RPC. If another goroutine is already probing,
+// latecomers fall back to POSIX grep for that single call rather than waiting.
+func (b *Backend) detectRipgrep(ctx context.Context) bool {
+	// Fast path: already probed.
+	state := b.rgState.Load()
+	if state != rgUnprobed {
+		return state == rgAvailable
+	}
+
+	// Slow path: try to become the probe goroutine. If someone else is already
+	// probing, fall back to POSIX grep for this call (non-blocking).
+	if !b.rgProbeMu.TryLock() {
+		return false
+	}
+	defer b.rgProbeMu.Unlock()
+
+	// Double-check after acquiring the lock: another goroutine may have finished
+	// probing between our Load() and TryLock().
+	state = b.rgState.Load()
+	if state != rgUnprobed {
+		return state == rgAvailable
+	}
+
+	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: "command -v rg >/dev/null 2>&1"})
+	if err != nil {
+		// Transport error — don't cache, retry next time.
+		b.shell.logger.DebugContext(ctx, "acp.shell grep: rg detection probe failed, will retry", "err", err)
+		return false
+	}
+	if resp.ExitCode != nil && *resp.ExitCode == 0 {
+		b.rgState.Store(rgAvailable)
+		return true
+	}
+	b.shell.logger.InfoContext(ctx, "acp.shell grep: ripgrep (rg) not found on client, falling back to POSIX grep")
+	b.rgState.Store(rgUnavailable)
+	return false
+}
+
+func (b *Backend) grepWithRipgrep(ctx context.Context, req *filesystem.GrepRequest) ([]filesystem.GrepMatch, error) {
+	args := []string{"rg", "--json"}
 	if req.CaseInsensitive {
 		args = append(args, "--ignore-case")
 	}
@@ -263,36 +481,127 @@ func (b *backend) GrepRaw(ctx context.Context, req *filesystem.GrepRequest) ([]f
 		args = append(args, ".")
 	}
 
-	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: joinShellArgs(args)})
+	cmd, err := joinShellArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("acp.shell grep: %w", err)
+	}
+	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: cmd})
 	if err != nil {
 		return nil, fmt.Errorf("acp.shell grep: %w", err)
 	}
 	// rg exit code 1 means "no matches" — not an error.
 	if resp.ExitCode != nil && *resp.ExitCode != 0 && *resp.ExitCode != 1 {
-		return nil, fmt.Errorf("acp.shell grep failed (exit %d): %s", *resp.ExitCode, resp.Output)
+		return nil, fmt.Errorf("acp.shell grep (exit %d): %w: %s", *resp.ExitCode, ErrShellNonZeroExit, resp.Output)
 	}
 	if resp.ExitCode != nil && *resp.ExitCode == 1 {
 		return nil, nil
 	}
-	return parseRipgrepOutput(resp.Output), nil
+	if resp.Truncated {
+		b.shell.logger.WarnContext(ctx, "acp.shell grep: output truncated, returning partial results")
+	}
+	return parseRipgrepJSONOutput(resp.Output, b.shell.logger)
 }
 
-func (b *backend) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) ([]filesystem.FileInfo, error) {
+// grepWithPosix is the fallback used when ripgrep (rg) is not installed on
+// the client. It shells out to POSIX `grep -RnE` (with widely-supported BSD/GNU
+// extensions: -R recursive, -n line numbers, -E extended regex, -H force path
+// prefix, --include for glob filtering, -A/-B for context).
+//
+// Limitations vs. ripgrep:
+//   - EnableMultiline is rejected: POSIX grep operates line-by-line, and
+//     silently ignoring this flag would change match semantics.
+//   - FileType is best-effort: POSIX grep has no built-in type registry, so
+//     the flag is ignored with a warning. Callers wanting strict type filtering
+//     should install rg or pass an equivalent Glob.
+func (b *Backend) grepWithPosix(ctx context.Context, req *filesystem.GrepRequest) ([]filesystem.GrepMatch, error) {
+	if req.EnableMultiline {
+		return nil, errors.New("acp.shell grep: EnableMultiline requires ripgrep (rg); not supported by POSIX grep fallback")
+	}
+	if req.FileType != "" {
+		b.shell.logger.WarnContext(ctx, "acp.shell grep: FileType is ignored in POSIX grep fallback (rg not installed)", "fileType", req.FileType)
+	}
+	args := []string{"grep", "-RHnE", "--no-messages"}
+	if req.CaseInsensitive {
+		args = append(args, "-i")
+	}
+	if req.BeforeLines > 0 {
+		args = append(args, "-B", strconv.Itoa(req.BeforeLines))
+	}
+	if req.AfterLines > 0 {
+		args = append(args, "-A", strconv.Itoa(req.AfterLines))
+	}
+	if req.Glob != "" {
+		args = append(args, "--include="+req.Glob)
+	}
+	args = append(args, "-e", req.Pattern)
+	if req.Path != "" {
+		args = append(args, req.Path)
+	} else {
+		args = append(args, ".")
+	}
+
+	cmd, err := joinShellArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("acp.shell grep: %w", err)
+	}
+	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: cmd})
+	if err != nil {
+		return nil, fmt.Errorf("acp.shell grep: %w", err)
+	}
+	// grep exit codes: 0 = matches found, 1 = no matches, >=2 = error.
+	if resp.ExitCode != nil && *resp.ExitCode >= 2 {
+		return nil, fmt.Errorf("acp.shell grep (exit %d): %w: %s", *resp.ExitCode, ErrShellNonZeroExit, resp.Output)
+	}
+	if resp.ExitCode != nil && *resp.ExitCode == 1 {
+		return nil, nil
+	}
+	if resp.Truncated {
+		b.shell.logger.WarnContext(ctx, "acp.shell grep: output truncated, returning partial results")
+	}
+	return parsePosixGrepOutput(resp.Output), nil
+}
+
+func (b *Backend) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) ([]filesystem.FileInfo, error) {
 	if b.shell == nil {
-		return nil, fmt.Errorf("acp client does not support glob info")
+		return nil, fmt.Errorf("%w: glob info", ErrCapabilityMissing)
 	}
 	basePath := req.Path
 	if basePath == "" {
 		basePath = "."
 	}
-	out, err := b.runShell(ctx, "find "+shellQuote(basePath)+" -type f")
+	basePath = path.Clean(basePath)
+
+	// We don't use runShell here because `find` may exit with code 1 when it
+	// encounters permission-denied directories, while still producing valid
+	// output on stdout. runShell treats any non-zero exit as a hard error,
+	// which would discard legitimate results.
+	quotedBase, err := shellQuote(basePath)
 	if err != nil {
 		return nil, fmt.Errorf("acp.shell glob path=%s: %w", basePath, err)
+	}
+	cmd := fmt.Sprintf("find %s -maxdepth %d 2>/dev/null", quotedBase, findMaxDepth)
+	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: cmd})
+	if err != nil {
+		return nil, fmt.Errorf("acp.shell glob path=%s: %w", basePath, err)
+	}
+	// find exit codes: 0 = success, 1 = partial failure (e.g. permission denied
+	// on some subdirectories but stdout still has results). Only treat exit >= 2
+	// or nil (signal-killed) as hard errors.
+	if resp.ExitCode == nil {
+		return nil, fmt.Errorf("acp.shell glob path=%s: %w: process terminated without exit code",
+			basePath, ErrShellNonZeroExit)
+	}
+	if *resp.ExitCode >= 2 {
+		return nil, fmt.Errorf("acp.shell glob path=%s (exit %d): %w: %s",
+			basePath, *resp.ExitCode, ErrShellNonZeroExit, resp.Output)
+	}
+	if resp.Truncated {
+		b.shell.logger.WarnContext(ctx, "acp.shell glob: output truncated, returning partial results", "path", basePath)
 	}
 
 	isAbsolutePattern := strings.HasPrefix(req.Pattern, "/")
 	var infos []filesystem.FileInfo
-	for _, p := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+	for _, p := range strings.Split(strings.TrimRight(resp.Output, "\n"), "\n") {
 		if p == "" {
 			continue
 		}
@@ -322,121 +631,263 @@ func (b *backend) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest)
 	return infos, nil
 }
 
-func (b *backend) Edit(ctx context.Context, req *filesystem.EditRequest) error {
-	if b.shell == nil {
-		return fmt.Errorf("acp client does not support edit")
-	}
+func (b *Backend) Edit(ctx context.Context, req *filesystem.EditRequest) error {
 	if req.OldString == "" {
 		return errors.New("oldString must be non-empty")
 	}
-
-	oldB64 := base64.StdEncoding.EncodeToString([]byte(req.OldString))
-	newB64 := base64.StdEncoding.EncodeToString([]byte(req.NewString))
-	replaceAll := "0"
-	if req.ReplaceAll {
-		replaceAll = "1"
+	if req.OldString == req.NewString {
+		return nil
 	}
-	cmd := joinShellArgs([]string{
-		"python3", "-c", editPythonScript,
-		req.FilePath, oldB64, newB64, replaceAll,
+
+	if !(b.hasReadFS && b.hasWriteFS) {
+		return fmt.Errorf("%w: edit requires fs.ReadTextFile and fs.WriteTextFile", ErrCapabilityMissing)
+	}
+	return b.editViaFS(ctx, req)
+}
+
+// readFull reads an entire file via the ACP ReadTextFile RPC (no offset/limit).
+// Used by both Read (when no offset) and Edit for the read-modify-write cycle.
+func (b *Backend) readFull(ctx context.Context, filePath string) (string, error) {
+	resp, err := b.conn.ReadTextFile(ctx, acpproto.ReadTextFileRequest{
+		Path:      filePath,
+		SessionID: b.sessionID,
 	})
-	if _, err := b.runShell(ctx, cmd); err != nil {
-		return fmt.Errorf("acp.shell edit %s: %w", req.FilePath, err)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+func (b *Backend) editViaFS(ctx context.Context, req *filesystem.EditRequest) error {
+	content, err := b.readFull(ctx, req.FilePath)
+	if err != nil {
+		return fmt.Errorf("acp.edit read %s: %w", req.FilePath, err)
+	}
+	if len(content) > maxEditFileSize {
+		return fmt.Errorf("acp.edit %s: file is %d bytes: %w", req.FilePath, len(content), ErrFileTooLarge)
+	}
+	count := strings.Count(content, req.OldString)
+	switch {
+	case count == 0:
+		return fmt.Errorf("acp.edit %s: %w", req.FilePath, ErrOldStringNotFound)
+	case count > 1 && !req.ReplaceAll:
+		return fmt.Errorf("acp.edit %s: %d occurrences found: %w", req.FilePath, count, ErrAmbiguousReplace)
+	}
+	if req.ReplaceAll {
+		content = strings.ReplaceAll(content, req.OldString, req.NewString)
+	} else {
+		content = strings.Replace(content, req.OldString, req.NewString, 1)
+	}
+	_, err = b.conn.WriteTextFile(ctx, acpproto.WriteTextFileRequest{
+		Path:      req.FilePath,
+		Content:   content,
+		SessionID: b.sessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("acp.edit write %s: %w", req.FilePath, err)
 	}
 	return nil
 }
 
-// editPythonScript reads a file, replaces OldString with NewString, and writes
-// it back. Args (after `-c <script>`): file_path old_b64 new_b64 replace_all
-// where replace_all is "1" or "0". Old/new are base64-encoded so they survive
-// argv as opaque byte strings. Avoids single quotes so the whole script can be
-// passed inside a single-quoted shell argument.
-const editPythonScript = `import base64, sys
-path = sys.argv[1]
-old = base64.b64decode(sys.argv[2]).decode("utf-8")
-new_ = base64.b64decode(sys.argv[3]).decode("utf-8")
-replace_all = sys.argv[4] == "1"
-try:
-    with open(path, "r") as f:
-        content = f.read()
-except FileNotFoundError:
-    sys.stderr.write("file not found: " + path + "\n")
-    sys.exit(2)
-if old not in content:
-    sys.stderr.write("oldString not found in file: " + path + "\n")
-    sys.exit(3)
-if not replace_all and content.count(old) > 1:
-    sys.stderr.write("multiple occurrences of oldString found in file " + path + ", but ReplaceAll is false\n")
-    sys.exit(4)
-content = content.replace(old, new_) if replace_all else content.replace(old, new_, 1)
-with open(path, "w") as f:
-    f.write(content)
-`
+// shellResult holds the output of a shell command execution along with
+// metadata about whether the output was truncated.
+type shellResult struct {
+	Output    string
+	Truncated bool
+}
 
-func (b *backend) runShell(ctx context.Context, cmd string) (string, error) {
+func (b *Backend) runShell(ctx context.Context, cmd string) (*shellResult, error) {
 	resp, err := b.shell.Execute(ctx, &filesystem.ExecuteRequest{Command: cmd})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if resp.ExitCode != nil && *resp.ExitCode != 0 {
-		return "", fmt.Errorf("exit %d: %s", *resp.ExitCode, resp.Output)
+	if resp.ExitCode == nil {
+		// Process was terminated by signal or exited without a code — treat as error.
+		return nil, fmt.Errorf("%w: process terminated without exit code (output=%q)",
+			ErrShellNonZeroExit, truncateStr(resp.Output, maxLogCommandLen))
 	}
-	return resp.Output, nil
+	if *resp.ExitCode != 0 {
+		return nil, fmt.Errorf("%w: exit %d: %s", ErrShellNonZeroExit, *resp.ExitCode, resp.Output)
+	}
+	return &shellResult{
+		Output:    resp.Output,
+		Truncated: resp.Truncated,
+	}, nil
+}
+
+// truncateStr shortens s to at most maxLen bytes, appending "..." if truncated.
+// It avoids splitting multi-byte UTF-8 characters by backing off to a valid rune boundary.
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	// Back off to avoid cutting a multi-byte rune in half.
+	for maxLen > 0 && !utf8.ValidString(s[:maxLen]) {
+		maxLen--
+	}
+	return s[:maxLen] + "..."
 }
 
 // shellQuote wraps s in single quotes for safe inclusion in a sh/bash/zsh command.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+// It rejects strings containing null bytes, which shells cannot represent in arguments.
+func shellQuote(s string) (string, error) {
+	if strings.ContainsRune(s, 0) {
+		return "", errors.New("acp.shell: argument contains null byte")
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'", nil
 }
 
-func joinShellArgs(args []string) string {
+func joinShellArgs(args []string) (string, error) {
 	quoted := make([]string, len(args))
 	for i, a := range args {
-		quoted[i] = shellQuote(a)
+		q, err := shellQuote(a)
+		if err != nil {
+			return "", err
+		}
+		quoted[i] = q
 	}
-	return strings.Join(quoted, " ")
+	return strings.Join(quoted, " "), nil
 }
 
-// parseRipgrepOutput parses output of `rg --line-number --no-heading`. Each
-// match line is "path:line:content"; each context line (when -A/-B/-C is set)
-// is "path:line-content". Group separators ("--") and unparsable lines are
-// skipped. Filenames containing ':' are not handled — they would be skipped.
-func parseRipgrepOutput(out string) []filesystem.GrepMatch {
+// rgJSONMatch represents a single match entry from `rg --json` output.
+type rgJSONMatch struct {
+	Type string `json:"type"`
+	Data struct {
+		Path struct {
+			Text string `json:"text"`
+		} `json:"path"`
+		LineNumber int `json:"line_number"`
+		Lines      struct {
+			Text string `json:"text"`
+		} `json:"lines"`
+	} `json:"data"`
+}
+
+// parseRipgrepJSONOutput parses `rg --json` output format. Each line is a JSON
+// object; we only extract entries with type=="match". This correctly handles
+// filenames containing ':' or other special characters.
+// Returns an error if the output is non-empty but every line fails to parse
+// (e.g. incompatible rg version).
+func parseRipgrepJSONOutput(out string, logger *slog.Logger) ([]filesystem.GrepMatch, error) {
 	var matches []filesystem.GrepMatch
+	var totalLines, failedLines int
 	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
 		if line == "" {
 			continue
 		}
-		m, ok := parseRipgrepLine(line)
+		totalLines++
+		var entry rgJSONMatch
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			failedLines++
+			logger.Warn("acp.grep: failed to parse rg JSON line", "err", err, "line", line)
+			continue
+		}
+		if entry.Type != "match" {
+			continue
+		}
+		content := entry.Data.Lines.Text
+		// rg --json includes trailing newline in lines.text; trim it.
+		content = strings.TrimSuffix(content, "\n")
+		matches = append(matches, filesystem.GrepMatch{
+			Path:    entry.Data.Path.Text,
+			Line:    entry.Data.LineNumber,
+			Content: content,
+		})
+	}
+	if totalLines > 0 && failedLines == totalLines {
+		return nil, fmt.Errorf("acp.grep: all %d output lines failed JSON parsing (possible rg version incompatibility)", totalLines)
+	}
+	if failedLines > 0 && float64(failedLines)/float64(totalLines) >= rgJSONMaxFailedRatio {
+		return nil, fmt.Errorf("acp.grep: %d/%d output lines failed JSON parsing (possible rg version incompatibility)", failedLines, totalLines)
+	}
+	return matches, nil
+}
+
+// parsePosixGrepOutput parses `grep -RHn` style output where each match line
+// is `<path>:<lineno>:<content>` and context lines use `-` as the separator.
+// `--` group separators emitted by -A/-B are skipped. Lines that don't match
+// the expected shape are skipped (best-effort), since `grep --no-messages` may
+// still emit content from binary files in unusual encodings.
+//
+// To handle paths containing colons, we search from the right for the last
+// occurrence of `:<digits>:` or `:<digits>-` boundary, which more reliably
+// identifies the line-number field.
+func parsePosixGrepOutput(out string) []filesystem.GrepMatch {
+	var matches []filesystem.GrepMatch
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" || line == "--" {
+			continue
+		}
+		filePath, lineno, content, ok := parsePosixGrepLine(line)
 		if !ok {
 			continue
 		}
-		matches = append(matches, m)
+		matches = append(matches, filesystem.GrepMatch{
+			Path:    filePath,
+			Line:    lineno,
+			Content: content,
+		})
 	}
 	return matches
 }
 
-func parseRipgrepLine(line string) (filesystem.GrepMatch, bool) {
-	i := strings.IndexByte(line, ':')
-	if i <= 0 {
-		return filesystem.GrepMatch{}, false
+// parsePosixGrepLine parses a single line of grep -RHn output. The format is:
+//
+//	<path><sep><lineno><sep><content>
+//
+// where <sep> is ':' (match line) or '-' (context line from -A/-B).
+//
+// Algorithm: scan left-to-right for the first <sep><digits><sep> boundary.
+// Everything before the leading separator is the path; everything after the
+// trailing separator is the content. This correctly handles paths containing
+// ':' (e.g. "vendor/pkg:v2/file.go") as long as the path does not contain a
+// substring matching :<positive-integer><sep> before the real line number.
+//
+// Known limitation: if the path itself contains a `:N:` or `:N-` pattern where
+// N is a positive integer (e.g. "prefix:1:rest.go"), the parser will mis-split.
+// POSIX grep has no NUL-delimited output mode (`-Z` is GNU-only), so this is
+// an inherent best-effort trade-off.
+func parsePosixGrepLine(line string) (filePath string, lineno int, content string, ok bool) {
+	n := len(line)
+	// Find first occurrence of <sep><digits><sep> scanning left-to-right.
+	i := 0
+	for i < n {
+		// Find next ':' or '-' separator.
+		sep1 := -1
+		for j := i; j < n; j++ {
+			if line[j] == ':' || line[j] == '-' {
+				sep1 = j
+				break
+			}
+		}
+		if sep1 < 0 || sep1+1 >= n {
+			return "", 0, "", false
+		}
+		// Check if digits follow.
+		digitStart := sep1 + 1
+		digitEnd := digitStart
+		for digitEnd < n && line[digitEnd] >= '0' && line[digitEnd] <= '9' {
+			digitEnd++
+		}
+		if digitEnd == digitStart || digitEnd >= n {
+			// No digits found after this separator, or digits run to end of line.
+			i = sep1 + 1
+			continue
+		}
+		// Check that digits are followed by another separator.
+		if line[digitEnd] != ':' && line[digitEnd] != '-' {
+			i = sep1 + 1
+			continue
+		}
+		// We have a valid <sep><digits><sep> at sep1..digitEnd.
+		num, err := strconv.Atoi(line[digitStart:digitEnd])
+		if err != nil || num <= 0 {
+			i = sep1 + 1
+			continue
+		}
+		filePath = line[:sep1]
+		content = line[digitEnd+1:]
+		return filePath, num, content, true
 	}
-	path := line[:i]
-	rest := line[i+1:]
-
-	j := 0
-	for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
-		j++
-	}
-	if j == 0 || j >= len(rest) {
-		return filesystem.GrepMatch{}, false
-	}
-	if sep := rest[j]; sep != ':' && sep != '-' {
-		return filesystem.GrepMatch{}, false
-	}
-	lineNum, err := strconv.Atoi(rest[:j])
-	if err != nil {
-		return filesystem.GrepMatch{}, false
-	}
-	return filesystem.GrepMatch{Path: path, Line: lineNum, Content: rest[j+1:]}, true
+	return "", 0, "", false
 }

--- a/acp/backend_test.go
+++ b/acp/backend_test.go
@@ -481,8 +481,8 @@ func TestParsePosixGrepLine_AdversarialPath(t *testing.T) {
 	}{
 		{
 			// Path "prefix:1:rest.go" contains `:1:` which the parser will
-			// match first. This is a known mis-split — we document it here.
-			name:    "path with :1: prefix mis-splits (known limitation)",
+			// match first. This is a known incorrect split — we document it here.
+			name:    "path with :1: prefix splits incorrectly (known limitation)",
 			line:    "prefix:1:rest.go:10:actual content",
 			wantOK:  true,
 			path:    "prefix",
@@ -548,12 +548,12 @@ func TestDetectRipgrep_CachesAfterFirstProbe(t *testing.T) {
 
 // mockConn implements ACPConn for unit testing Backend methods.
 type mockConn struct {
-	readTextFile       func(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error)
-	writeTextFile      func(ctx context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error)
-	createTerminal     func(ctx context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error)
+	readTextFile        func(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error)
+	writeTextFile       func(ctx context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error)
+	createTerminal      func(ctx context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error)
 	waitForTerminalExit func(ctx context.Context, req acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error)
-	terminalOutput     func(ctx context.Context, req acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error)
-	releaseTerminal    func(ctx context.Context, req acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error)
+	terminalOutput      func(ctx context.Context, req acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error)
+	releaseTerminal     func(ctx context.Context, req acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error)
 }
 
 func (m *mockConn) ReadTextFile(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
@@ -624,8 +624,8 @@ func terminalMock(output string, exitCode int, truncated bool) *mockConn {
 		},
 		terminalOutput: func(_ context.Context, _ acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error) {
 			return acpproto.TerminalOutputResponse{
-				Output:    output,
-				Truncated: truncated,
+				Output:     output,
+				Truncated:  truncated,
 				ExitStatus: &acpproto.TerminalExitStatus{ExitCode: &ec},
 			}, nil
 		},

--- a/acp/backend_test.go
+++ b/acp/backend_test.go
@@ -1,0 +1,1016 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package einoacp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino/adk/filesystem"
+	acpproto "github.com/eino-contrib/acp"
+)
+
+// discardLogger is a slog.Logger that drops every record. It keeps test output
+// clean while still exercising the warn/info/debug paths inside Backend.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// stubConn returns a minimal ACPConn implementation that is safe to embed in
+// a Backend as long as no RPC method is actually invoked. Used for
+// Config.validate / NewBackend bookkeeping tests.
+func stubConn() ACPConn {
+	return &mockConn{}
+}
+
+// --- Config.validate ---
+
+func TestConfigValidate(t *testing.T) {
+	conn := stubConn()
+	caps := &acpproto.ClientCapabilities{}
+
+	cases := []struct {
+		name    string
+		cfg     *Config
+		wantErr string // substring; "" means must succeed
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: "cfg is required",
+		},
+		{
+			name:    "missing Conn",
+			cfg:     &Config{SessionID: "s", Capabilities: caps},
+			wantErr: "cfg.Conn is required",
+		},
+		{
+			name:    "missing SessionID",
+			cfg:     &Config{Conn: conn, Capabilities: caps},
+			wantErr: "cfg.SessionID is required",
+		},
+		{
+			name:    "missing Capabilities",
+			cfg:     &Config{Conn: conn, SessionID: "s"},
+			wantErr: "cfg.Capabilities is required",
+		},
+		{
+			name:    "valid",
+			cfg:     &Config{Conn: conn, SessionID: "s", Capabilities: caps},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// --- NewBackend ---
+
+func TestNewBackend_PropagatesCapabilities(t *testing.T) {
+	conn := stubConn()
+
+	t.Run("fs both enabled, terminal disabled", func(t *testing.T) {
+		b, err := NewBackend(&Config{
+			Conn:      conn,
+			SessionID: "s1",
+			Capabilities: &acpproto.ClientCapabilities{
+				FS:       &acpproto.FileSystemCapabilities{ReadTextFile: true, WriteTextFile: true},
+				Terminal: false,
+			},
+			Logger: discardLogger(),
+		})
+		if err != nil {
+			t.Fatalf("NewBackend: %v", err)
+		}
+		if !b.hasReadFS || !b.hasWriteFS {
+			t.Fatalf("expected hasReadFS && hasWriteFS to be true, got %v %v", b.hasReadFS, b.hasWriteFS)
+		}
+		if b.shell != nil {
+			t.Fatalf("expected nil shell when terminal capability is off")
+		}
+	})
+
+	t.Run("terminal advertised but UseTerminalForFileTools off", func(t *testing.T) {
+		b, err := NewBackend(&Config{
+			Conn:                    conn,
+			SessionID:               "s2",
+			Capabilities:            &acpproto.ClientCapabilities{Terminal: true},
+			UseTerminalForFileTools: false,
+			Logger:                  discardLogger(),
+		})
+		if err != nil {
+			t.Fatalf("NewBackend: %v", err)
+		}
+		if b.shell != nil {
+			t.Fatalf("expected nil shell when UseTerminalForFileTools is false")
+		}
+	})
+
+	t.Run("terminal + UseTerminalForFileTools wires shell", func(t *testing.T) {
+		b, err := NewBackend(&Config{
+			Conn:                    conn,
+			SessionID:               "s3",
+			Capabilities:            &acpproto.ClientCapabilities{Terminal: true},
+			UseTerminalForFileTools: true,
+			Logger:                  discardLogger(),
+		})
+		if err != nil {
+			t.Fatalf("NewBackend: %v", err)
+		}
+		if b.shell == nil {
+			t.Fatalf("expected shell to be wired")
+		}
+		if b.shell.sessionID != "s3" {
+			t.Fatalf("shell.sessionID = %q, want s3", b.shell.sessionID)
+		}
+	})
+
+	t.Run("nil FS capability leaves flags false", func(t *testing.T) {
+		b, err := NewBackend(&Config{
+			Conn:         conn,
+			SessionID:    "s4",
+			Capabilities: &acpproto.ClientCapabilities{}, // FS == nil
+		})
+		if err != nil {
+			t.Fatalf("NewBackend: %v", err)
+		}
+		if b.hasReadFS || b.hasWriteFS {
+			t.Fatalf("expected fs flags to default to false")
+		}
+	})
+
+	t.Run("invalid config bubbles up", func(t *testing.T) {
+		_, err := NewBackend(&Config{}) // missing everything
+		if err == nil {
+			t.Fatal("expected error from invalid config")
+		}
+	})
+}
+
+// --- Capability-missing gates ---
+
+// newBackendNoShell builds a Backend with no shell wired so we can assert that
+// the terminal-backed tools surface ErrCapabilityMissing without ever touching
+// the underlying ACPConn.
+func newBackendNoShell(t *testing.T) *Backend {
+	t.Helper()
+	b, err := NewBackend(&Config{
+		Conn:         stubConn(),
+		SessionID:    "test-session",
+		Capabilities: &acpproto.ClientCapabilities{}, // no fs, no terminal
+	})
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+	return b
+}
+
+func TestBackend_LsInfo_NoShell(t *testing.T) {
+	b := newBackendNoShell(t)
+	_, err := b.LsInfo(context.Background(), &filesystem.LsInfoRequest{Path: "."})
+	if !errors.Is(err, ErrCapabilityMissing) {
+		t.Fatalf("expected ErrCapabilityMissing, got %v", err)
+	}
+}
+
+func TestBackend_GrepRaw_NoShell(t *testing.T) {
+	b := newBackendNoShell(t)
+	_, err := b.GrepRaw(context.Background(), &filesystem.GrepRequest{Pattern: "x"})
+	if !errors.Is(err, ErrCapabilityMissing) {
+		t.Fatalf("expected ErrCapabilityMissing, got %v", err)
+	}
+}
+
+func TestBackend_GlobInfo_NoShell(t *testing.T) {
+	b := newBackendNoShell(t)
+	_, err := b.GlobInfo(context.Background(), &filesystem.GlobInfoRequest{Pattern: "*.go"})
+	if !errors.Is(err, ErrCapabilityMissing) {
+		t.Fatalf("expected ErrCapabilityMissing, got %v", err)
+	}
+}
+
+// --- Backend.Edit early-return semantics ---
+
+func TestBackend_Edit_EmptyOldString(t *testing.T) {
+	b := newBackendNoShell(t)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath:  "f.txt",
+		OldString: "",
+		NewString: "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "oldString must be non-empty") {
+		t.Fatalf("expected oldString validation error, got %v", err)
+	}
+}
+
+func TestBackend_Edit_NoOpReturnsNil(t *testing.T) {
+	// When OldString == NewString, Edit must short-circuit BEFORE the fs
+	// capability check, otherwise harmless no-op edits would surface as
+	// errors when running against clients that don't expose fs.
+	b := newBackendNoShell(t)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath:  "f.txt",
+		OldString: "same",
+		NewString: "same",
+	})
+	if err != nil {
+		t.Fatalf("expected nil for no-op edit, got %v", err)
+	}
+}
+
+func TestBackend_Edit_RequiresFSCapability(t *testing.T) {
+	b := newBackendNoShell(t)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath:  "f.txt",
+		OldString: "a",
+		NewString: "b",
+	})
+	if !errors.Is(err, ErrCapabilityMissing) {
+		t.Fatalf("expected ErrCapabilityMissing, got %v", err)
+	}
+}
+
+// --- shellQuote / joinShellArgs ---
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "''"},
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"it's", `'it'\''s'`}, // single quote becomes '\''
+		{"a'b'c", `'a'\''b'\''c'`},
+		{"$(echo pwn)", "'$(echo pwn)'"}, // shell metacharacters stay literal
+	}
+	for _, c := range cases {
+		got, err := shellQuote(c.in)
+		if err != nil {
+			t.Errorf("shellQuote(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestJoinShellArgs(t *testing.T) {
+	got, err := joinShellArgs([]string{"grep", "-e", "foo bar", "."})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "'grep' '-e' 'foo bar' '.'"
+	if got != want {
+		t.Fatalf("joinShellArgs = %q, want %q", got, want)
+	}
+
+	// Empty input must produce empty string, not panic.
+	if got, err := joinShellArgs(nil); err != nil {
+		t.Fatalf("joinShellArgs(nil) unexpected error: %v", err)
+	} else if got != "" {
+		t.Fatalf("joinShellArgs(nil) = %q, want empty", got)
+	}
+}
+
+// --- parseRipgrepJSONOutput ---
+
+func TestParseRipgrepJSONOutput_Empty(t *testing.T) {
+	matches, err := parseRipgrepJSONOutput("", discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(matches))
+	}
+}
+
+func TestParseRipgrepJSONOutput_Valid(t *testing.T) {
+	// Simulate a minimal rg --json stream: one "begin" event (ignored) and
+	// one "match" event (kept). Trailing newline on lines.text is trimmed.
+	out := strings.Join([]string{
+		`{"type":"begin","data":{"path":{"text":"main.go"}}}`,
+		`{"type":"match","data":{"path":{"text":"main.go"},"line_number":42,"lines":{"text":"hello\n"}}}`,
+	}, "\n")
+
+	matches, err := parseRipgrepJSONOutput(out, discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := []filesystem.GrepMatch{{Path: "main.go", Line: 42, Content: "hello"}}
+	if !reflect.DeepEqual(matches, want) {
+		t.Fatalf("matches = %#v, want %#v", matches, want)
+	}
+}
+
+func TestParseRipgrepJSONOutput_AllFailedReturnsError(t *testing.T) {
+	// Non-JSON output simulates an incompatible rg version that does not
+	// emit JSON at all. We expect an error rather than silently returning
+	// an empty slice.
+	out := "this is not json\nneither is this\n"
+	_, err := parseRipgrepJSONOutput(out, discardLogger())
+	if err == nil {
+		t.Fatal("expected error when every output line fails to parse")
+	}
+	if !strings.Contains(err.Error(), "failed JSON parsing") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseRipgrepJSONOutput_PartialFailureLogged(t *testing.T) {
+	// One bad line + two valid lines (one match, one begin): parsing must
+	// succeed and skip the bad line. Failure rate 1/3 < 50%.
+	out := strings.Join([]string{
+		`not json`,
+		`{"type":"begin","data":{"path":{"text":"a.go"}}}`,
+		`{"type":"match","data":{"path":{"text":"a.go"},"line_number":1,"lines":{"text":"x"}}}`,
+	}, "\n")
+	matches, err := parseRipgrepJSONOutput(out, discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "a.go" {
+		t.Fatalf("matches = %#v", matches)
+	}
+}
+
+// --- parsePosixGrepOutput ---
+
+func TestParsePosixGrepOutput_Basic(t *testing.T) {
+	out := strings.Join([]string{
+		"main.go:10:func Foo() {",
+		"util.go:3:package util",
+	}, "\n")
+
+	got := parsePosixGrepOutput(out)
+	want := []filesystem.GrepMatch{
+		{Path: "main.go", Line: 10, Content: "func Foo() {"},
+		{Path: "util.go", Line: 3, Content: "package util"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParsePosixGrepOutput_ContextAndSeparators(t *testing.T) {
+	// `--` separates context groups; context lines use `-` instead of `:`
+	// after the line number. Both should flow through, preserving line
+	// numbers, while `--` itself is dropped.
+	out := strings.Join([]string{
+		"f.go-9-// before",
+		"f.go:10:hit",
+		"f.go-11-// after",
+		"--",
+		"g.go:5:hit",
+	}, "\n")
+
+	got := parsePosixGrepOutput(out)
+	want := []filesystem.GrepMatch{
+		{Path: "f.go", Line: 9, Content: "// before"},
+		{Path: "f.go", Line: 10, Content: "hit"},
+		{Path: "f.go", Line: 11, Content: "// after"},
+		{Path: "g.go", Line: 5, Content: "hit"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParsePosixGrepOutput_SkipsMalformed(t *testing.T) {
+	// Lines without the expected `path:lineno:...` shape (e.g. "Binary file
+	// foo matches") are skipped silently rather than producing zero-row
+	// noise in the result.
+	out := strings.Join([]string{
+		"Binary file foo matches",
+		"f.go:1:ok",
+		"",
+		"--",
+	}, "\n")
+	got := parsePosixGrepOutput(out)
+	want := []filesystem.GrepMatch{
+		{Path: "f.go", Line: 1, Content: "ok"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParsePosixGrepOutput_NongreedyPathWithColon(t *testing.T) {
+	// The parser splits on the FIRST `<sep><digits><sep>` boundary.
+	// Content containing additional colons and digits should not confuse it.
+	out := "main.go:7:url := \"http://example.com:8080/\""
+	got := parsePosixGrepOutput(out)
+	want := []filesystem.GrepMatch{
+		{Path: "main.go", Line: 7, Content: `url := "http://example.com:8080/"`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParsePosixGrepOutput_PathContainingColonDigits(t *testing.T) {
+	// Path like "vendor/pkg:v2/file.go" should parse correctly — the first
+	// valid <sep><digits><sep> after "v2" is `:10:`.
+	out := "vendor/pkg:v2/file.go:10:func Init() {"
+	got := parsePosixGrepOutput(out)
+	// Note: "v2" is not a valid line number boundary because 'v' precedes '2',
+	// so the parser correctly finds `:10:` as the first <sep><digits><sep>.
+	// However, our left-to-right scan finds the first separator at index of first
+	// ':' -> checks if digits follow. "v2/file.go" doesn't start with digits.
+	// Actually `:` at position 10 (after "vendor/pkg"), next char is 'v' — not a digit.
+	// So it skips, finds next `:` after "v2/file.go", digits "10", then ':'. Correct!
+	want := []filesystem.GrepMatch{
+		{Path: "vendor/pkg:v2/file.go", Line: 10, Content: "func Init() {"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParsePosixGrepOutput_Empty(t *testing.T) {
+	if got := parsePosixGrepOutput(""); len(got) != 0 {
+		t.Fatalf("expected no matches, got %#v", got)
+	}
+	if got := parsePosixGrepOutput("\n--\n\n"); len(got) != 0 {
+		t.Fatalf("expected no matches, got %#v", got)
+	}
+}
+
+func TestParsePosixGrepLine_AdversarialPath(t *testing.T) {
+	// Paths containing `:N:` substrings are a known limitation. Document the
+	// current best-effort behavior so future changes have a regression baseline.
+	cases := []struct {
+		name    string
+		line    string
+		wantOK  bool
+		path    string
+		lineno  int
+		content string
+	}{
+		{
+			// Path "prefix:1:rest.go" contains `:1:` which the parser will
+			// match first. This is a known mis-split — we document it here.
+			name:    "path with :1: prefix mis-splits (known limitation)",
+			line:    "prefix:1:rest.go:10:actual content",
+			wantOK:  true,
+			path:    "prefix",
+			lineno:  1,
+			content: "rest.go:10:actual content",
+		},
+		{
+			// Path "vendor/pkg:v2/file.go" — `:v2` is not digits, so the
+			// parser correctly skips it and finds `:10:`.
+			name:    "path with :v2/ correctly finds :10:",
+			line:    "vendor/pkg:v2/file.go:10:func Init() {",
+			wantOK:  true,
+			path:    "vendor/pkg:v2/file.go",
+			lineno:  10,
+			content: "func Init() {",
+		},
+		{
+			// Content containing `:digits:` should not confuse the parser
+			// because we find the FIRST valid boundary scanning left-to-right.
+			name:    "content with :8080: is not confused",
+			line:    "main.go:7:url := \"http://example.com:8080/\"",
+			wantOK:  true,
+			path:    "main.go",
+			lineno:  7,
+			content: "url := \"http://example.com:8080/\"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, lineno, content, ok := parsePosixGrepLine(tc.line)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if path != tc.path || lineno != tc.lineno || content != tc.content {
+				t.Fatalf("got (%q, %d, %q), want (%q, %d, %q)",
+					path, lineno, content, tc.path, tc.lineno, tc.content)
+			}
+		})
+	}
+}
+
+// --- detectRipgrep caching ---
+
+func TestDetectRipgrep_CachesAfterFirstProbe(t *testing.T) {
+	// Verify cached state is honored without re-probing.
+	b := &Backend{}
+	b.rgState.Store(rgUnavailable)
+	if b.detectRipgrep(context.Background()) {
+		t.Fatal("expected cached false to be returned, got true")
+	}
+
+	b2 := &Backend{}
+	b2.rgState.Store(rgAvailable)
+	if !b2.detectRipgrep(context.Background()) {
+		t.Fatal("expected cached true to be returned, got false")
+	}
+}
+
+// --- Mock-based tests using ACPConn interface ---
+
+// mockConn implements ACPConn for unit testing Backend methods.
+type mockConn struct {
+	readTextFile       func(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error)
+	writeTextFile      func(ctx context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error)
+	createTerminal     func(ctx context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error)
+	waitForTerminalExit func(ctx context.Context, req acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error)
+	terminalOutput     func(ctx context.Context, req acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error)
+	releaseTerminal    func(ctx context.Context, req acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error)
+}
+
+func (m *mockConn) ReadTextFile(ctx context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+	if m.readTextFile != nil {
+		return m.readTextFile(ctx, req)
+	}
+	return acpproto.ReadTextFileResponse{}, errors.New("ReadTextFile not mocked")
+}
+
+func (m *mockConn) WriteTextFile(ctx context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error) {
+	if m.writeTextFile != nil {
+		return m.writeTextFile(ctx, req)
+	}
+	return acpproto.WriteTextFileResponse{}, errors.New("WriteTextFile not mocked")
+}
+
+func (m *mockConn) CreateTerminal(ctx context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error) {
+	if m.createTerminal != nil {
+		return m.createTerminal(ctx, req)
+	}
+	return acpproto.CreateTerminalResponse{}, errors.New("CreateTerminal not mocked")
+}
+
+func (m *mockConn) WaitForTerminalExit(ctx context.Context, req acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error) {
+	if m.waitForTerminalExit != nil {
+		return m.waitForTerminalExit(ctx, req)
+	}
+	return acpproto.WaitForTerminalExitResponse{}, errors.New("WaitForTerminalExit not mocked")
+}
+
+func (m *mockConn) TerminalOutput(ctx context.Context, req acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error) {
+	if m.terminalOutput != nil {
+		return m.terminalOutput(ctx, req)
+	}
+	return acpproto.TerminalOutputResponse{}, errors.New("TerminalOutput not mocked")
+}
+
+func (m *mockConn) ReleaseTerminal(ctx context.Context, req acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error) {
+	if m.releaseTerminal != nil {
+		return m.releaseTerminal(ctx, req)
+	}
+	return acpproto.ReleaseTerminalResponse{}, nil
+}
+
+// newMockBackend creates a Backend with a mock connection and shell wired up.
+func newMockBackend(mc *mockConn) *Backend {
+	logger := discardLogger()
+	s := &shell{conn: mc, sessionID: "test-session", logger: logger}
+	return &Backend{
+		conn:       mc,
+		sessionID:  "test-session",
+		shell:      s,
+		hasReadFS:  true,
+		hasWriteFS: true,
+	}
+}
+
+// terminalMock returns a mockConn that simulates a shell command producing the
+// given output and exit code. Used by LsInfo/GlobInfo/GrepRaw tests.
+func terminalMock(output string, exitCode int, truncated bool) *mockConn {
+	ec := int64(exitCode)
+	return &mockConn{
+		createTerminal: func(_ context.Context, req acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error) {
+			return acpproto.CreateTerminalResponse{TerminalID: "t1"}, nil
+		},
+		waitForTerminalExit: func(_ context.Context, _ acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error) {
+			return acpproto.WaitForTerminalExitResponse{ExitCode: &ec}, nil
+		},
+		terminalOutput: func(_ context.Context, _ acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error) {
+			return acpproto.TerminalOutputResponse{
+				Output:    output,
+				Truncated: truncated,
+				ExitStatus: &acpproto.TerminalExitStatus{ExitCode: &ec},
+			}, nil
+		},
+		releaseTerminal: func(_ context.Context, _ acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error) {
+			return acpproto.ReleaseTerminalResponse{}, nil
+		},
+	}
+}
+
+// --- Backend.Read / Write with mock ---
+
+func TestBackend_Read_WithMock(t *testing.T) {
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, req acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			if req.Path != "/foo/bar.txt" {
+				t.Errorf("unexpected path: %s", req.Path)
+			}
+			if req.SessionID != "test-session" {
+				t.Errorf("unexpected session: %s", req.SessionID)
+			}
+			return acpproto.ReadTextFileResponse{Content: "hello world"}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	fc, err := b.Read(context.Background(), &filesystem.ReadRequest{FilePath: "/foo/bar.txt"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if fc.Content != "hello world" {
+		t.Fatalf("got content %q, want %q", fc.Content, "hello world")
+	}
+}
+
+func TestBackend_Read_Error(t *testing.T) {
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, _ acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			return acpproto.ReadTextFileResponse{}, errors.New("file not found")
+		},
+	}
+	b := newMockBackend(mc)
+	_, err := b.Read(context.Background(), &filesystem.ReadRequest{FilePath: "/missing.txt"})
+	if err == nil || !strings.Contains(err.Error(), "file not found") {
+		t.Fatalf("expected error containing 'file not found', got %v", err)
+	}
+}
+
+func TestBackend_Write_WithMock(t *testing.T) {
+	var captured acpproto.WriteTextFileRequest
+	mc := &mockConn{
+		writeTextFile: func(_ context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error) {
+			captured = req
+			return acpproto.WriteTextFileResponse{}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	err := b.Write(context.Background(), &filesystem.WriteRequest{FilePath: "/out.txt", Content: "data"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if captured.Path != "/out.txt" || captured.Content != "data" {
+		t.Fatalf("unexpected captured request: %+v", captured)
+	}
+}
+
+// --- Backend.LsInfo with mock ---
+
+func TestBackend_LsInfo_WithMock(t *testing.T) {
+	mc := terminalMock("file1.txt\ndir1/\nfile2.go\n", 0, false)
+	b := newMockBackend(mc)
+	infos, err := b.LsInfo(context.Background(), &filesystem.LsInfoRequest{Path: "/tmp"})
+	if err != nil {
+		t.Fatalf("LsInfo: %v", err)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(infos), infos)
+	}
+	if infos[0].Path != "file1.txt" || infos[0].IsDir {
+		t.Errorf("infos[0] = %+v", infos[0])
+	}
+	if infos[1].Path != "dir1" || !infos[1].IsDir {
+		t.Errorf("infos[1] = %+v", infos[1])
+	}
+	if infos[2].Path != "file2.go" || infos[2].IsDir {
+		t.Errorf("infos[2] = %+v", infos[2])
+	}
+}
+
+func TestBackend_LsInfo_EmptyDir(t *testing.T) {
+	mc := terminalMock("", 0, false)
+	b := newMockBackend(mc)
+	infos, err := b.LsInfo(context.Background(), &filesystem.LsInfoRequest{Path: "."})
+	if err != nil {
+		t.Fatalf("LsInfo: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(infos))
+	}
+}
+
+// --- Backend.GlobInfo with mock ---
+
+func TestBackend_GlobInfo_WithMock(t *testing.T) {
+	// find output includes the base path and nested files
+	output := ".\n./main.go\n./sub/util.go\n./sub/readme.md\n"
+	mc := terminalMock(output, 0, false)
+	b := newMockBackend(mc)
+	infos, err := b.GlobInfo(context.Background(), &filesystem.GlobInfoRequest{Pattern: "**/*.go", Path: "."})
+	if err != nil {
+		t.Fatalf("GlobInfo: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %+v", len(infos), infos)
+	}
+	paths := []string{infos[0].Path, infos[1].Path}
+	if paths[0] != "main.go" || paths[1] != "sub/util.go" {
+		t.Fatalf("unexpected paths: %v", paths)
+	}
+}
+
+func TestBackend_GlobInfo_PartialFailure(t *testing.T) {
+	// Simulate `find` encountering permission-denied on some subdirectories:
+	// exit code 1 but stdout still has valid results.
+	output := ".\n./main.go\n./sub/util.go\n"
+	mc := terminalMock(output, 1, false)
+	b := newMockBackend(mc)
+	infos, err := b.GlobInfo(context.Background(), &filesystem.GlobInfoRequest{Pattern: "**/*.go", Path: "."})
+	if err != nil {
+		t.Fatalf("GlobInfo should succeed on exit code 1 with valid output, got: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %+v", len(infos), infos)
+	}
+}
+
+func TestBackend_GlobInfo_HardFailure(t *testing.T) {
+	// Exit code >= 2 is treated as a hard error.
+	mc := terminalMock("", 2, false)
+	b := newMockBackend(mc)
+	_, err := b.GlobInfo(context.Background(), &filesystem.GlobInfoRequest{Pattern: "**/*.go", Path: "."})
+	if err == nil {
+		t.Fatal("expected error on exit code 2")
+	}
+	if !errors.Is(err, ErrShellNonZeroExit) {
+		t.Fatalf("expected ErrShellNonZeroExit, got %v", err)
+	}
+}
+
+// --- Backend.Edit with mock ---
+
+func TestBackend_Edit_WithMock_Success(t *testing.T) {
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, _ acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			return acpproto.ReadTextFileResponse{Content: "aaa bbb ccc"}, nil
+		},
+		writeTextFile: func(_ context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error) {
+			if req.Content != "aaa xxx ccc" {
+				t.Errorf("unexpected content: %q", req.Content)
+			}
+			return acpproto.WriteTextFileResponse{}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath: "f.go", OldString: "bbb", NewString: "xxx",
+	})
+	if err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+}
+
+func TestBackend_Edit_WithMock_NotFound(t *testing.T) {
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, _ acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			return acpproto.ReadTextFileResponse{Content: "hello"}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath: "f.go", OldString: "missing", NewString: "x",
+	})
+	if !errors.Is(err, ErrOldStringNotFound) {
+		t.Fatalf("expected ErrOldStringNotFound, got %v", err)
+	}
+}
+
+func TestBackend_Edit_WithMock_Ambiguous(t *testing.T) {
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, _ acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			return acpproto.ReadTextFileResponse{Content: "aa bb aa"}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath: "f.go", OldString: "aa", NewString: "xx", ReplaceAll: false,
+	})
+	if !errors.Is(err, ErrAmbiguousReplace) {
+		t.Fatalf("expected ErrAmbiguousReplace, got %v", err)
+	}
+}
+
+func TestBackend_Edit_WithMock_ReplaceAll(t *testing.T) {
+	var written string
+	mc := &mockConn{
+		readTextFile: func(_ context.Context, _ acpproto.ReadTextFileRequest) (acpproto.ReadTextFileResponse, error) {
+			return acpproto.ReadTextFileResponse{Content: "aa bb aa"}, nil
+		},
+		writeTextFile: func(_ context.Context, req acpproto.WriteTextFileRequest) (acpproto.WriteTextFileResponse, error) {
+			written = req.Content
+			return acpproto.WriteTextFileResponse{}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	err := b.Edit(context.Background(), &filesystem.EditRequest{
+		FilePath: "f.go", OldString: "aa", NewString: "xx", ReplaceAll: true,
+	})
+	if err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	if written != "xx bb xx" {
+		t.Fatalf("unexpected written content: %q", written)
+	}
+}
+
+// --- runShell ExitCode==nil (C2 fix) ---
+
+func TestBackend_RunShell_NilExitCode(t *testing.T) {
+	// Simulate a process killed by signal: ExitCode is nil in both wait and output responses.
+	mc := &mockConn{
+		createTerminal: func(_ context.Context, _ acpproto.CreateTerminalRequest) (acpproto.CreateTerminalResponse, error) {
+			return acpproto.CreateTerminalResponse{TerminalID: "t1"}, nil
+		},
+		waitForTerminalExit: func(_ context.Context, _ acpproto.WaitForTerminalExitRequest) (acpproto.WaitForTerminalExitResponse, error) {
+			return acpproto.WaitForTerminalExitResponse{Signal: "SIGKILL"}, nil
+		},
+		terminalOutput: func(_ context.Context, _ acpproto.TerminalOutputRequest) (acpproto.TerminalOutputResponse, error) {
+			return acpproto.TerminalOutputResponse{
+				Output:    "partial output before kill\n[terminated by signal: SIGKILL]",
+				Truncated: false,
+			}, nil
+		},
+		releaseTerminal: func(_ context.Context, _ acpproto.ReleaseTerminalRequest) (acpproto.ReleaseTerminalResponse, error) {
+			return acpproto.ReleaseTerminalResponse{}, nil
+		},
+	}
+	b := newMockBackend(mc)
+	_, err := b.runShell(context.Background(), "sleep 999")
+	if err == nil {
+		t.Fatal("expected error when ExitCode is nil")
+	}
+	if !errors.Is(err, ErrShellNonZeroExit) {
+		t.Fatalf("expected ErrShellNonZeroExit, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "terminated without exit code") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestBackend_RunShell_Success(t *testing.T) {
+	mc := terminalMock("output line\n", 0, false)
+	b := newMockBackend(mc)
+	result, err := b.runShell(context.Background(), "echo hello")
+	if err != nil {
+		t.Fatalf("runShell: %v", err)
+	}
+	if result.Output != "output line\n" {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}
+
+func TestBackend_RunShell_NonZeroExit(t *testing.T) {
+	mc := terminalMock("error msg", 1, false)
+	b := newMockBackend(mc)
+	_, err := b.runShell(context.Background(), "false")
+	if !errors.Is(err, ErrShellNonZeroExit) {
+		t.Fatalf("expected ErrShellNonZeroExit, got %v", err)
+	}
+}
+
+// --- GrepRaw with mock (ripgrep path) ---
+
+func TestBackend_GrepRaw_Ripgrep(t *testing.T) {
+	rgOutput := strings.Join([]string{
+		`{"type":"begin","data":{"path":{"text":"main.go"}}}`,
+		`{"type":"match","data":{"path":{"text":"main.go"},"line_number":5,"lines":{"text":"func hello()\n"}}}`,
+	}, "\n")
+	mc := terminalMock(rgOutput, 0, false)
+	b := newMockBackend(mc)
+	// Force rg available
+	b.rgState.Store(rgAvailable)
+
+	matches, err := b.GrepRaw(context.Background(), &filesystem.GrepRequest{Pattern: "hello", Path: "."})
+	if err != nil {
+		t.Fatalf("GrepRaw: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "main.go" || matches[0].Line != 5 {
+		t.Fatalf("unexpected matches: %+v", matches)
+	}
+}
+
+func TestBackend_GrepRaw_PosixFallback(t *testing.T) {
+	posixOutput := "main.go:10:func Foo() {"
+	mc := terminalMock(posixOutput, 0, false)
+	b := newMockBackend(mc)
+	// Force rg unavailable
+	b.rgState.Store(rgUnavailable)
+
+	matches, err := b.GrepRaw(context.Background(), &filesystem.GrepRequest{Pattern: "Foo", Path: "."})
+	if err != nil {
+		t.Fatalf("GrepRaw: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Path != "main.go" || matches[0].Line != 10 {
+		t.Fatalf("unexpected matches: %+v", matches)
+	}
+}
+
+func TestBackend_GrepRaw_NoMatches(t *testing.T) {
+	mc := terminalMock("", 1, false)
+	b := newMockBackend(mc)
+	b.rgState.Store(rgAvailable)
+
+	matches, err := b.GrepRaw(context.Background(), &filesystem.GrepRequest{Pattern: "nonexistent", Path: "."})
+	if err != nil {
+		t.Fatalf("GrepRaw: %v", err)
+	}
+	if matches != nil {
+		t.Fatalf("expected nil matches, got %+v", matches)
+	}
+}
+
+// --- parseRipgrepJSONOutput majority failure (H2 fix) ---
+
+func TestParseRipgrepJSONOutput_MajorityFailure(t *testing.T) {
+	// 3 bad lines + 1 good line = 75% failure rate → should error
+	out := strings.Join([]string{
+		"not json 1",
+		"not json 2",
+		"not json 3",
+		`{"type":"match","data":{"path":{"text":"a.go"},"line_number":1,"lines":{"text":"x"}}}`,
+	}, "\n")
+	_, err := parseRipgrepJSONOutput(out, discardLogger())
+	if err == nil {
+		t.Fatal("expected error when majority of lines fail parsing")
+	}
+	if !strings.Contains(err.Error(), "3/4") {
+		t.Fatalf("expected error mentioning failure ratio, got: %v", err)
+	}
+}
+
+func TestParseRipgrepJSONOutput_MinorityFailureSucceeds(t *testing.T) {
+	// 1 bad line + 3 good lines = 25% failure rate → should succeed
+	out := strings.Join([]string{
+		"not json",
+		`{"type":"match","data":{"path":{"text":"a.go"},"line_number":1,"lines":{"text":"x"}}}`,
+		`{"type":"match","data":{"path":{"text":"b.go"},"line_number":2,"lines":{"text":"y"}}}`,
+		`{"type":"begin","data":{"path":{"text":"c.go"}}}`,
+	}, "\n")
+	matches, err := parseRipgrepJSONOutput(out, discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+}
+
+// --- shellQuote with newline ---
+
+func TestShellQuote_Newline(t *testing.T) {
+	got, err := shellQuote("a\nb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "'a\nb'"
+	if got != want {
+		t.Errorf("shellQuote(%q) = %q, want %q", "a\nb", got, want)
+	}
+}
+
+// --- truncateStr ---
+
+func TestTruncateStr(t *testing.T) {
+	if got := truncateStr("short", 10); got != "short" {
+		t.Errorf("truncateStr short: %q", got)
+	}
+	if got := truncateStr("hello world", 5); got != "hello..." {
+		t.Errorf("truncateStr long: %q", got)
+	}
+}

--- a/acp/conv.go
+++ b/acp/conv.go
@@ -105,7 +105,14 @@ func AgentEventToSessionUpdate(
 					ID:       a.id,
 					Function: schema.FunctionCall{Name: a.name, Arguments: a.args.String()},
 				}
-				if !yield(acpproto.NewSessionUpdateToolCall(fromToolCall(tc)), nil) {
+				converted, err := fromToolCall(tc)
+				if err != nil {
+					if !yield(acpproto.SessionUpdate{}, err) {
+						return false
+					}
+					continue
+				}
+				if !yield(acpproto.NewSessionUpdateToolCall(converted), nil) {
 					return false
 				}
 			}
@@ -121,7 +128,28 @@ func AgentEventToSessionUpdate(
 				return
 			}
 			if err != nil {
-				// Discard any partially-accumulated tool call buffer — the args may be incomplete JSON.
+				// Before yielding the error, flush any tool calls whose arguments
+				// are already complete JSON. Partially-accumulated calls are discarded.
+				for _, idx := range pendingOrder {
+					a := pendingToolCalls[idx]
+					if a.id == "" || a.name == "" {
+						continue
+					}
+					if !json.Valid([]byte(a.args.String())) {
+						continue
+					}
+					tc := schema.ToolCall{
+						ID:       a.id,
+						Function: schema.FunctionCall{Name: a.name, Arguments: a.args.String()},
+					}
+					converted, convErr := fromToolCall(tc)
+					if convErr != nil {
+						continue
+					}
+					if !yield(acpproto.NewSessionUpdateToolCall(converted), nil) {
+						return
+					}
+				}
 				yield(acpproto.SessionUpdate{}, err)
 				return
 			}
@@ -309,7 +337,12 @@ func yieldMessageUpdates(msg adk.Message, yield func(acpproto.SessionUpdate, err
 			}
 		}
 		for _, tc := range msg.ToolCalls {
-			if !yield(acpproto.NewSessionUpdateToolCall(fromToolCall(tc)), nil) {
+			converted, err := fromToolCall(tc)
+			if err != nil {
+				yield(acpproto.SessionUpdate{}, err)
+				return false
+			}
+			if !yield(acpproto.NewSessionUpdateToolCall(converted), nil) {
 				return false
 			}
 		}
@@ -481,14 +514,18 @@ func outputPartToSessionUpdate(part schema.MessageOutputPart) (acpproto.SessionU
 	}
 }
 
-func fromToolCall(call schema.ToolCall) acpproto.ToolCall {
+func fromToolCall(call schema.ToolCall) (acpproto.ToolCall, error) {
 	args := call.Function.Arguments
-	if args == "" || !json.Valid([]byte(args)) {
+	if args == "" {
 		args = "{}"
+	} else if !json.Valid([]byte(args)) {
+		return acpproto.ToolCall{}, fmt.Errorf(
+			"invalid JSON arguments for tool %q (id=%s): %q",
+			call.Function.Name, call.ID, args)
 	}
 	return acpproto.ToolCall{
 		ToolCallID: acpproto.ToolCallID(call.ID),
 		Title:      call.Function.Name,
 		RawInput:   json.RawMessage(args),
-	}
+	}, nil
 }

--- a/acp/conv_test.go
+++ b/acp/conv_test.go
@@ -883,7 +883,10 @@ func TestFromToolCall(t *testing.T) {
 		ID:       "call-123",
 		Function: schema.FunctionCall{Name: "search", Arguments: `{"q":"test"}`},
 	}
-	result := fromToolCall(tc)
+	result, err := fromToolCall(tc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if string(result.ToolCallID) != "call-123" {
 		t.Fatalf("ToolCallID = %q, want %q", result.ToolCallID, "call-123")
 	}
@@ -892,6 +895,31 @@ func TestFromToolCall(t *testing.T) {
 	}
 	if string(result.RawInput) != `{"q":"test"}` {
 		t.Fatalf("RawInput = %s, want %s", result.RawInput, `{"q":"test"}`)
+	}
+}
+
+func TestFromToolCallEmptyArgs(t *testing.T) {
+	tc := schema.ToolCall{
+		ID:       "call-456",
+		Function: schema.FunctionCall{Name: "noop", Arguments: ""},
+	}
+	result, err := fromToolCall(tc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.RawInput) != `{}` {
+		t.Fatalf("RawInput = %s, want {}", result.RawInput)
+	}
+}
+
+func TestFromToolCallInvalidJSON(t *testing.T) {
+	tc := schema.ToolCall{
+		ID:       "call-789",
+		Function: schema.FunctionCall{Name: "broken", Arguments: `{invalid`},
+	}
+	_, err := fromToolCall(tc)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON args, got nil")
 	}
 }
 
@@ -1505,4 +1533,56 @@ func TestAgentEventToSessionUpdate_OptNilConverterUsesDefault(t *testing.T) {
 		t.Fatalf("expected 1 update, got %d", len(updates))
 	}
 	requireTextChunk(t, updates[0], "hello")
+}
+
+func TestAgentEventToSessionUpdate_StreamingFlushDoesNotDropValidToolCalls(t *testing.T) {
+	// When one tool call in a batch has invalid JSON args, the other valid ones
+	// should still be yielded (the invalid one yields an error but doesn't abort).
+	reader, writer := schema.Pipe[*schema.Message](10)
+	idx0, idx1, idx2 := 0, 1, 2
+	go func() {
+		// Stream 3 tool calls: index 0 valid, index 1 invalid JSON, index 2 valid
+		writer.Send(&schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{
+				{Index: &idx0, ID: "tc-good-1", Function: schema.FunctionCall{Name: "read_file", Arguments: `{"path":"/a.txt"}`}},
+				{Index: &idx1, ID: "tc-bad", Function: schema.FunctionCall{Name: "write_file", Arguments: `{invalid`}},
+				{Index: &idx2, ID: "tc-good-2", Function: schema.FunctionCall{Name: "ls", Arguments: `{"path":"."}`}},
+			},
+		}, nil)
+		writer.Close()
+	}()
+
+	event := &adk.AgentEvent{
+		Output: &adk.AgentOutput{
+			MessageOutput: &adk.MessageVariant{
+				IsStreaming:   true,
+				MessageStream: reader,
+			},
+		},
+	}
+	updates, errs := collectUpdates(AgentEventToSessionUpdate(event, nil))
+
+	// Should get 1 error (for the invalid tool call) and 2 valid ToolCall updates
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if len(updates) != 2 {
+		t.Fatalf("expected 2 tool call updates, got %d", len(updates))
+	}
+	// Verify the valid tool calls came through
+	tc0, ok := updates[0].AsToolCall()
+	if !ok {
+		t.Fatal("expected first update to be ToolCall")
+	}
+	if tc0.Title != "read_file" {
+		t.Fatalf("expected first tool call name 'read_file', got %q", tc0.Title)
+	}
+	tc1, ok := updates[1].AsToolCall()
+	if !ok {
+		t.Fatal("expected second update to be ToolCall")
+	}
+	if tc1.Title != "ls" {
+		t.Fatalf("expected second tool call name 'ls', got %q", tc1.Title)
+	}
 }

--- a/acp/examples/agent.go
+++ b/acp/examples/agent.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -42,6 +43,9 @@ type sessionState struct {
 
 // agent implements acp.Agent by embedding BaseAgent for default stubs,
 // and overriding the methods we care about.
+//
+// NOTE: In production, sessions should have TTL-based expiration or LRU eviction
+// to prevent unbounded memory growth. This example omits cleanup for brevity.
 type agent struct {
 	acp.BaseAgent
 
@@ -222,6 +226,7 @@ func capturedMessage(event *adk.AgentEvent, historyCopy adk.MessageStream) adk.M
 	// ConcatMessageStream drains and closes the stream.
 	msg, err := schema.ConcatMessageStream(historyCopy)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to concat message stream for history: %v\n", err)
 		return nil
 	}
 	return msg
@@ -229,13 +234,15 @@ func capturedMessage(event *adk.AgentEvent, historyCopy adk.MessageStream) adk.M
 
 // --- Helpers ---
 
+// extractTextFromPrompt concatenates all text blocks from the ACP prompt.
 func extractTextFromPrompt(blocks []acp.ContentBlock) string {
+	var parts []string
 	for _, block := range blocks {
 		if tc, ok := block.AsText(); ok {
-			return tc.Text
+			parts = append(parts, tc.Text)
 		}
 	}
-	return ""
+	return strings.Join(parts, "\n")
 }
 
 func createChatModel(ctx context.Context) (*ark.ChatModel, error) {


### PR DESCRIPTION
## What

Backend & streaming improvements for the `acp` package.

### `acp/backend.go`
- Introduce `ACPConn` interface so callers can substitute the connection (testing/proxying); `*conn.AgentConnection` still satisfies it.
- Add sentinel errors (`ErrShellNonZeroExit`, `ErrCapabilityMissing`, `ErrOldStringNotFound`, `ErrAmbiguousReplace`, `ErrFileTooLarge`) for structured error handling.
- Add `Config.validate()` and require `Capabilities`; clean up middleware wiring.
- Edit tool no longer requires terminal — it always uses fs `ReadTextFile` + `WriteTextFile` and rejects files beyond `maxEditFileSize` (32 MiB) to prevent OOM.
- Grep prefers `rg --json` and falls back transparently to POSIX `grep -RnE` when ripgrep is unavailable.
- Properly release terminals via a background context with timeout so cancellation does not leak terminal handles.
- Optional `slog.Logger` for non-fatal diagnostics.

### `acp/conv.go`
- `fromToolCall` now returns an error on invalid JSON arguments instead of silently coercing them.
- Streaming path flushes any tool calls whose arguments are already complete JSON before yielding the stream error, so a single broken tool call no longer drops the valid ones.

### Tests
- New `acp/backend_test.go`.
- Added `TestFromToolCallEmptyArgs`, `TestFromToolCallInvalidJSON`, and `TestAgentEventToSessionUpdate_StreamingFlushDoesNotDropValidToolCalls` in `conv_test.go`.

### Misc
- Example agent: concatenate all text blocks from prompts and surface stream errors to stderr.
- Update `acp/README.md` / `acp/README_zh.md` for the new behavior.
- `.gitignore`: ignore `*.local.md`.

## Why

- Make the ACP backend more robust against malformed model output (invalid JSON tool args), large files, and missing client tools (`rg`).
- Make the package easier to test by depending on an interface instead of the concrete connection type.
- Avoid resource leaks on cancelled requests.

## Test
- `go test ./acp/...`
