### PR TITLE
refactor(agenticopenai): use upstream prompt cache retention type directly

### DIFF
--- a/components/model/agenticopenai/README.md
+++ b/components/model/agenticopenai/README.md
@@ -191,7 +191,7 @@ type Config struct {
 
     // PromptCacheRetention specifies the retention policy for the prompt cache.
     // Optional.
-    PromptCacheRetention *PromptCacheRetention
+    PromptCacheRetention *responses.ResponseNewParamsPromptCacheRetention
     
     // CustomHeaders specifies custom HTTP headers to include in API requests.
     // CustomHeaders allows passing additional metadata or authentication information.
@@ -205,15 +205,6 @@ type Config struct {
 }
 ```
 
-Available `PromptCacheRetention` constants:
-
-```go
-const (
-    PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
-    PromptCacheRetention24H      PromptCacheRetention = "24h"
-)
-```
-
 ## Advanced Usage
 
 ### Cache
@@ -221,7 +212,7 @@ const (
 Use `EnableAutoCache` to enable auto-caching for multi-turn conversations. If a cached message becomes invalid, call `InvalidateMessageCaches` to temporarily skip it.
 
 ```go
-retention := agenticopenai.PromptCacheRetention24H
+retention := responses.ResponseNewParamsPromptCacheRetention24h
 
 am, err := agenticopenai.New(ctx, &agenticopenai.Config{
 	Model:                os.Getenv("OPENAI_MODEL_ID"),

--- a/components/model/agenticopenai/README.zh_CN.md
+++ b/components/model/agenticopenai/README.zh_CN.md
@@ -191,7 +191,7 @@ type Config struct {
 
 	// PromptCacheRetention 指定 prompt cache 的保留策略。
 	// 可选。
-	PromptCacheRetention *PromptCacheRetention
+	PromptCacheRetention *responses.ResponseNewParamsPromptCacheRetention
 
 	// CustomHeaders 指定 API 请求中包含的自定义 HTTP 标头。
 	// CustomHeaders 允许传递额外的元数据或身份验证信息。
@@ -205,15 +205,6 @@ type Config struct {
 }
 ```
 
-可用的 `PromptCacheRetention` 常量：
-
-```go
-const (
-	PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
-	PromptCacheRetention24H      PromptCacheRetention = "24h"
-)
-```
-
 ## 高级用法
 
 ### 缓存
@@ -221,7 +212,7 @@ const (
 使用 `EnableAutoCache` 开启多轮对话自动缓存。若某条缓存消息已经失效，可以调用 `InvalidateMessageCaches` 临时跳过该缓存。
 
 ```go
-retention := agenticopenai.PromptCacheRetention24H
+retention := responses.ResponseNewParamsPromptCacheRetention24h
 
 am, err := agenticopenai.New(ctx, &agenticopenai.Config{
 	Model:                os.Getenv("OPENAI_MODEL_ID"),

--- a/components/model/agenticopenai/consts.go
+++ b/components/model/agenticopenai/consts.go
@@ -28,13 +28,6 @@ const (
 	ServerToolNameShell           ServerToolName = "shell"
 )
 
-type PromptCacheRetention string
-
-const (
-	PromptCacheRetentionInMemory PromptCacheRetention = "in_memory"
-	PromptCacheRetention24H      PromptCacheRetention = "24h"
-)
-
 type WebSearchAction string
 
 const (

--- a/components/model/agenticopenai/model.go
+++ b/components/model/agenticopenai/model.go
@@ -128,13 +128,13 @@ type Config struct {
 	// by locating the most recent cached message in the input (via Response ID in ResponseMeta).
 	// This cached message and all preceding inputs are excluded from the request.
 	// If the cached message becomes invalid, you can call InvalidateMessageCaches to temporarily invalidate the cache.
-	// Unless store is set to false explicitly for a request, auto-cache forces Store to true.
+	// Unless Store is set to false explicitly for a request, auto-cache forces Store to true.
 	// Optional.
 	EnableAutoCache bool
 
 	// PromptCacheRetention specifies the retention policy for the prompt cache.
 	// Optional.
-	PromptCacheRetention *PromptCacheRetention
+	PromptCacheRetention *responses.ResponseNewParamsPromptCacheRetention
 
 	// CustomHeaders specifies custom HTTP headers to include in API requests.
 	// CustomHeaders allows passing additional metadata or authentication information.
@@ -235,7 +235,7 @@ type Model struct {
 	mcpTools             []*responses.ToolMcpParam
 	truncation           *responses.ResponseNewParamsTruncation
 	enableAutoCache      bool
-	promptCacheRetention *PromptCacheRetention
+	promptCacheRetention *responses.ResponseNewParamsPromptCacheRetention
 
 	customHeader map[string]string
 	extraFields  map[string]any
@@ -582,7 +582,7 @@ func (m *Model) prePopulateConfig(responseReq *responses.ResponseNewParams, opti
 	}
 	responseReq.Include = m.include
 	if m.promptCacheRetention != nil {
-		responseReq.PromptCacheRetention = responses.ResponseNewParamsPromptCacheRetention(*m.promptCacheRetention)
+		responseReq.PromptCacheRetention = *m.promptCacheRetention
 	}
 
 	// options configuration


### PR DESCRIPTION
#### Summary
This change removes the local prompt cache retention wrapper from `agenticopenai` and uses the OpenAI SDK's `responses.ResponseNewParamsPromptCacheRetention` type directly. It reduces redundant API surface and keeps prompt-cache retention configuration aligned with the upstream Responses API.

#### Breaking Changes
1. `Config.PromptCacheRetention` now uses `*responses.ResponseNewParamsPromptCacheRetention` instead of `*agenticopenai.PromptCacheRetention`; callers must update their config values to use the upstream type.
2. Local constants `agenticopenai.PromptCacheRetentionInMemory` and `agenticopenai.PromptCacheRetention24H` are removed; callers must switch to `responses.ResponseNewParamsPromptCacheRetentionInMemory` and `responses.ResponseNewParamsPromptCacheRetention24h`.

#### Key Changes
1. Request building now passes the upstream prompt cache retention enum through directly instead of converting from a local wrapper.
2. Documentation examples now show direct use of the upstream `responses` constants.
