### PR TITLE
fix(agentic): tolerate unknown stream variants instead of failing

### DIFF
--- a/components/model/agenticark/event_convertor.go
+++ b/components/model/agenticark/event_convertor.go
@@ -46,22 +46,6 @@ func receivedStreamResponse(streamReader *utils.ResponsesStreamReader,
 		sender.errHeader = fmt.Sprintf("failed to convert event %q", event.GetEventType())
 
 		switch ev := event.Event.(type) {
-		case *responses.Event_TextDone,
-			*responses.Event_ReasoningPart,
-			*responses.Event_ReasoningPartDone,
-			*responses.Event_ReasoningTextDone,
-			*responses.Event_FunctionCallArgumentsDone,
-			*responses.Event_ResponseMcpCallArgumentsDone,
-			*responses.Event_ResponseMcpApprovalRequest,
-			*responses.Event_ResponseDoubaoAppCallBlockAdded,
-			*responses.Event_ResponseDoubaoAppCallBlockDone,
-			*responses.Event_ResponseDoubaoAppCallOutputTextDone,
-			*responses.Event_ResponseDoubaoAppCallReasoningTextDone,
-			*responses.Event_ResponseDoubaoAppCallSearchInProgress,
-			*responses.Event_ResponseDoubaoAppCallReasoningSearchInProgress:
-			// Do nothing.
-			continue
-
 		case *responses.Event_Error:
 			meta := receiver.errorEventToResponseMeta(ev.Error)
 			sender.sendMeta(meta, nil)
@@ -255,7 +239,8 @@ func receivedStreamResponse(streamReader *utils.ResponsesStreamReader,
 			sender.sendBlock(block, nil)
 
 		default:
-			sw.Send(nil, fmt.Errorf("unknown event type: %T", ev))
+			// Unhandled event types are ignored rather than failing the stream.
+			continue
 		}
 	}
 }
@@ -278,7 +263,9 @@ func (s *callbackSender) sendMeta(meta *schema.AgenticResponseMeta, err error) {
 }
 
 func (s *callbackSender) sendBlock(block *schema.ContentBlock, err error) {
-	s.send(nil, block, err)
+	if block != nil || err != nil {
+		s.send(nil, block, err)
+	}
 }
 
 func (s *callbackSender) send(meta *schema.AgenticResponseMeta, block *schema.ContentBlock, err error) {
@@ -419,17 +406,9 @@ func (r *streamReceiver) itemAddedEventToContentBlock(ev *responses.ItemEvent) (
 		k := makeMCPListToolsItemAddedEventCacheKey(item.FunctionMcpListTools.GetId(), ev.OutputIndex)
 		r.ItemAddedEventCache[k] = item.FunctionMcpListTools
 
-	case *responses.OutputItem_OutputMessage,
-		*responses.OutputItem_FunctionWebSearch,
-		*responses.OutputItem_FunctionImageProcess,
-		*responses.OutputItem_FunctionDoubaoAppCall,
-		*responses.OutputItem_FunctionKnowledgeSearch,
-		*responses.OutputItem_FunctionMcpApprovalRequest:
-
-		// Do nothing.
-
 	default:
-		return nil, fmt.Errorf("unknown item type %T with 'output_item.added' event", item)
+		// Unknown item types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	return blocks, nil
@@ -463,10 +442,6 @@ func (r *streamReceiver) itemAddedEventReasoningToContentBlock(outputIdx int64, 
 
 func (r *streamReceiver) itemDoneEventToContentBlocks(ev *responses.ItemDoneEvent) (blocks []*schema.ContentBlock, err error) {
 	switch item := ev.Item.Union.(type) {
-	case *responses.OutputItem_FunctionDoubaoAppCall:
-		// Do nothing.
-		return nil, nil
-
 	case *responses.OutputItem_OutputMessage:
 		blocks, err = r.itemDoneEventOutputMessageToContentBlock(item)
 		if err != nil {
@@ -536,7 +511,8 @@ func (r *streamReceiver) itemDoneEventToContentBlocks(ev *responses.ItemDoneEven
 		blocks = append(blocks, block)
 
 	default:
-		return nil, fmt.Errorf("unknown item type %T with 'output_item.done' event", item)
+		// Unknown item types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	return blocks, nil
@@ -749,11 +725,12 @@ func (r *streamReceiver) eventContentPartToContentBlock(itemID string, content *
 
 	meta := &schema.StreamingMeta{Index: blockIdx}
 
-	switch part := content.Union.(type) {
+	switch content.Union.(type) {
 	case *responses.OutputContentItem_Text:
 		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
 	default:
-		return nil, fmt.Errorf("unknown content part type: %T", part)
+		// Unknown content part types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	setItemStatus(block, status.String())

--- a/components/model/agenticark/event_convertor_test.go
+++ b/components/model/agenticark/event_convertor_test.go
@@ -114,13 +114,15 @@ func TestItemAddedEventToContentBlockReasoning(t *testing.T) {
 	assert.NotNil(t, blocks[0].Reasoning)
 }
 
-func TestItemAddedEventToContentBlockInvalid(t *testing.T) {
+func TestItemAddedEventToContentBlockUnknown(t *testing.T) {
 	r := newStreamReceiver()
 	ev := &responses.ItemEvent{
 		Item: &responses.OutputItem{Union: nil},
 	}
-	_, err := r.itemAddedEventToContentBlock(ev)
-	assert.Error(t, err)
+	// Unknown item types are ignored rather than failing the stream.
+	blocks, err := r.itemAddedEventToContentBlock(ev)
+	assert.NoError(t, err)
+	assert.Empty(t, blocks)
 }
 
 func TestItemDoneEventToContentBlocksReasoning(t *testing.T) {
@@ -160,13 +162,15 @@ func TestItemDoneEventToContentBlocksFunctionToolCall(t *testing.T) {
 	assert.NotNil(t, blocks[0].FunctionToolCall)
 }
 
-func TestItemDoneEventToContentBlocksInvalid(t *testing.T) {
+func TestItemDoneEventToContentBlocksUnknown(t *testing.T) {
 	r := newStreamReceiver()
 	ev := &responses.ItemDoneEvent{
 		Item: &responses.OutputItem{Union: nil},
 	}
-	_, err := r.itemDoneEventToContentBlocks(ev)
-	assert.Error(t, err)
+	// Unknown item types are ignored rather than failing the stream.
+	blocks, err := r.itemDoneEventToContentBlocks(ev)
+	assert.NoError(t, err)
+	assert.Empty(t, blocks)
 }
 
 func TestItemDoneEventOutputMessageToContentBlockMissingProcessing(t *testing.T) {
@@ -332,10 +336,12 @@ func TestContentPartDoneEventToContentBlockOK(t *testing.T) {
 	assert.Equal(t, responses.ItemStatus_completed.String(), status)
 }
 
-func TestEventContentPartToContentBlockInvalid(t *testing.T) {
+func TestEventContentPartToContentBlockUnknown(t *testing.T) {
 	r := newStreamReceiver()
-	_, err := r.eventContentPartToContentBlock("id", &responses.OutputContentItem{}, 1, responses.ItemStatus_in_progress)
-	assert.Error(t, err)
+	// Unknown content part types are ignored rather than failing the stream.
+	block, err := r.eventContentPartToContentBlock("id", &responses.OutputContentItem{}, 1, responses.ItemStatus_in_progress)
+	assert.NoError(t, err)
+	assert.Nil(t, block)
 }
 
 func TestOutputTextDeltaEventToContentBlock(t *testing.T) {

--- a/components/model/agenticopenai/responses_event_convertor.go
+++ b/components/model/agenticopenai/responses_event_convertor.go
@@ -44,18 +44,6 @@ func receivedStreamingResponse(sr *ssestream.Stream[responses.ResponseStreamEven
 		sender.errHeader = fmt.Sprintf("failed to convert event '%s'", event.Type)
 
 		switch variant := event.AsAny().(type) {
-		case responses.ResponseTextDoneEvent,
-			responses.ResponseReasoningSummaryPartAddedEvent,
-			responses.ResponseReasoningSummaryPartDoneEvent,
-			responses.ResponseReasoningSummaryTextDoneEvent,
-			responses.ResponseFunctionCallArgumentsDoneEvent,
-			responses.ResponseMcpCallArgumentsDoneEvent,
-			responses.ResponseRefusalDoneEvent,
-			responses.ResponseCodeInterpreterCallCodeDoneEvent:
-
-			// Do nothing.
-			continue
-
 		case responses.ResponseErrorEvent:
 			_ = sw.Send(nil, fmt.Errorf("received error event: code=%s message=%s", variant.Code, variant.Message))
 
@@ -208,7 +196,8 @@ func receivedStreamingResponse(sr *ssestream.Stream[responses.ResponseStreamEven
 			sender.sendBlock(block, nil)
 
 		default:
-			sw.Send(nil, fmt.Errorf("unknown event type: %s", event.Type))
+			// Unhandled event types are ignored rather than failing the stream.
+			continue
 		}
 	}
 
@@ -236,7 +225,9 @@ func (s *callbackSender) sendMeta(meta *schema.AgenticResponseMeta, err error) {
 }
 
 func (s *callbackSender) sendBlock(block *schema.ContentBlock, err error) {
-	s.send(nil, block, err)
+	if block != nil || err != nil {
+		s.send(nil, block, err)
+	}
 }
 
 func (s *callbackSender) send(meta *schema.AgenticResponseMeta, block *schema.ContentBlock, err error) {
@@ -387,15 +378,9 @@ func (r *streamReceiver) itemAddedEventToContentBlock(ev responses.ResponseOutpu
 		}
 		blocks = append(blocks, block)
 
-	case responses.ResponseOutputMessage,
-		responses.ResponseFunctionWebSearch,
-		responses.ResponseFileSearchToolCall,
-		responses.ResponseOutputItemImageGenerationCall,
-		responses.ResponseOutputItemMcpApprovalRequest:
-		// Do nothing.
-
 	default:
-		return nil, fmt.Errorf("unknown item type %T with 'output_item.added' event", item)
+		// Unhandled event types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	return blocks, nil
@@ -570,7 +555,8 @@ func (r *streamReceiver) itemDoneEventToContentBlocks(ev responses.ResponseOutpu
 		blocks = append(blocks, block)
 
 	default:
-		return nil, fmt.Errorf("unknown item type %T with 'output_item.done' event", item)
+		// Unhandled event types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	return blocks, nil
@@ -795,24 +781,25 @@ func (r *streamReceiver) itemDoneEventShellOutputToContentBlock(outputIdx int64,
 }
 
 func (r *streamReceiver) contentPartAddedEventToContentBlock(ev responses.ResponseContentPartAddedEvent) (block *schema.ContentBlock, err error) {
-	key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
-	blockIdx := r.getBlockIndex(key)
-
-	indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemID]
-	if !ok {
-		indices = map[int]bool{}
-		r.ProcessingAssistantGenTextBlockIndex[ev.ItemID] = indices
-	}
-
-	indices[blockIdx] = true
-
-	meta := &schema.StreamingMeta{Index: blockIdx}
-
 	switch ev.Part.AsAny().(type) {
 	case responses.ResponseOutputText, responses.ResponseOutputRefusal:
+		key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
+		blockIdx := r.getBlockIndex(key)
+
+		indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemID]
+		if !ok {
+			indices = map[int]bool{}
+			r.ProcessingAssistantGenTextBlockIndex[ev.ItemID] = indices
+		}
+
+		indices[blockIdx] = true
+
+		meta := &schema.StreamingMeta{Index: blockIdx}
 		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+
 	default:
-		return nil, fmt.Errorf("unknown content part type: %T", ev.Part)
+		// Unknown content part types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	setItemStatus(block, string(responses.ResponseStatusInProgress))
@@ -822,27 +809,24 @@ func (r *streamReceiver) contentPartAddedEventToContentBlock(ev responses.Respon
 }
 
 func (r *streamReceiver) contentPartDoneEventToContentBlock(ev responses.ResponseContentPartDoneEvent) (block *schema.ContentBlock, err error) {
-	key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
-	blockIdx := r.getBlockIndex(key)
-
-	indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemID]
-	if !ok {
-		return nil, fmt.Errorf("item %q has no processing assistant gen text block index", ev.ItemID)
-	}
-
-	delete(indices, blockIdx)
-
-	meta := &schema.StreamingMeta{Index: blockIdx}
-
 	switch ev.Part.AsAny().(type) {
-	case responses.ResponseOutputText:
-		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
-	default:
-		return nil, fmt.Errorf("unknown content part type: %T", ev.Part)
-	}
+	case responses.ResponseOutputText, responses.ResponseOutputRefusal:
+		key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
+		blockIdx := r.getBlockIndex(key)
 
-	block.StreamingMeta = &schema.StreamingMeta{
-		Index: blockIdx,
+		indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemID]
+		if !ok {
+			return nil, fmt.Errorf("item %q has no processing assistant gen text block index", ev.ItemID)
+		}
+
+		delete(indices, blockIdx)
+
+		meta := &schema.StreamingMeta{Index: blockIdx}
+		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+
+	default:
+		// Unknown content part types are ignored rather than failing the stream.
+		return nil, nil
 	}
 
 	setItemStatus(block, string(responses.ResponseStatusCompleted))

--- a/components/model/agenticopenai/responses_event_convertor_test.go
+++ b/components/model/agenticopenai/responses_event_convertor_test.go
@@ -313,15 +313,25 @@ func TestItemDoneEventOutputMessageToContentBlockSuccess(t *testing.T) {
 }
 
 func TestContentPartAddedEventToContentBlockInvalidType(t *testing.T) {
-	mockey.PatchConvey("TestContentPartAddedEventToContentBlockInvalidType", t, func() {
-		r := newStreamReceiver(&model.Options{})
-		ev := responses.ResponseContentPartAddedEvent{}
+	r := newStreamReceiver(&model.Options{})
+	// A zero-value part matches none of the known content part types.
+	ev := responses.ResponseContentPartAddedEvent{}
 
-		mockey.Mock(responses.ResponseOutputMessageContentUnion.AsAny).Return("invalid").Build()
+	// Unknown content part types are ignored rather than failing the stream.
+	block, err := r.contentPartAddedEventToContentBlock(ev)
+	assert.NoError(t, err)
+	assert.Nil(t, block)
+}
 
-		_, err := r.contentPartAddedEventToContentBlock(ev)
-		assert.Error(t, err)
-	})
+func TestContentPartDoneEventToContentBlockInvalidType(t *testing.T) {
+	r := newStreamReceiver(&model.Options{})
+	// A zero-value part matches none of the known content part types.
+	ev := responses.ResponseContentPartDoneEvent{}
+
+	// Unknown content part types are ignored rather than failing the stream.
+	block, err := r.contentPartDoneEventToContentBlock(ev)
+	assert.NoError(t, err)
+	assert.Nil(t, block)
 }
 
 func TestContentPartDoneEventToContentBlockNoIndex(t *testing.T) {
@@ -333,7 +343,7 @@ func TestContentPartDoneEventToContentBlockNoIndex(t *testing.T) {
 			ContentIndex: 2,
 		}
 
-		mockey.Mock(responses.ResponseOutputMessageContentUnion.AsAny).Return(responses.ResponseOutputText{}).Build()
+		mockey.Mock(responses.ResponseContentPartDoneEventPartUnion.AsAny).Return(responses.ResponseOutputText{}).Build()
 
 		_, err := r.contentPartDoneEventToContentBlock(ev)
 		assert.Error(t, err)
@@ -430,6 +440,28 @@ func TestReasoningSummaryTextDeltaEventToContentBlock(t *testing.T) {
 	id, ok := getItemID(block)
 	assert.True(t, ok)
 	assert.Equal(t, "iid", id)
+}
+
+func TestContentPartDoneEventToContentBlockRefusal(t *testing.T) {
+	mockey.PatchConvey("TestContentPartDoneEventToContentBlockRefusal", t, func() {
+		r := newStreamReceiver(&model.Options{})
+		ev := responses.ResponseContentPartDoneEvent{
+			ItemID:       "iid",
+			OutputIndex:  1,
+			ContentIndex: 2,
+		}
+
+		// Register the block as the added event would have.
+		blockIdx := r.getBlockIndex(makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex))
+		r.ProcessingAssistantGenTextBlockIndex["iid"] = map[int]bool{blockIdx: true}
+
+		mockey.Mock(responses.ResponseContentPartDoneEventPartUnion.AsAny).
+			Return(responses.ResponseOutputRefusal{}).Build()
+
+		block, err := r.contentPartDoneEventToContentBlock(ev)
+		assert.NoError(t, err)
+		assert.NotNil(t, block.AssistantGenText)
+	})
 }
 
 func TestFunctionCallArgumentsDeltaEventToContentBlock(t *testing.T) {


### PR DESCRIPTION
## Summary

The agenticopenai and agenticark Responses stream convertors previously returned an error the moment they encountered an unrecognized stream event, output item, or content part type, which aborted the entire stream. Providers add new event/item/part variants over time, so a single unknown variant could break otherwise-valid streaming responses. These convertors now skip unknown variants and continue.

## Key Changes

1. Main stream dispatch (`receivedStreamingResponse` / `receivedStreamResponse`): the `default` branch now `continue`s instead of emitting an `unknown event type` error. The explicit no-op `case` lists are dropped since they collapse into the lenient default.
2. `itemAddedEventToContentBlock` / `itemDoneEventToContentBlocks` (ark) and the content-part handlers (`contentPartAddedEventToContentBlock`, `contentPartDoneEventToContentBlock`, `eventContentPartToContentBlock`): unknown item / content part types now return `(nil, nil)` instead of erroring. Internal-invariant switches over already-built `block.Type` still error.
3. `sendBlock` now skips sending when both block and error are nil, so the ignored variants do not produce empty content blocks.
4. agenticopenai content-part handlers were restructured into a single type switch; the done-event handler also accepts `ResponseOutputRefusal` (it previously only matched `ResponseOutputText`).
