### PR TITLE
refactor(qdrant): enhance embedding callback context and error wrapping

### DIFF
--- a/components/indexer/qdrant/indexer.go
+++ b/components/indexer/qdrant/indexer.go
@@ -128,7 +128,8 @@ func (i *Indexer) batchUpsert(ctx context.Context, docs []*schema.Document, opti
 		for _, doc := range batch {
 			texts = append(texts, doc.Content)
 		}
-		vectors, err := emb.EmbedStrings(ctx, texts)
+
+		vectors, err := emb.EmbedStrings(i.makeEmbeddingCtx(ctx, emb), texts)
 		if err != nil {
 			return fmt.Errorf("[batchUpsert] embedding failed, %w", err)
 		}
@@ -151,7 +152,7 @@ func (i *Indexer) batchUpsert(ctx context.Context, docs []*schema.Document, opti
 			Points:         points,
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("[batchUpsert] failed to upsert points to qdrant, %w", err)
 		}
 	}
 	return nil
@@ -191,4 +192,19 @@ func float64SliceToFloat32(v []float64) []float32 {
 		f[i] = float32(x)
 	}
 	return f
+}
+
+// makeEmbeddingCtx creates a context with embedding callback information.
+func (i *Indexer) makeEmbeddingCtx(ctx context.Context, emb embedding.Embedder) context.Context {
+	runInfo := &callbacks.RunInfo{
+		Component: components.ComponentOfEmbedding,
+	}
+
+	if embType, ok := components.GetType(emb); ok {
+		runInfo.Type = embType
+	}
+
+	runInfo.Name = runInfo.Type + string(runInfo.Component)
+
+	return callbacks.ReuseHandlers(ctx, runInfo)
 }


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
refactor(qdrant): 完善 Qdrant Indexer 的 Embedding 链路追踪与错误封装

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
This PR improves the observability and error handling robustness of the Qdrant Indexer:
1. **Enhance Embedding Tracing Context**: Implemented the `makeEmbeddingCtx` method (similar to the Milvus2 implementation) to pass callback contexts correctly when calling the `embedding.Embedder`. This ensures the callback trace remains intact and metrics/logs for the embedding process are accurately captured within the overall Indexer execution.
2. **Improve Error Wrapping**: Replaced bare `return err` statements in the `batchUpsert` method (specifically when the Qdrant client upsert fails) with `fmt.Errorf("...: %w", err)`. This preserves the underlying error stack while providing necessary execution context for easier debugging.

zh:
这个 PR 增强了 Qdrant Indexer 的可观测性以及错误处理的鲁棒性：
1. **完善 Embedding 链路追踪**：参考 `milvus2` indexer 的实现，新增了 `makeEmbeddingCtx` 方法。在调用大模型生成向量时，能够正确传递 callbacks 上下文，从而确保了 Eino 框架中整体回调追踪链路的完整性。
2. **优化错误封装**：修复了 `batchUpsert` 方法中，调用 Qdrant 客户端 Upsert 失败时直接透传底层 `err` 的问题。统一使用 `fmt.Errorf` 与 `%w` 进行错误包装，在保留底层原始错误信息的同时，补充了当前的操作上下文，降低了线上排障难度。

#### (Optional) Which issue(s) this PR fixes:
#### (optional) The PR that updates user documentation: