### PR TITLE
fix(claude): report cached tokens via PromptTokenDetails

### DIFF
--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -1197,7 +1197,7 @@ func toWebFetchDocumentBlockParam(document *WebFetchDocument) (anthropic.Documen
 }
 
 func toDeltaResponseMeta(delta anthropic.MessageDeltaEvent) *schema.AgenticResponseMeta {
-	promptTokens := int(delta.Usage.InputTokens + delta.Usage.CacheReadInputTokens + delta.Usage.CacheCreationInputTokens)
+	promptTokens := int(delta.Usage.InputTokens + delta.Usage.CacheCreationInputTokens)
 	completionTokens := int(delta.Usage.OutputTokens)
 
 	return &schema.AgenticResponseMeta{
@@ -1229,7 +1229,7 @@ func toClaudeStopDetails(details anthropic.RefusalStopDetails) *claude.StopDetai
 }
 
 func toTokenUsage(usage anthropic.Usage) *schema.TokenUsage {
-	promptTokens := int(usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens)
+	promptTokens := int(usage.InputTokens + usage.CacheCreationInputTokens)
 	completionTokens := int(usage.OutputTokens)
 	return &schema.TokenUsage{
 		PromptTokens: promptTokens,

--- a/components/model/agenticclaude/convertor_test.go
+++ b/components/model/agenticclaude/convertor_test.go
@@ -174,7 +174,7 @@ func TestToDeltaResponseMeta(t *testing.T) {
 	if meta == nil || meta.TokenUsage == nil || meta.ClaudeExtension == nil {
 		t.Fatalf("toDeltaResponseMeta() = %#v", meta)
 	}
-	if meta.TokenUsage.PromptTokens != 15 || meta.TokenUsage.CompletionTokens != 7 || meta.TokenUsage.TotalTokens != 22 {
+	if meta.TokenUsage.PromptTokens != 12 || meta.TokenUsage.CompletionTokens != 7 || meta.TokenUsage.TotalTokens != 19 {
 		t.Fatalf("token usage = %#v", meta.TokenUsage)
 	}
 	if meta.TokenUsage.PromptTokenDetails.CachedTokens != 3 {

--- a/components/model/agenticclaude/event_convertor_test.go
+++ b/components/model/agenticclaude/event_convertor_test.go
@@ -110,7 +110,7 @@ func TestToMessageStreamingChunk(t *testing.T) {
 		if chunk == nil || chunk.ResponseMeta == nil || chunk.ResponseMeta.TokenUsage == nil {
 			t.Fatalf("chunk = %#v", chunk)
 		}
-		if chunk.ResponseMeta.TokenUsage.TotalTokens != 9 {
+		if chunk.ResponseMeta.TokenUsage.TotalTokens != 8 {
 			t.Fatalf("token usage = %#v", chunk.ResponseMeta.TokenUsage)
 		}
 	})

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -1242,7 +1242,7 @@ func populateContentBlockBreakPoint(block anthropic.ContentBlockParamUnion, cach
 }
 
 func toTokenUsage(u anthropic.Usage) *schema.TokenUsage {
-	promptTokens := int(u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens)
+	promptTokens := int(u.InputTokens + u.CacheCreationInputTokens)
 	completionTokens := int(u.OutputTokens)
 
 	return &schema.TokenUsage{
@@ -1256,7 +1256,7 @@ func toTokenUsage(u anthropic.Usage) *schema.TokenUsage {
 }
 
 func toDeltaTokenUsage(u anthropic.MessageDeltaUsage) *schema.TokenUsage {
-	promptTokens := int(u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens)
+	promptTokens := int(u.InputTokens + u.CacheCreationInputTokens)
 	completionTokens := int(u.OutputTokens)
 
 	return &schema.TokenUsage{


### PR DESCRIPTION
For both claude and agenticclaude, count CacheReadInputTokens only in PromptTokenDetails.CachedTokens instead of double-counting them in PromptTokens, include cached/prompt tokens in stream delta usage, and update the affected unit tests.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
