### PR TITLE
docs: add docstring for of utility function

### DIFF
--- a/components/model/claude/utils.go
+++ b/components/model/claude/utils.go
@@ -16,6 +16,7 @@
 
 package claude
 
+// of returns a pointer to the given value.
 func of[T any](v T) *T {
 	return &v
 }


### PR DESCRIPTION
### 问题背景

在 `components/model/claude/utils.go` 文件中，`of` 函数缺少文档注释。这不符合 Go 语言的良好实践，降低了代码的可读性和可维护性。为函数添加清晰的文档注释是持续改进代码库的一部分。

### 修改内容

- **修改了什么**: 为 `of` 函数添加了一行符合 Go 风格的文档注释 `// of returns a pointer to the given value.`
- **为什么这样改**: 该函数是一个通用的辅助函数，用于获取任意类型值的指针。添加注释可以明确其用途，帮助其他开发者快速理解其功能，而无需查看函数实现。
- **对代码质量的提升**: 显著提升了代码的可读性和自文档化程度，使代码库更易于维护。

### 验证方式

- 该修改仅添加了注释，不涉及任何逻辑变更，因此所有现有的单元测试和功能均不受影响，可以正常通过。
- 无需为文档注释添加新的测试。
- 已确认注释准确描述了函数的行为。

### 其他信息

- **Breaking Changes**: 无。本次修改不涉及任何 API 或行为的变更。
- **文档更新**: 不需要。本次修改本身就是在更新代码内嵌的文档。
- **已知限制**: 无。