### PR TITLE
feat(agenticgemini): support server tools options

### DIFF
--- a/components/model/agenticgemini/README.md
+++ b/components/model/agenticgemini/README.md
@@ -121,28 +121,6 @@ type Config struct {
     // Optional. Used when you want structured output in JSON format
     ResponseJSONSchema *jsonschema.Schema
     
-    // EnableCodeExecution allows the model to use the server tool CodeExecution
-    // Optional.
-    EnableCodeExecution *genai.ToolCodeExecution
-    // EnableGoogleSearch allows the model to use the server tool GoogleSearch
-    // Optional.
-    EnableGoogleSearch *genai.GoogleSearch
-    // EnableGoogleSearchRetrieval allows the model to use the server tool GoogleSearchRetrieval
-    // Optional.
-    EnableGoogleSearchRetrieval *genai.GoogleSearchRetrieval
-    // EnableComputerUse allows the model to use the server tool ComputerUse
-    // Optional.
-    EnableComputerUse *genai.ComputerUse
-    // EnableURLContext allows the model to use the server tool URLContext
-    // Optional.
-    EnableURLContext *genai.URLContext
-    // EnableFileSearch allows the model to use the server tool FileSearch
-    // Optional.
-    EnableFileSearch *genai.FileSearch
-    // EnableGoogleMaps allows the model to use the server tool GoogleMaps
-    // Optional.
-    EnableGoogleMaps *genai.GoogleMaps
-    
     // SafetySettings configures content filtering for different harm categories
     // Controls the model's filtering behavior for potentially harmful content
     // Optional.

--- a/components/model/agenticgemini/README.zh_CN.md
+++ b/components/model/agenticgemini/README.zh_CN.md
@@ -121,28 +121,6 @@ type Config struct {
     // 可选。当需要 JSON 格式的结构化输出时使用
     ResponseJSONSchema *jsonschema.Schema
     
-    // EnableCodeExecution 允许模型使用服务端工具 CodeExecution
-    // 可选。
-    EnableCodeExecution *genai.ToolCodeExecution
-    // EnableGoogleSearch 允许模型使用服务端工具 GoogleSearch
-    // 可选。
-    EnableGoogleSearch *genai.GoogleSearch
-    // EnableGoogleSearchRetrieval 允许模型使用服务端工具 GoogleSearchRetrieval
-    // 可选。
-    EnableGoogleSearchRetrieval *genai.GoogleSearchRetrieval
-    // EnableComputerUse 允许模型使用服务端工具 ComputerUse
-    // 可选。
-    EnableComputerUse *genai.ComputerUse
-    // EnableURLContext 允许模型使用服务端工具 URLContext
-    // 可选。
-    EnableURLContext *genai.URLContext
-    // EnableFileSearch 允许模型使用服务端工具 FileSearch
-    // 可选。
-    EnableFileSearch *genai.FileSearch
-    // EnableGoogleMaps 允许模型使用服务端工具 GoogleMaps
-    // 可选。
-    EnableGoogleMaps *genai.GoogleMaps
-    
     // SafetySettings 配置不同危害类别的内容过滤
     // 控制模型对潜在有害内容的过滤行为
     // 可选。

--- a/components/model/agenticgemini/conv.go
+++ b/components/model/agenticgemini/conv.go
@@ -757,41 +757,11 @@ func (g *Gemini) genInputAndConf(input []*schema.AgenticMessage, opts ...model.O
 		copy(t.FunctionDeclarations, tools)
 		m.Tools = append(m.Tools, t)
 	}
-	if g.enableCodeExecution != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			CodeExecution: g.enableCodeExecution,
-		})
+	serverTools, err := toServerTools(geminiOptions.ServerTools)
+	if err != nil {
+		return "", nil, nil, nil, err
 	}
-	if g.enableGoogleSearch != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			GoogleSearch: g.enableGoogleSearch,
-		})
-	}
-	if g.enableGoogleSearchRetrieval != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			GoogleSearchRetrieval: g.enableGoogleSearchRetrieval,
-		})
-	}
-	if g.enableComputerUse != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			ComputerUse: g.enableComputerUse,
-		})
-	}
-	if g.enableURLContext != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			URLContext: g.enableURLContext,
-		})
-	}
-	if g.enableFileSearch != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			FileSearch: g.enableFileSearch,
-		})
-	}
-	if g.enableGoogleMaps != nil {
-		m.Tools = append(m.Tools, &genai.Tool{
-			GoogleMaps: g.enableGoogleMaps,
-		})
-	}
+	m.Tools = append(m.Tools, serverTools...)
 
 	m.MediaResolution = g.mediaResolution
 

--- a/components/model/agenticgemini/examples/server_tool/server_tool.go
+++ b/components/model/agenticgemini/examples/server_tool/server_tool.go
@@ -79,13 +79,13 @@ func streamAndConcat(stream *schema.StreamReader[*schema.AgenticMessage]) (*sche
 // responses with source citations.
 func runGoogleSearchExample(ctx context.Context, client *genai.Client, modelName string) {
 	cm, err := agenticgemini.NewAgenticModel(ctx, &agenticgemini.Config{
-		Client:             client,
-		Model:              modelName,
-		EnableGoogleSearch: &genai.GoogleSearch{},
+		Client: client,
+		Model:  modelName,
 	})
 	if err != nil {
 		log.Fatalf("NewAgenticModel with GoogleSearch failed, err=%v", err)
 	}
+	serverTools := []*agenticgemini.ServerToolConfig{{GoogleSearch: &genai.GoogleSearch{}}}
 
 	// First turn: Ask about AI news
 	fmt.Println("\n--- First Turn ---")
@@ -93,7 +93,7 @@ func runGoogleSearchExample(ctx context.Context, client *genai.Client, modelName
 
 	stream, err := cm.Stream(ctx, []*schema.AgenticMessage{
 		schema.UserAgenticMessage("Use GoogleSearch and tell me what are the latest news about AI developments today?"),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}
@@ -122,7 +122,7 @@ func runGoogleSearchExample(ctx context.Context, client *genai.Client, modelName
 		schema.UserAgenticMessage("Use GoogleSearch and tell me what are the latest news about AI developments today?"),
 		firstResp,
 		schema.UserAgenticMessage("Can you give me more details about the most significant one? Search for more information if needed."),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}
@@ -153,7 +153,7 @@ func runGoogleSearchExample(ctx context.Context, client *genai.Client, modelName
 		schema.UserAgenticMessage("Can you give me more details about the most significant one? Search for more information if needed."),
 		secondResp,
 		schema.UserAgenticMessage("Please summarize all the key points we discussed."),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}
@@ -170,13 +170,13 @@ func runGoogleSearchExample(ctx context.Context, client *genai.Client, modelName
 // to solve problems and iterate on solutions.
 func runCodeExecutionExample(ctx context.Context, client *genai.Client, modelName string) {
 	cm, err := agenticgemini.NewAgenticModel(ctx, &agenticgemini.Config{
-		Client:              client,
-		Model:               modelName,
-		EnableCodeExecution: &genai.ToolCodeExecution{},
+		Client: client,
+		Model:  modelName,
 	})
 	if err != nil {
 		log.Fatalf("NewAgenticModel with CodeExecution failed, err=%v", err)
 	}
+	serverTools := []*agenticgemini.ServerToolConfig{{CodeExecution: &genai.ToolCodeExecution{}}}
 
 	// First turn: Calculate factorial and Fibonacci
 	fmt.Println("\n--- First Turn ---")
@@ -184,7 +184,7 @@ func runCodeExecutionExample(ctx context.Context, client *genai.Client, modelNam
 
 	stream, err := cm.Stream(ctx, []*schema.AgenticMessage{
 		schema.UserAgenticMessage("Calculate the factorial of 10 using Python code, and also generate the first 20 Fibonacci numbers."),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}
@@ -203,7 +203,7 @@ func runCodeExecutionExample(ctx context.Context, client *genai.Client, modelNam
 		schema.UserAgenticMessage("Calculate the factorial of 10 using Python code, and also generate the first 20 Fibonacci numbers."),
 		firstResp,
 		schema.UserAgenticMessage("Can you optimize the Fibonacci function using memoization and compare the performance with the previous implementation? Generate Fibonacci for n=30 and time both approaches."),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}
@@ -224,7 +224,7 @@ func runCodeExecutionExample(ctx context.Context, client *genai.Client, modelNam
 		schema.UserAgenticMessage("Can you optimize the Fibonacci function using memoization and compare the performance with the previous implementation? Generate Fibonacci for n=30 and time both approaches."),
 		secondResp,
 		schema.UserAgenticMessage("Now create a simple visualization showing the exponential growth of Fibonacci numbers. Use matplotlib to plot the first 20 Fibonacci numbers."),
-	})
+	}, agenticgemini.WithServerTools(serverTools))
 	if err != nil {
 		log.Fatalf("Stream error: %v", err)
 	}

--- a/components/model/agenticgemini/model.go
+++ b/components/model/agenticgemini/model.go
@@ -66,28 +66,6 @@ type Config struct {
 	// Optional. Used when you want structured output in JSON format
 	ResponseJSONSchema *jsonschema.Schema
 
-	// EnableCodeExecution allows the model to use the server tool CodeExecution
-	// Optional.
-	EnableCodeExecution *genai.ToolCodeExecution
-	// EnableGoogleSearch allows the model to use the server tool GoogleSearch
-	// Optional.
-	EnableGoogleSearch *genai.GoogleSearch
-	// EnableGoogleSearchRetrieval allows the model to use the server tool GoogleSearchRetrieval
-	// Optional.
-	EnableGoogleSearchRetrieval *genai.GoogleSearchRetrieval
-	// EnableComputerUse allows the model to use the server tool ComputerUse
-	// Optional.
-	EnableComputerUse *genai.ComputerUse
-	// EnableURLContext allows the model to use the server tool URLContext
-	// Optional.
-	EnableURLContext *genai.URLContext
-	// EnableFileSearch allows the model to use the server tool FileSearch
-	// Optional.
-	EnableFileSearch *genai.FileSearch
-	// EnableGoogleMaps allows the model to use the server tool GoogleMaps
-	// Optional.
-	EnableGoogleMaps *genai.GoogleMaps
-
 	// SafetySettings configures content filtering for different harm categories
 	// Controls the model's filtering behavior for potentially harmful content
 	// Optional.
@@ -123,60 +101,96 @@ const (
 	ResponseModalityAudio ResponseModality = "AUDIO"
 )
 
+type ServerToolConfig struct {
+	CodeExecution         *genai.ToolCodeExecution
+	GoogleSearch          *genai.GoogleSearch
+	GoogleSearchRetrieval *genai.GoogleSearchRetrieval
+	URLContext            *genai.URLContext
+	FileSearch            *genai.FileSearch
+	GoogleMaps            *genai.GoogleMaps
+}
+
 // NewAgenticModel creates a new Gemini agentic model instance
 func NewAgenticModel(_ context.Context, cfg *Config) (*Gemini, error) {
 	return &Gemini{
 		cli: cfg.Client,
 
-		model:                       cfg.Model,
-		maxTokens:                   cfg.MaxTokens,
-		temperature:                 cfg.Temperature,
-		topP:                        cfg.TopP,
-		topK:                        cfg.TopK,
-		responseJSONSchema:          cfg.ResponseJSONSchema,
-		enableCodeExecution:         cfg.EnableCodeExecution,
-		enableGoogleSearch:          cfg.EnableGoogleSearch,
-		enableGoogleSearchRetrieval: cfg.EnableGoogleSearchRetrieval,
-		enableComputerUse:           cfg.EnableComputerUse,
-		enableURLContext:            cfg.EnableURLContext,
-		enableFileSearch:            cfg.EnableFileSearch,
-		enableGoogleMaps:            cfg.EnableGoogleMaps,
-		safetySettings:              cfg.SafetySettings,
-		thinkingConfig:              cfg.ThinkingConfig,
-		imageConfig:                 cfg.ImageConfig,
-		responseModalities:          cfg.ResponseModalities,
-		mediaResolution:             cfg.MediaResolution,
-		cacheTTL:                    cfg.CacheTTL,
-		cacheExpireTime:             cfg.CacheExpireTime,
+		model:              cfg.Model,
+		maxTokens:          cfg.MaxTokens,
+		temperature:        cfg.Temperature,
+		topP:               cfg.TopP,
+		topK:               cfg.TopK,
+		responseJSONSchema: cfg.ResponseJSONSchema,
+		safetySettings:     cfg.SafetySettings,
+		thinkingConfig:     cfg.ThinkingConfig,
+		imageConfig:        cfg.ImageConfig,
+		responseModalities: cfg.ResponseModalities,
+		mediaResolution:    cfg.MediaResolution,
+		cacheTTL:           cfg.CacheTTL,
+		cacheExpireTime:    cfg.CacheExpireTime,
 	}, nil
 }
 
 type Gemini struct {
 	cli *genai.Client
 
-	model                       string
-	maxTokens                   *int
-	topP                        *float32
-	temperature                 *float32
-	topK                        *int32
-	responseJSONSchema          *jsonschema.Schema
-	tools                       []*genai.FunctionDeclaration
-	origTools                   []*schema.ToolInfo
-	toolChoice                  *schema.AgenticToolChoice
-	enableCodeExecution         *genai.ToolCodeExecution
-	enableGoogleSearch          *genai.GoogleSearch
-	enableGoogleSearchRetrieval *genai.GoogleSearchRetrieval
-	enableComputerUse           *genai.ComputerUse
-	enableURLContext            *genai.URLContext
-	enableFileSearch            *genai.FileSearch
-	enableGoogleMaps            *genai.GoogleMaps
-	safetySettings              []*genai.SafetySetting
-	thinkingConfig              *genai.ThinkingConfig
-	imageConfig                 *genai.ImageConfig
-	responseModalities          []ResponseModality
-	mediaResolution             genai.MediaResolution
-	cacheTTL                    time.Duration
-	cacheExpireTime             time.Time
+	model              string
+	maxTokens          *int
+	topP               *float32
+	temperature        *float32
+	topK               *int32
+	responseJSONSchema *jsonschema.Schema
+	tools              []*genai.FunctionDeclaration
+	origTools          []*schema.ToolInfo
+	toolChoice         *schema.AgenticToolChoice
+	safetySettings     []*genai.SafetySetting
+	thinkingConfig     *genai.ThinkingConfig
+	imageConfig        *genai.ImageConfig
+	responseModalities []ResponseModality
+	mediaResolution    genai.MediaResolution
+	cacheTTL           time.Duration
+	cacheExpireTime    time.Time
+}
+
+func toServerTools(serverTools []*ServerToolConfig) ([]*genai.Tool, error) {
+	tools := make([]*genai.Tool, len(serverTools))
+
+	for i := range serverTools {
+		ti := serverTools[i]
+		if ti == nil {
+			return nil, fmt.Errorf("unknown server tool type")
+		}
+		switch {
+		case ti.CodeExecution != nil:
+			tools[i] = &genai.Tool{
+				CodeExecution: ti.CodeExecution,
+			}
+		case ti.GoogleSearch != nil:
+			tools[i] = &genai.Tool{
+				GoogleSearch: ti.GoogleSearch,
+			}
+		case ti.GoogleSearchRetrieval != nil:
+			tools[i] = &genai.Tool{
+				GoogleSearchRetrieval: ti.GoogleSearchRetrieval,
+			}
+		case ti.URLContext != nil:
+			tools[i] = &genai.Tool{
+				URLContext: ti.URLContext,
+			}
+		case ti.FileSearch != nil:
+			tools[i] = &genai.Tool{
+				FileSearch: ti.FileSearch,
+			}
+		case ti.GoogleMaps != nil:
+			tools[i] = &genai.Tool{
+				GoogleMaps: ti.GoogleMaps,
+			}
+		default:
+			return nil, fmt.Errorf("unknown server tool type")
+		}
+	}
+
+	return tools, nil
 }
 
 // CreatePrefixCache assembles inputs the same as Generate/Stream and writes

--- a/components/model/agenticgemini/model_test.go
+++ b/components/model/agenticgemini/model_test.go
@@ -33,13 +33,12 @@ import (
 
 func TestNewAgenticModel(t *testing.T) {
 	config := &Config{
-		Client:              &genai.Client{},
-		Model:               "gemini-pro",
-		MaxTokens:           ptrOf(100),
-		Temperature:         ptrOf(float32(0.7)),
-		TopP:                ptrOf(float32(0.9)),
-		TopK:                ptrOf(int32(40)),
-		EnableCodeExecution: &genai.ToolCodeExecution{},
+		Client:      &genai.Client{},
+		Model:       "gemini-pro",
+		MaxTokens:   ptrOf(100),
+		Temperature: ptrOf(float32(0.7)),
+		TopP:        ptrOf(float32(0.9)),
+		TopK:        ptrOf(int32(40)),
 		SafetySettings: []*genai.SafetySetting{
 			{
 				Category:  genai.HarmCategoryHarassment,
@@ -48,7 +47,7 @@ func TestNewAgenticModel(t *testing.T) {
 		},
 		ResponseModalities: []ResponseModality{ResponseModalityText, ResponseModalityImage},
 		ImageConfig:        &genai.ImageConfig{AspectRatio: "16:9", ImageSize: "1K"},
-		CacheTTL: time.Hour,
+		CacheTTL:           time.Hour,
 	}
 	model, err := NewAgenticModel(context.Background(), config)
 	assert.NoError(t, err)
@@ -58,7 +57,6 @@ func TestNewAgenticModel(t *testing.T) {
 	assert.Equal(t, float32(0.7), *model.temperature)
 	assert.Equal(t, float32(0.9), *model.topP)
 	assert.Equal(t, int32(40), *model.topK)
-	assert.NotNil(t, model.enableCodeExecution)
 	assert.Len(t, model.safetySettings, 1)
 	assert.Len(t, model.responseModalities, 2)
 	assert.Equal(t, time.Hour, model.cacheTTL)
@@ -134,6 +132,13 @@ func TestGemini_GenInputAndConf(t *testing.T) {
 	_, _, genaiConf, _, err = g.genInputAndConf(input, WithImageConfig(overrideImageConfig))
 	assert.NoError(t, err)
 	assert.Equal(t, overrideImageConfig, genaiConf.ImageConfig)
+
+	_, _, genaiConf, _, err = g.genInputAndConf(input,
+		WithServerTools([]*ServerToolConfig{{GoogleSearch: &genai.GoogleSearch{}}}),
+	)
+	assert.NoError(t, err)
+	assert.Len(t, genaiConf.Tools, 1)
+	assert.NotNil(t, genaiConf.Tools[0].GoogleSearch)
 }
 
 func TestGemini_Generate_Success(t *testing.T) {

--- a/components/model/agenticgemini/option.go
+++ b/components/model/agenticgemini/option.go
@@ -28,6 +28,7 @@ type options struct {
 	ThinkingConfig     *genai.ThinkingConfig
 	ResponseModalities []ResponseModality
 	ImageConfig        *genai.ImageConfig
+	ServerTools        []*ServerToolConfig
 
 	CachedContentName string
 }
@@ -62,6 +63,13 @@ func WithResponseModalities(m []ResponseModality) model.Option {
 func WithImageConfig(cfg *genai.ImageConfig) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.ImageConfig = cfg
+	})
+}
+
+// WithServerTools sets Gemini server-side tools for this request.
+func WithServerTools(tools []*ServerToolConfig) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.ServerTools = tools
 	})
 }
 

--- a/components/model/agenticgemini/option_test.go
+++ b/components/model/agenticgemini/option_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestSpecificOptions(t *testing.T) {
+	tools := []*ServerToolConfig{{GoogleSearch: &genai.GoogleSearch{}}}
+
 	o := model.GetImplSpecificOptions[options](nil,
 		WithTopK(2),
 		WithResponseJSONSchema(&jsonschema.Schema{}),
@@ -33,6 +35,7 @@ func TestSpecificOptions(t *testing.T) {
 		WithThinkingConfig(&genai.ThinkingConfig{}),
 		WithResponseModalities([]ResponseModality{ResponseModalityText}),
 		WithImageConfig(&genai.ImageConfig{AspectRatio: "16:9"}),
+		WithServerTools(tools),
 	)
 
 	assert.Equal(t, int32(2), *o.TopK)
@@ -41,4 +44,5 @@ func TestSpecificOptions(t *testing.T) {
 	assert.NotNil(t, o.ThinkingConfig)
 	assert.Len(t, o.ResponseModalities, 1)
 	assert.Equal(t, "16:9", o.ImageConfig.AspectRatio)
+	assert.Equal(t, tools, o.ServerTools)
 }


### PR DESCRIPTION
## Summary
- Add ServerToolConfig and WithServerTools for request-level Gemini server tools, matching the agenticopenai option pattern.
- Keep server tools out of Config so tools are passed as call inputs.
- Exclude ComputerUse from the supported server tool config.
- Update agenticgemini server-tool examples, README docs, and tests.

## Tests
- go test -count=1 ./... (components/model/agenticgemini)
