### PR TITLE
fix(claude): merge consecutive tool messages into single UserMessage

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -652,7 +652,37 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 	msgParams := make([]anthropic.MessageParam, 0, len(msgs))
 	hasSetMsgBreakPoint := false
 
-	for _, msg := range msgs {
+	for i := 0; i < len(msgs); {
+		msg := msgs[i]
+
+		// Merge consecutive tool messages into a single UserMessage.
+		// Anthropic API requires all tool_result blocks for a given
+		// assistant turn to be in the same user message.
+		if msg.Role == schema.Tool {
+			// Collect all consecutive tool messages
+			toolMsgs := []*schema.Message{msg}
+			j := i + 1
+			for j < len(msgs) && msgs[j].Role == schema.Tool {
+				toolMsgs = append(toolMsgs, msgs[j])
+				j++
+			}
+
+			// Convert each and merge content blocks into one UserMessage
+			blocks := make([]anthropic.ContentBlockParamUnion, 0, len(toolMsgs))
+			for _, tm := range toolMsgs {
+				mp, err := convSchemaMessage(tm)
+				if err != nil {
+					return fmt.Errorf("convert schema message fail: %w", err)
+				}
+				blocks = append(blocks, mp.Content...)
+			}
+
+			msgParam := anthropic.NewUserMessage(blocks...)
+			msgParams = append(msgParams, msgParam)
+			i = j
+			continue
+		}
+
 		msgParam, err := convSchemaMessage(msg)
 		if err != nil {
 			return fmt.Errorf("convert schema message fail: %w", err)
@@ -665,6 +695,7 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 		}
 
 		msgParams = append(msgParams, msgParam)
+		i++
 	}
 
 	if !hasSetMsgBreakPoint && specOptions.AutoCacheControl != nil {

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1054,3 +1054,111 @@ func TestToolSearchEventsRoundTrip(t *testing.T) {
 		assert.True(t, hasErrorResult, "should have error result block")
 	})
 }
+
+// TestPopulateInputMergeConsecutiveTools verifies that consecutive
+// Tool messages are merged into a single Anthropic UserMessage.
+// Anthropic API requires all tool_result blocks for the same assistant
+// turn to be in the same user message.
+func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
+	clearAnthropicAuthEnv(t)
+	ctx := context.Background()
+
+	cm, err := NewChatModel(ctx, &Config{
+		APIKey: "test-key",
+		Model:  "claude-3-opus-20240229",
+	})
+	assert.NoError(t, err)
+
+	toolMsg := func(id, name, content string) *schema.Message {
+		return &schema.Message{
+			Role:       schema.Tool,
+			Content:    content,
+			ToolCallID: id,
+			ToolName:   name,
+		}
+	}
+
+	t.Run("single tool message unchanged", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("hello"),
+			toolMsg("call_1", "tool1", "result1"),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, params.Messages, 2)
+		// The tool message becomes a UserMessage with one tool_result block
+		assert.Len(t, params.Messages[1].Content, 1)
+		assert.NotNil(t, params.Messages[1].Content[0].OfToolResult)
+	})
+
+	t.Run("two consecutive tool messages merged", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("hello"),
+			toolMsg("call_1", "tool1", "result1"),
+			toolMsg("call_2", "tool2", "result2"),
+		})
+		assert.NoError(t, err)
+		// User + merged tool = 2 messages
+		assert.Len(t, params.Messages, 2)
+		// Merged message has 2 content blocks
+		assert.Len(t, params.Messages[1].Content, 2)
+	})
+
+	t.Run("three consecutive tools merged", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("hello"),
+			toolMsg("call_1", "t1", "r1"),
+			toolMsg("call_2", "t2", "r2"),
+			toolMsg("call_3", "t3", "r3"),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, params.Messages, 2)
+		assert.Len(t, params.Messages[1].Content, 3)
+	})
+
+	t.Run("tool messages separated by non-tool are not merged", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("hello"),
+			toolMsg("call_1", "t1", "r1"),
+			schema.AssistantMessage("ok", nil),
+			toolMsg("call_2", "t2", "r2"),
+		})
+		assert.NoError(t, err)
+		// User + Tool(r1) + Assistant + Tool(r2) = 4 messages
+		assert.Len(t, params.Messages, 4)
+		assert.Len(t, params.Messages[1].Content, 1)
+		assert.Len(t, params.Messages[3].Content, 1)
+	})
+
+	t.Run("no tool messages unchanged", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("hello"),
+			schema.AssistantMessage("hi", nil),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, params.Messages, 2)
+	})
+
+	t.Run("real world pattern: user assistant(tool_calls) tool tool", func(t *testing.T) {
+		params, err := cm.genMessageNewParams([]*schema.Message{
+			schema.UserMessage("what's the weather in Paris and London?"),
+			{
+				Role:    schema.Assistant,
+				Content: "",
+				ToolCalls: []schema.ToolCall{
+					{ID: "call_1", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"city":"Paris"}`}},
+					{ID: "call_2", Function: schema.FunctionCall{Name: "get_weather", Arguments: `{"city":"London"}`}},
+				},
+			},
+			toolMsg("call_1", "get_weather", "Paris: sunny, 22°C"),
+			toolMsg("call_2", "get_weather", "London: cloudy, 15°C"),
+		})
+		assert.NoError(t, err)
+		// User + Assistant + merged_tool = 3 messages
+		assert.Len(t, params.Messages, 3)
+		// Assistant has tool_use blocks
+		assert.Equal(t, anthropic.MessageParamRoleAssistant, params.Messages[1].Role)
+		// Merged tool message has 2 tool_result blocks
+		assert.Equal(t, anthropic.MessageParamRoleUser, params.Messages[2].Role)
+		assert.Len(t, params.Messages[2].Content, 2)
+	})
+}


### PR DESCRIPTION
## Problem

When an assistant invokes multiple tools in a single turn, Eino produces consecutive `schema.Tool` messages. The current `populateInput` converts each one to a separate `UserMessage` via `convSchemaMessage`, but the Anthropic API requires all `tool_result` blocks for the same assistant turn to be delivered in a **single** user message.

This results in a 400 error from the Anthropic API when the agent makes parallel tool calls.

## Root Cause

The message loop in `populateInput` uses a simple `for _, msg := range msgs` loop that converts each message independently. For Tool-role messages, each becomes a separate Anthropic `UserMessage` — but consecutive user messages violate the Anthropic message structure requirement.

## Fix

Detect consecutive Tool-role messages in `populateInput`, collect them, convert each via `convSchemaMessage`, and merge all resulting content blocks into one `NewUserMessage`.

This is the same approach used to fix the equivalent issue for Gemini in #565.

## Changes

- `claude.go`: +32/−1 in `populateInput` to merge consecutive tool messages
- `claude_test.go`: +108 lines, 6 sub-tests covering:
  - Single tool message (no merge)
  - Two consecutive tools (merged into 1 message, 2 content blocks)
  - Three consecutive tools (merged into 1 message, 3 content blocks)
  - Tools separated by non-tool message (not merged)
  - No tool messages (passthrough)
  - Real-world multi-tool-call pattern