### PR TITLE
fix(agentic): merge adjacent tool-result messages for claude and gemini

### DIFF
--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -66,7 +66,42 @@ func toAnthropicMessages(input []*schema.AgenticMessage) (systemBlocks []anthrop
 		}
 	}
 
+	msgParams = mergeAdjacentToolResults(msgParams)
+
 	return systemBlocks, msgParams, nil
+}
+
+// mergeAdjacentToolResults merges adjacent tool-result user messages into one.
+// Anthropic requires all tool_result blocks for an assistant turn in a single
+// user message.
+func mergeAdjacentToolResults(msgParams []anthropic.MessageParam) []anthropic.MessageParam {
+	if len(msgParams) <= 1 {
+		return msgParams
+	}
+
+	result := make([]anthropic.MessageParam, 0, len(msgParams))
+	for _, mp := range msgParams {
+		if len(result) > 0 && isToolResultMessage(mp) && isToolResultMessage(result[len(result)-1]) {
+			result[len(result)-1].Content = append(result[len(result)-1].Content, mp.Content...)
+		} else {
+			result = append(result, mp)
+		}
+	}
+	return result
+}
+
+// isToolResultMessage reports whether a message consists solely of tool_result
+// content blocks.
+func isToolResultMessage(mp anthropic.MessageParam) bool {
+	if mp.Role != anthropic.MessageParamRoleUser || len(mp.Content) == 0 {
+		return false
+	}
+	for _, block := range mp.Content {
+		if block.OfToolResult == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func toSystemBlocks(msg *schema.AgenticMessage) ([]anthropic.TextBlockParam, error) {

--- a/components/model/agenticclaude/convertor_test.go
+++ b/components/model/agenticclaude/convertor_test.go
@@ -1309,3 +1309,89 @@ func TestAssistantGenTextToBlockParamWithCitations(t *testing.T) {
 		t.Fatalf("json = %s", mustJSON(t, blockParam))
 	}
 }
+
+func TestToAnthropicMessagesMergeToolOnly(t *testing.T) {
+	toolMsg := func(callID string) *schema.AgenticMessage {
+		return &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				schema.NewContentBlock(&schema.FunctionToolResult{
+					CallID: callID,
+					Name:   "get_weather",
+					Content: []*schema.FunctionToolResultContentBlock{
+						{
+							Type: schema.FunctionToolResultContentBlockTypeText,
+							Text: &schema.UserInputText{Text: "ok"},
+						},
+					},
+				}),
+			},
+		}
+	}
+
+	t.Run("two consecutive tool-only messages merged", func(t *testing.T) {
+		_, msgParams, err := toAnthropicMessages([]*schema.AgenticMessage{
+			schema.UserAgenticMessage("hello"),
+			toolMsg("call_1"),
+			toolMsg("call_2"),
+		})
+		if err != nil {
+			t.Fatalf("toAnthropicMessages() error = %v", err)
+		}
+		if len(msgParams) != 2 {
+			t.Fatalf("len(msgParams) = %d, want 2", len(msgParams))
+		}
+		if len(msgParams[1].Content) != 2 {
+			t.Fatalf("len(merged content) = %d, want 2", len(msgParams[1].Content))
+		}
+	})
+
+	t.Run("three consecutive tool-only messages merged", func(t *testing.T) {
+		_, msgParams, err := toAnthropicMessages([]*schema.AgenticMessage{
+			toolMsg("call_1"),
+			toolMsg("call_2"),
+			toolMsg("call_3"),
+		})
+		if err != nil {
+			t.Fatalf("toAnthropicMessages() error = %v", err)
+		}
+		if len(msgParams) != 1 {
+			t.Fatalf("len(msgParams) = %d, want 1", len(msgParams))
+		}
+		if len(msgParams[0].Content) != 3 {
+			t.Fatalf("len(merged content) = %d, want 3", len(msgParams[0].Content))
+		}
+	})
+
+	t.Run("tool messages separated by assistant not merged", func(t *testing.T) {
+		_, msgParams, err := toAnthropicMessages([]*schema.AgenticMessage{
+			toolMsg("call_1"),
+			{
+				Role: schema.AgenticRoleTypeAssistant,
+				ContentBlocks: []*schema.ContentBlock{
+					schema.NewContentBlock(&schema.AssistantGenText{Text: "ok"}),
+				},
+			},
+			toolMsg("call_2"),
+		})
+		if err != nil {
+			t.Fatalf("toAnthropicMessages() error = %v", err)
+		}
+		if len(msgParams) != 3 {
+			t.Fatalf("len(msgParams) = %d, want 3", len(msgParams))
+		}
+	})
+
+	t.Run("user message with text not merged with tool message", func(t *testing.T) {
+		_, msgParams, err := toAnthropicMessages([]*schema.AgenticMessage{
+			toolMsg("call_1"),
+			schema.UserAgenticMessage("more"),
+		})
+		if err != nil {
+			t.Fatalf("toAnthropicMessages() error = %v", err)
+		}
+		if len(msgParams) != 2 {
+			t.Fatalf("len(msgParams) = %d, want 2", len(msgParams))
+		}
+	})
+}

--- a/components/model/agenticgemini/conv.go
+++ b/components/model/agenticgemini/conv.go
@@ -44,7 +44,40 @@ func convAgenticMessages(messages []*schema.AgenticMessage) ([]*genai.Content, e
 		}
 		result[i] = content
 	}
-	return result, nil
+	return mergeAdjacentToolContents(result), nil
+}
+
+// mergeAdjacentToolContents merges adjacent tool response contents into one.
+// Gemini requires all tool responses to be in a single message when responding
+// to parallel tool calls.
+func mergeAdjacentToolContents(contents []*genai.Content) []*genai.Content {
+	if len(contents) <= 1 {
+		return contents
+	}
+
+	result := make([]*genai.Content, 0, len(contents))
+	for _, content := range contents {
+		if len(result) > 0 && isToolResponseContent(content) && isToolResponseContent(result[len(result)-1]) {
+			result[len(result)-1].Parts = append(result[len(result)-1].Parts, content.Parts...)
+		} else {
+			result = append(result, content)
+		}
+	}
+	return result
+}
+
+// isToolResponseContent reports whether a content consists solely of tool
+// response parts.
+func isToolResponseContent(content *genai.Content) bool {
+	if content == nil || len(content.Parts) == 0 {
+		return false
+	}
+	for _, part := range content.Parts {
+		if part.FunctionResponse == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // convAgenticMessage converts a single AgenticMessage to genai.Content

--- a/components/model/agenticgemini/conv_test.go
+++ b/components/model/agenticgemini/conv_test.go
@@ -1192,3 +1192,70 @@ func TestConvGroundingMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestConvAgenticMessages_MergeToolResults(t *testing.T) {
+	toolMsg := func(name, text string) *schema.AgenticMessage {
+		return &schema.AgenticMessage{
+			Role: schema.AgenticRoleTypeUser,
+			ContentBlocks: []*schema.ContentBlock{
+				{
+					Type: schema.ContentBlockTypeFunctionToolResult,
+					FunctionToolResult: &schema.FunctionToolResult{
+						Name: name,
+						Content: []*schema.FunctionToolResultContentBlock{
+							{Type: schema.FunctionToolResultContentBlockTypeText, Text: &schema.UserInputText{Text: text}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("two consecutive tool results merged", func(t *testing.T) {
+		contents, err := convAgenticMessages([]*schema.AgenticMessage{
+			schema.UserAgenticMessage("hello"),
+			toolMsg("a", `{"x":1}`),
+			toolMsg("b", `{"y":2}`),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, contents, 2)
+		assert.Len(t, contents[1].Parts, 2)
+		assert.NotNil(t, contents[1].Parts[0].FunctionResponse)
+		assert.NotNil(t, contents[1].Parts[1].FunctionResponse)
+	})
+
+	t.Run("three consecutive tool results merged", func(t *testing.T) {
+		contents, err := convAgenticMessages([]*schema.AgenticMessage{
+			toolMsg("a", `{"x":1}`),
+			toolMsg("b", `{"y":2}`),
+			toolMsg("c", `{"z":3}`),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, contents, 1)
+		assert.Len(t, contents[0].Parts, 3)
+	})
+
+	t.Run("tool results separated by assistant not merged", func(t *testing.T) {
+		contents, err := convAgenticMessages([]*schema.AgenticMessage{
+			toolMsg("a", `{"x":1}`),
+			{
+				Role: schema.AgenticRoleTypeAssistant,
+				ContentBlocks: []*schema.ContentBlock{
+					{Type: schema.ContentBlockTypeAssistantGenText, AssistantGenText: &schema.AssistantGenText{Text: "ok"}},
+				},
+			},
+			toolMsg("b", `{"y":2}`),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, contents, 3)
+	})
+
+	t.Run("user text not merged with tool result", func(t *testing.T) {
+		contents, err := convAgenticMessages([]*schema.AgenticMessage{
+			toolMsg("a", `{"x":1}`),
+			schema.UserAgenticMessage("more"),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, contents, 2)
+	})
+}

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -652,37 +652,7 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 	msgParams := make([]anthropic.MessageParam, 0, len(msgs))
 	hasSetMsgBreakPoint := false
 
-	for i := 0; i < len(msgs); {
-		msg := msgs[i]
-
-		// Merge consecutive tool messages into a single UserMessage.
-		// Anthropic API requires all tool_result blocks for a given
-		// assistant turn to be in the same user message.
-		if msg.Role == schema.Tool {
-			// Collect all consecutive tool messages
-			toolMsgs := []*schema.Message{msg}
-			j := i + 1
-			for j < len(msgs) && msgs[j].Role == schema.Tool {
-				toolMsgs = append(toolMsgs, msgs[j])
-				j++
-			}
-
-			// Convert each and merge content blocks into one UserMessage
-			blocks := make([]anthropic.ContentBlockParamUnion, 0, len(toolMsgs))
-			for _, tm := range toolMsgs {
-				mp, err := convSchemaMessage(tm)
-				if err != nil {
-					return fmt.Errorf("convert schema message fail: %w", err)
-				}
-				blocks = append(blocks, mp.Content...)
-			}
-
-			msgParam := anthropic.NewUserMessage(blocks...)
-			msgParams = append(msgParams, msgParam)
-			i = j
-			continue
-		}
-
+	for _, msg := range msgs {
 		msgParam, err := convSchemaMessage(msg)
 		if err != nil {
 			return fmt.Errorf("convert schema message fail: %w", err)
@@ -695,8 +665,9 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 		}
 
 		msgParams = append(msgParams, msgParam)
-		i++
 	}
+
+	msgParams = mergeAdjacentToolResults(msgParams)
 
 	if !hasSetMsgBreakPoint && specOptions.AutoCacheControl != nil {
 		lastMsgParam := msgParams[len(msgParams)-1]
@@ -707,6 +678,39 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 	params.Messages = msgParams
 
 	return nil
+}
+
+// mergeAdjacentToolResults merges adjacent tool-result user messages into one.
+// Anthropic requires all tool_result blocks for an assistant turn in a single
+// user message.
+func mergeAdjacentToolResults(msgParams []anthropic.MessageParam) []anthropic.MessageParam {
+	if len(msgParams) <= 1 {
+		return msgParams
+	}
+
+	result := make([]anthropic.MessageParam, 0, len(msgParams))
+	for _, mp := range msgParams {
+		if len(result) > 0 && isToolResultMessage(mp) && isToolResultMessage(result[len(result)-1]) {
+			result[len(result)-1].Content = append(result[len(result)-1].Content, mp.Content...)
+		} else {
+			result = append(result, mp)
+		}
+	}
+	return result
+}
+
+// isToolResultMessage reports whether a message consists solely of tool_result
+// content blocks.
+func isToolResultMessage(mp anthropic.MessageParam) bool {
+	if mp.Role != anthropic.MessageParamRoleUser || len(mp.Content) == 0 {
+		return false
+	}
+	for _, block := range mp.Content {
+		if block.OfToolResult == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func populateToolSearchResultTools(params *anthropic.MessageNewParams, msgs []*schema.Message) error {

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -771,8 +771,12 @@ func isToolResponseContent(content *genai.Content) bool {
 	if content == nil || len(content.Parts) == 0 {
 		return false
 	}
-	// Check if the first part is a FunctionResponse
-	return content.Parts[0].FunctionResponse != nil
+	for _, part := range content.Parts {
+		if part.FunctionResponse == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func convSchemaMessage(message *schema.Message) (*genai.Content, error) {


### PR DESCRIPTION
## Summary

When an assistant makes parallel tool calls, the agentic runtime produces one tool-result `AgenticMessage` per call. Both the Anthropic and Gemini APIs require all tool results for a single assistant turn to be delivered in **one** message, so emitting them separately causes a 400 error. This applies the same fix already shipped for the gemini chat model (#565) to the agentic claude and gemini models.

## Key Changes

1. Message conversion stays a pure 1:1 mapping; a normalization pass over the converted SDK output then merges adjacent messages that consist solely of tool-result blocks.
2. `agenticclaude`: `mergeAdjacentToolResults` over `[]anthropic.MessageParam` (a user message is merge-eligible when every content block is `OfToolResult`).
3. `agenticgemini`: `mergeAdjacentToolContents` over `[]*genai.Content` (a content is merge-eligible when every part is a `FunctionResponse`).
4. Messages separated by a non-tool message, or carrying mixed content, are left untouched.
