### PR TITLE
fix(claude): report full token usage for streaming responses

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -1241,21 +1241,40 @@ func populateContentBlockBreakPoint(block anthropic.ContentBlockParamUnion, cach
 	}
 }
 
-func convOutputMessage(resp *anthropic.Message) (*schema.Message, error) {
-	promptTokens := int(resp.Usage.InputTokens + resp.Usage.CacheReadInputTokens + resp.Usage.CacheCreationInputTokens)
+func toTokenUsage(u anthropic.Usage) *schema.TokenUsage {
+	promptTokens := int(u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens)
+	completionTokens := int(u.OutputTokens)
 
+	return &schema.TokenUsage{
+		PromptTokens: promptTokens,
+		PromptTokenDetails: schema.PromptTokenDetails{
+			CachedTokens: int(u.CacheReadInputTokens),
+		},
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+}
+
+func toDeltaTokenUsage(u anthropic.MessageDeltaUsage) *schema.TokenUsage {
+	promptTokens := int(u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens)
+	completionTokens := int(u.OutputTokens)
+
+	return &schema.TokenUsage{
+		PromptTokens: promptTokens,
+		PromptTokenDetails: schema.PromptTokenDetails{
+			CachedTokens: int(u.CacheReadInputTokens),
+		},
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+}
+
+func convOutputMessage(resp *anthropic.Message) (*schema.Message, error) {
 	message := &schema.Message{
 		Role: schema.Assistant,
 		ResponseMeta: &schema.ResponseMeta{
 			FinishReason: string(resp.StopReason),
-			Usage: &schema.TokenUsage{
-				PromptTokens: promptTokens,
-				PromptTokenDetails: schema.PromptTokenDetails{
-					CachedTokens: int(resp.Usage.CacheReadInputTokens),
-				},
-				CompletionTokens: int(resp.Usage.OutputTokens),
-				TotalTokens:      promptTokens + int(resp.Usage.OutputTokens),
-			},
+			Usage:        toTokenUsage(resp.Usage),
 		},
 	}
 
@@ -1358,9 +1377,7 @@ func convStreamEvent(event anthropic.MessageStreamEventUnion, streamCtx *streamC
 	case anthropic.MessageDeltaEvent:
 		result.ResponseMeta = &schema.ResponseMeta{
 			FinishReason: string(e.Delta.StopReason),
-			Usage: &schema.TokenUsage{
-				CompletionTokens: int(e.Usage.OutputTokens),
-			},
+			Usage:        toDeltaTokenUsage(e.Usage),
 		}
 		return result, nil
 


### PR DESCRIPTION
## Summary

The Claude model component previously reported only `CompletionTokens` for streaming `MessageDelta` events, omitting prompt, cached, and total token counts. This made streaming usage statistics inconsistent with non-streaming responses and undercounted billable input tokens. This change reports the full token usage for streaming responses.

## Key Changes

1. Extracted token usage conversion into two shared helpers, `toTokenUsage` (for `anthropic.Usage`) and `toDeltaTokenUsage` (for `anthropic.MessageDeltaUsage`), keeping non-streaming and streaming usage reporting consistent.
2. Streaming `MessageDelta` events now populate `PromptTokens`, `PromptTokenDetails.CachedTokens`, and `TotalTokens` in addition to `CompletionTokens`.
