### PR TITLE
chore: update cloudwego/eino dependency to v0.9.0

### DIFF
--- a/adk/backend/agentkit/go.mod
+++ b/adk/backend/agentkit/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.12
 
 require (
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774
+	github.com/cloudwego/eino v0.9.0
 	github.com/gen2brain/go-fitz v1.24.15
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f
 	github.com/stretchr/testify v1.11.1

--- a/adk/backend/agentkit/go.sum
+++ b/adk/backend/agentkit/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774 h1:3sHDyCGNuD19forSBM3BmtsQif8jSFTg9HjZS5B6Mqw=
-github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/adk/backend/local/go.mod
+++ b/adk/backend/local/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774
+	github.com/cloudwego/eino v0.9.0
 	github.com/gen2brain/go-fitz v1.24.15
 	github.com/stretchr/testify v1.11.1
 )

--- a/adk/backend/local/go.sum
+++ b/adk/backend/local/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774 h1:3sHDyCGNuD19forSBM3BmtsQif8jSFTg9HjZS5B6Mqw=
-github.com/cloudwego/eino v0.9.0-alpha.5.0.20260421122314-28a9142a0774/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/callbacks/cozeloop/go.mod
+++ b/callbacks/cozeloop/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/coze-dev/cozeloop-go v0.1.20
 	github.com/coze-dev/cozeloop-go/spec v0.1.8
 	github.com/smartystreets/goconvey v1.8.1

--- a/callbacks/cozeloop/go.sum
+++ b/callbacks/cozeloop/go.sum
@@ -22,8 +22,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/coze-dev/cozeloop-go v0.1.20 h1:RO/o5cm8Nu71hG+7yoveA53oY9Q24u7NJBYZ9KBEDIo=
 github.com/coze-dev/cozeloop-go v0.1.20/go.mod h1:lM7cmUEZlnAlQYdwfk4Li0SC3RdZ++QMHX75nvKceSc=
 github.com/coze-dev/cozeloop-go/spec v0.1.8 h1:hFVBj/C1B6mUNGH/q52kO2n1pXuTomG578RbKlfYLGk=

--- a/components/model/agenticark/go.mod
+++ b/components/model/agenticark/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -23,8 +23,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticclaude/go.mod
+++ b/components/model/agenticclaude/go.mod
@@ -7,8 +7,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-alpha.25
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
+	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 )
 
@@ -33,6 +34,7 @@ require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -40,7 +42,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/nikolalohinski/gonja v1.5.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f // indirect
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829 // indirect

--- a/components/model/agenticclaude/go.sum
+++ b/components/model/agenticclaude/go.sum
@@ -56,8 +56,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-alpha.25 h1:06Ndrs44GD5SDTkZvsrHsLDWuv0mU5hp0dd8k43N0Pw=
-github.com/cloudwego/eino v0.9.0-alpha.25/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -219,8 +219,6 @@ go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGX
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/arch v0.11.0 h1:KXV8WWKCXm6tRpLirl2szsO5j/oOODwZf4hATmGVNs4=
 golang.org/x/arch v0.11.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/components/model/agenticdeepseek/go.mod
+++ b/components/model/agenticdeepseek/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticdeepseek/go.sum
+++ b/components/model/agenticdeepseek/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticgemini/go.mod
+++ b/components/model/agenticgemini/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/genai v1.36.0

--- a/components/model/agenticgemini/go.sum
+++ b/components/model/agenticgemini/go.sum
@@ -28,8 +28,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticopenai/go.mod
+++ b/components/model/agenticopenai/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/openai/openai-go/v3 v3.35.0

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -26,8 +26,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticqwen/go.mod
+++ b/components/model/agenticqwen/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticqwen/go.sum
+++ b/components/model/agenticqwen/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/claude/go.mod
+++ b/components/model/claude/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.54
 	github.com/bytedance/mockey v1.2.13
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/components/model/claude/go.sum
+++ b/components/model/claude/go.sum
@@ -58,8 +58,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/libs/acl/openai/go.mod
+++ b/libs/acl/openai/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.3.0
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0-beta.1
+	github.com/cloudwego/eino v0.9.0
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/meguminnnnnnnnn/go-openai v0.1.2 // fork from github.com/sashabaranov/go-openai, temporary solution, switch to github.com/openai/openai-go in the future.
 	github.com/stretchr/testify v1.11.1

--- a/libs/acl/openai/go.sum
+++ b/libs/acl/openai/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0-beta.1 h1:VODgzmP+vGKNiSBKC49DscimsZejpDSM5iPqO8QM62U=
-github.com/cloudwego/eino v0.9.0-beta.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
+github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

| Dimension | Detail |
|-----------|--------|
| Problem | Sub-modules depend on pre-release versions of `github.com/cloudwego/eino` (v0.9.0-alpha.x and v0.9.0-beta.1) |
| Solution | Upgrade all 11 affected sub-modules to the stable `v0.9.0` release |
| Impact | Aligns all modules to the stable API surface; no behavioral changes |

## Key Insight

With `v0.9.0` now published as a stable release, pre-release dependencies should be bumped to avoid downstream consumers pulling in unstable transitive versions. This is a pure dependency version bump with no code changes.

## Changes

Updated `github.com/cloudwego/eino` to `v0.9.0` in the following modules:

- `libs/acl/openai` (from v0.9.0-beta.1)
- `components/model/claude` (from v0.9.0-beta.1)
- `components/model/agenticqwen` (from v0.9.0-beta.1)
- `components/model/agenticopenai` (from v0.9.0-beta.1)
- `components/model/agenticgemini` (from v0.9.0-beta.1)
- `components/model/agenticdeepseek` (from v0.9.0-beta.1)
- `components/model/agenticark` (from v0.9.0-beta.1)
- `components/model/agenticclaude` (from v0.9.0-alpha.25)
- `callbacks/cozeloop` (from v0.9.0-beta.1)
- `adk/backend/local` (from v0.9.0-alpha.5 pseudo-version)
- `adk/backend/agentkit` (from v0.9.0-alpha.5 pseudo-version)

## Testing

- All modules verified to build successfully (`go build ./...`)
- No code changes; only `go.mod` and `go.sum` updates

---

## 概要

| 维度 | 说明 |
|------|------|
| 问题 | 多个子模块依赖 `github.com/cloudwego/eino` 的预发布版本（v0.9.0-alpha.x / v0.9.0-beta.1） |
| 方案 | 将所有 11 个受影响子模块升级到稳定版 `v0.9.0` |
| 影响 | 统一至稳定 API 版本；无行为变更 |

## 核心观点

`v0.9.0` 已作为稳定版发布，预发布依赖应当升级以避免下游消费者传递性引入不稳定版本。本次变更仅涉及依赖版本号更新，无代码改动。

## 变更内容

将以下模块的 `github.com/cloudwego/eino` 依赖升级至 `v0.9.0`：

- `libs/acl/openai`（从 v0.9.0-beta.1）
- `components/model/claude`（从 v0.9.0-beta.1）
- `components/model/agenticqwen`（从 v0.9.0-beta.1）
- `components/model/agenticopenai`（从 v0.9.0-beta.1）
- `components/model/agenticgemini`（从 v0.9.0-beta.1）
- `components/model/agenticdeepseek`（从 v0.9.0-beta.1）
- `components/model/agenticark`（从 v0.9.0-beta.1）
- `components/model/agenticclaude`（从 v0.9.0-alpha.25）
- `callbacks/cozeloop`（从 v0.9.0-beta.1）
- `adk/backend/local`（从 v0.9.0-alpha.5 伪版本）
- `adk/backend/agentkit`（从 v0.9.0-alpha.5 伪版本）

## 测试

- 所有模块已验证构建成功（`go build ./...`）
- 仅 `go.mod` 和 `go.sum` 更新，无代码变更
