### PR TITLE
chore: bump cloudwego/eino dependency from v0.9.0 to v0.9.1

### DIFF
--- a/adk/backend/agentkit/go.mod
+++ b/adk/backend/agentkit/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.12
 
 require (
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/gen2brain/go-fitz v1.24.15
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f
 	github.com/stretchr/testify v1.11.1

--- a/adk/backend/agentkit/go.sum
+++ b/adk/backend/agentkit/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/adk/backend/local/go.mod
+++ b/adk/backend/local/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/gen2brain/go-fitz v1.24.15
 	github.com/stretchr/testify v1.11.1
 )

--- a/adk/backend/local/go.sum
+++ b/adk/backend/local/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/callbacks/cozeloop/go.mod
+++ b/callbacks/cozeloop/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/coze-dev/cozeloop-go v0.1.20
 	github.com/coze-dev/cozeloop-go/spec v0.1.8
 	github.com/smartystreets/goconvey v1.8.1

--- a/callbacks/cozeloop/go.sum
+++ b/callbacks/cozeloop/go.sum
@@ -22,8 +22,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/coze-dev/cozeloop-go v0.1.20 h1:RO/o5cm8Nu71hG+7yoveA53oY9Q24u7NJBYZ9KBEDIo=
 github.com/coze-dev/cozeloop-go v0.1.20/go.mod h1:lM7cmUEZlnAlQYdwfk4Li0SC3RdZ++QMHX75nvKceSc=
 github.com/coze-dev/cozeloop-go/spec v0.1.8 h1:hFVBj/C1B6mUNGH/q52kO2n1pXuTomG578RbKlfYLGk=

--- a/components/model/agenticark/go.mod
+++ b/components/model/agenticark/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -23,8 +23,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticclaude/go.mod
+++ b/components/model/agenticclaude/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/components/model/agenticclaude/go.sum
+++ b/components/model/agenticclaude/go.sum
@@ -56,8 +56,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticdeepseek/go.mod
+++ b/components/model/agenticdeepseek/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticdeepseek/go.mod
+++ b/components/model/agenticdeepseek/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/cloudwego/eino v0.9.1
-	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
+	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6
 	github.com/smartystreets/goconvey v1.8.1
 )
 
@@ -26,7 +26,7 @@ require (
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/meguminnnnnnnnn/go-openai v0.1.1 // indirect
+	github.com/meguminnnnnnnnn/go-openai v0.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nikolalohinski/gonja v1.5.3 // indirect

--- a/components/model/agenticdeepseek/go.sum
+++ b/components/model/agenticdeepseek/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticdeepseek/go.sum
+++ b/components/model/agenticdeepseek/go.sum
@@ -20,8 +20,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
 github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6 h1:ES/xufN5eqJ3h+9tw/tq6F8kkgnAxBAHVUB6nqKsIDU=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6/go.mod h1:5Xj74dGrfHo1z7I07Fzp3SlTF7Bt4tss3A2FSt8SqQ4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -63,8 +63,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
-github.com/meguminnnnnnnnn/go-openai v0.1.1 h1:u/IMMgrj/d617Dh/8BKAwlcstD74ynOJzCtVl+y8xAs=
-github.com/meguminnnnnnnnn/go-openai v0.1.1/go.mod h1:qs96ysDmxhE4BZoU45I43zcyfnaYxU3X+aRzLko/htY=
+github.com/meguminnnnnnnnn/go-openai v0.1.2 h1:iXombGGjqjBrmE9WaSidUhhi3YQhf42QTHvHLMkgvCA=
+github.com/meguminnnnnnnnn/go-openai v0.1.2/go.mod h1:qs96ysDmxhE4BZoU45I43zcyfnaYxU3X+aRzLko/htY=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/components/model/agenticgemini/go.mod
+++ b/components/model/agenticgemini/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0

--- a/components/model/agenticgemini/go.sum
+++ b/components/model/agenticgemini/go.sum
@@ -28,8 +28,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/components/model/agenticopenai/go.mod
+++ b/components/model/agenticopenai/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/components/model/agenticopenai/go.mod
+++ b/components/model/agenticopenai/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
 	github.com/cloudwego/eino v0.9.1
-	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05
+	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/openai/openai-go/v3 v3.35.0

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -26,8 +26,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05 h1:4Wh4mEENsDnG8aRfLZf/5c9/eE6w81akIv/N3nyCglw=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05/go.mod h1:SQNCRCXLu/xNSUA9rwYKgAHUI7MNiQ7Yng0mO3AImzY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -28,8 +28,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
 github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05 h1:4Wh4mEENsDnG8aRfLZf/5c9/eE6w81akIv/N3nyCglw=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260525035716-1372ee451d05/go.mod h1:SQNCRCXLu/xNSUA9rwYKgAHUI7MNiQ7Yng0mO3AImzY=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6 h1:ES/xufN5eqJ3h+9tw/tq6F8kkgnAxBAHVUB6nqKsIDU=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6/go.mod h1:5Xj74dGrfHo1z7I07Fzp3SlTF7Bt4tss3A2FSt8SqQ4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticqwen/go.mod
+++ b/components/model/agenticqwen/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/cloudwego/eino v0.9.1
-	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
+	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6
 	github.com/smartystreets/goconvey v1.8.1
 )
 

--- a/components/model/agenticqwen/go.mod
+++ b/components/model/agenticqwen/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bytedance/mockey v1.4.6
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26
 	github.com/smartystreets/goconvey v1.8.1
 )

--- a/components/model/agenticqwen/go.sum
+++ b/components/model/agenticqwen/go.sum
@@ -20,8 +20,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
 github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
-github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6 h1:ES/xufN5eqJ3h+9tw/tq6F8kkgnAxBAHVUB6nqKsIDU=
+github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6/go.mod h1:5Xj74dGrfHo1z7I07Fzp3SlTF7Bt4tss3A2FSt8SqQ4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticqwen/go.sum
+++ b/components/model/agenticqwen/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26 h1:lmDmKI2c1BI2K2RhyAPrD1oc8m2YzFyuCu8P16V5TPQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.15-0.20260511062004-19cf9e449a26/go.mod h1:3kLBa3I6mxi7fkaMDMv+sA9aJD0cU/RxjHGKfnfatqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/claude/go.mod
+++ b/components/model/claude/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.54
 	github.com/bytedance/mockey v1.2.13
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/stretchr/testify v1.10.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8

--- a/components/model/claude/go.sum
+++ b/components/model/claude/go.sum
@@ -58,8 +58,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/libs/acl/openai/go.mod
+++ b/libs/acl/openai/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.3.0
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.0
+	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/meguminnnnnnnnn/go-openai v0.1.2 // fork from github.com/sashabaranov/go-openai, temporary solution, switch to github.com/openai/openai-go in the future.
 	github.com/stretchr/testify v1.11.1

--- a/libs/acl/openai/go.sum
+++ b/libs/acl/openai/go.sum
@@ -18,8 +18,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.0 h1:no5bko5r21pM7oJv9BQMux5ncfXIy0Dkd9tjIF5bC0A=
-github.com/cloudwego/eino v0.9.0/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
+github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

Bump `github.com/cloudwego/eino` from v0.9.0 to v0.9.1 across all 11 sub-modules that depend on it.

## Affected Modules

- `libs/acl/openai`
- `components/model/claude`
- `components/model/agenticqwen`
- `components/model/agenticopenai`
- `components/model/agenticgemini`
- `components/model/agenticdeepseek`
- `components/model/agenticclaude`
- `components/model/agenticark`
- `callbacks/cozeloop`
- `adk/backend/local`
- `adk/backend/agentkit`

## Changes

- Updated `go.mod` require directives from `v0.9.0` to `v0.9.1`
- Ran `go mod tidy` to update `go.sum` files
