### PR TITLE
feat(agentic): support openai.ReasoningExtension for reasoning text

### DIFF
--- a/components/model/agenticark/event_convertor.go
+++ b/components/model/agenticark/event_convertor.go
@@ -946,8 +946,8 @@ func (r *streamReceiver) doubaoAppOutputTextDeltaToContentBlock(ev *responses.Re
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeOutputText,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeOutputText,
 			OutputText: &DoubaoAppOutputText{
 				Text: ev.GetDelta(),
 			},
@@ -985,8 +985,8 @@ func (r *streamReceiver) doubaoAppReasoningTextDeltaToContentBlock(ev *responses
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeReasoningText,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeReasoningText,
 			ReasoningText: &DoubaoAppReasoningText{
 				ReasoningText: ev.GetDelta(),
 			},
@@ -1010,8 +1010,8 @@ func (r *streamReceiver) doubaoAppSearchSearchingToContentBlock(ev *responses.Re
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeSearch,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeSearch,
 			Search: &DoubaoAppSearch{
 				SearchingState: ev.GetSearchingState(),
 			},
@@ -1046,8 +1046,8 @@ func (r *streamReceiver) doubaoAppSearchCompletedToContentBlock(ev *responses.Re
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeSearch,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeSearch,
 			Search: &DoubaoAppSearch{
 				Summary: ev.GetSummary(),
 				Queries: ev.Queries,
@@ -1073,8 +1073,8 @@ func (r *streamReceiver) doubaoAppReasoningSearchSearchingToContentBlock(ev *res
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeReasoningSearch,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeReasoningSearch,
 			ReasoningSearch: &DoubaoAppReasoningSearch{
 				SearchingState: ev.GetSearchingState(),
 			},
@@ -1109,8 +1109,8 @@ func (r *streamReceiver) doubaoAppReasoningSearchCompletedToContentBlock(ev *res
 
 	result := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{{
-			StreamingMeta: &DoubaoAppStreamingMeta{Index: ev.BlockIndex},
-			Type:          DoubaoAppBlockTypeReasoningSearch,
+			Index: ptrOf(int(ev.BlockIndex)),
+			Type:  DoubaoAppBlockTypeReasoningSearch,
 			ReasoningSearch: &DoubaoAppReasoningSearch{
 				Summary: ev.GetSummary(),
 				Queries: ev.Queries,

--- a/components/model/agenticark/extension.go
+++ b/components/model/agenticark/extension.go
@@ -68,9 +68,9 @@ type DoubaoAppResult struct {
 }
 
 type DoubaoAppBlock struct {
-	// StreamingMeta contains streaming metadata for this block.
-	// Only present when processing streaming response.
-	StreamingMeta *DoubaoAppStreamingMeta `json:"streaming_meta,omitempty" mapstructure:"streaming_meta,omitempty"`
+	// Index is the index of this block within DoubaoApp result.
+	// Only available in streaming response.
+	Index *int `json:"index,omitempty" mapstructure:"index,omitempty"`
 
 	Type            DoubaoAppBlockType        `json:"type,omitempty" mapstructure:"type,omitempty"`
 	OutputText      *DoubaoAppOutputText      `json:"output_text,omitempty" mapstructure:"output_text,omitempty"`
@@ -79,19 +79,13 @@ type DoubaoAppBlock struct {
 	ReasoningSearch *DoubaoAppReasoningSearch `json:"reasoning_search,omitempty" mapstructure:"reasoning_search,omitempty"`
 }
 
-// DoubaoAppStreamingMeta contains streaming metadata for DoubaoAppBlock.
-type DoubaoAppStreamingMeta struct {
-	// Index is the index of this block within DoubaoApp result.
-	Index int64 `json:"index,omitempty" mapstructure:"index,omitempty"`
-}
-
 type DoubaoAppOutputText struct {
 	ID       string `json:"id,omitempty" mapstructure:"id,omitempty"`
 	ParentID string `json:"parent_id,omitempty" mapstructure:"parent_id,omitempty"`
 	Text     string `json:"text,omitempty" mapstructure:"text,omitempty"`
 
 	// Status represents the status of the output text.
-	// It is only available in non-streaming response.
+	// Only available in non-streaming response.
 	Status string `json:"status,omitempty" mapstructure:"status,omitempty"`
 }
 
@@ -101,7 +95,7 @@ type DoubaoAppReasoningText struct {
 	ReasoningText string `json:"reasoning_text,omitempty" mapstructure:"reasoning_text,omitempty"`
 
 	// Status represents the status of the reasoning text.
-	// It is only available in non-streaming response.
+	// Only available in non-streaming response.
 	Status string `json:"status,omitempty" mapstructure:"status,omitempty"`
 }
 
@@ -113,11 +107,11 @@ type DoubaoAppSearch struct {
 	Results  []*DoubaoAppSearchResult `json:"results,omitempty" mapstructure:"results,omitempty"`
 
 	// SearchingState represents the state of searching.
-	// It is only available in streaming response.
+	// Only available in streaming response.
 	SearchingState string `json:"searching_state,omitempty" mapstructure:"searching_state,omitempty"`
 
 	// Status represents the status of the search.
-	// It is only available in non-streaming response.
+	// Only available in non-streaming response.
 	Status string `json:"status,omitempty" mapstructure:"status,omitempty"`
 }
 
@@ -556,8 +550,8 @@ func concatDoubaoAppResults(chunks []*DoubaoAppResult) (*DoubaoAppResult, error)
 	ret := &DoubaoAppResult{}
 	var (
 		blocks        []*DoubaoAppBlock
-		blockIndices  []int64
-		indexToBlocks = make(map[int64][]*DoubaoAppBlock)
+		blockIndices  []int
+		indexToBlocks = make(map[int][]*DoubaoAppBlock)
 	)
 
 	for _, chunk := range chunks {
@@ -568,7 +562,7 @@ func concatDoubaoAppResults(chunks []*DoubaoAppResult) (*DoubaoAppResult, error)
 			if block == nil {
 				continue
 			}
-			if block.StreamingMeta == nil {
+			if block.Index == nil {
 				if len(blockIndices) > 0 {
 					return nil, fmt.Errorf("found non-streaming block after streaming blocks")
 				}
@@ -577,7 +571,7 @@ func concatDoubaoAppResults(chunks []*DoubaoAppResult) (*DoubaoAppResult, error)
 				if len(blocks) > 0 {
 					return nil, fmt.Errorf("found streaming block after non-streaming blocks")
 				}
-				idx := block.StreamingMeta.Index
+				idx := *block.Index
 				if _, ok := indexToBlocks[idx]; !ok {
 					blockIndices = append(blockIndices, idx)
 				}
@@ -592,7 +586,7 @@ func concatDoubaoAppResults(chunks []*DoubaoAppResult) (*DoubaoAppResult, error)
 	}
 
 	if len(blockIndices) > 0 {
-		indexToBlock := make(map[int64]*DoubaoAppBlock)
+		indexToBlock := make(map[int]*DoubaoAppBlock)
 		for idx, bs := range indexToBlocks {
 			indexToBlock[idx] = concatDoubaoAppBlocks(bs)
 		}

--- a/components/model/agenticark/extension_test.go
+++ b/components/model/agenticark/extension_test.go
@@ -387,36 +387,36 @@ func TestConcatDoubaoAppResults(t *testing.T) {
 	chunk1 := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{
 			{
-				StreamingMeta: &DoubaoAppStreamingMeta{Index: 0},
-				Type:          DoubaoAppBlockTypeOutputText,
-				OutputText:    &DoubaoAppOutputText{ID: "text1", Text: "hello "},
+				Index:      ptrOf(0),
+				Type:       DoubaoAppBlockTypeOutputText,
+				OutputText: &DoubaoAppOutputText{ID: "text1", Text: "hello "},
 			},
 		},
 	}
 	chunk2 := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{
 			{
-				StreamingMeta: &DoubaoAppStreamingMeta{Index: 0},
-				Type:          DoubaoAppBlockTypeOutputText,
-				OutputText:    &DoubaoAppOutputText{Text: "world"},
+				Index:      ptrOf(0),
+				Type:       DoubaoAppBlockTypeOutputText,
+				OutputText: &DoubaoAppOutputText{Text: "world"},
 			},
 		},
 	}
 	chunk3 := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{
 			{
-				StreamingMeta: &DoubaoAppStreamingMeta{Index: 1},
-				Type:          DoubaoAppBlockTypeSearch,
-				Search:        &DoubaoAppSearch{ID: "s1", SearchingState: "searching"},
+				Index:  ptrOf(1),
+				Type:   DoubaoAppBlockTypeSearch,
+				Search: &DoubaoAppSearch{ID: "s1", SearchingState: "searching"},
 			},
 		},
 	}
 	chunk4 := &DoubaoAppResult{
 		Blocks: []*DoubaoAppBlock{
 			{
-				StreamingMeta: &DoubaoAppStreamingMeta{Index: 1},
-				Type:          DoubaoAppBlockTypeSearch,
-				Search:        &DoubaoAppSearch{Summary: "done", Queries: []string{"q1"}},
+				Index:  ptrOf(1),
+				Type:   DoubaoAppBlockTypeSearch,
+				Search: &DoubaoAppSearch{Summary: "done", Queries: []string{"q1"}},
 			},
 		},
 	}

--- a/components/model/agenticark/go.mod
+++ b/components/model/agenticark/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0
-	github.com/volcengine/volcengine-go-sdk v1.2.27
+	github.com/volcengine/volcengine-go-sdk v1.2.34
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/sync v0.8.0
 	google.golang.org/protobuf v1.31.0

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -138,8 +138,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.27 h1:azBueeKhhGQukss+ob6m3oJ5K8GGYbfDNj8RKAEXVTE=
-github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.34 h1:oty2YY90UvH05RDbDn6348Y6oS7A5Tr6kIteAjVqFlY=
+github.com/volcengine/volcengine-go-sdk v1.2.34/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/agenticopenai/go.mod
+++ b/components/model/agenticopenai/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.1
+	github.com/cloudwego/eino v0.9.5
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/components/model/agenticopenai/go.sum
+++ b/components/model/agenticopenai/go.sum
@@ -26,8 +26,8 @@ github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCc
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
-github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.5 h1:0Nftjx9gPek/2S/hzm38LVxSjk5/6mqRr3I9VKrKvm4=
+github.com/cloudwego/eino v0.9.5/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6 h1:ES/xufN5eqJ3h+9tw/tq6F8kkgnAxBAHVUB6nqKsIDU=
 github.com/cloudwego/eino-ext/libs/acl/openai v0.1.18-0.20260527084435-846f52bd97c6/go.mod h1:5Xj74dGrfHo1z7I07Fzp3SlTF7Bt4tss3A2FSt8SqQ4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/agenticopenai/responses_convertor.go
+++ b/components/model/agenticopenai/responses_convertor.go
@@ -911,15 +911,30 @@ func reasoningToInputItem(block *schema.ContentBlock) (item responses.ResponseIn
 	id, _ := getItemID(block)
 	status, _ := GetItemStatus(block)
 
-	item = responses.ResponseInputItemUnionParam{
-		OfReasoning: &responses.ResponseReasoningItemParam{
-			ID:     id,
-			Status: responses.ResponseReasoningItemStatus(status),
-			Summary: []responses.ResponseReasoningItemSummaryParam{
-				{Text: content.Text},
-			},
-			EncryptedContent: newOpenaiStrOpt(content.Signature),
+	reasoningItem := &responses.ResponseReasoningItemParam{
+		ID:     id,
+		Status: responses.ResponseReasoningItemStatus(status),
+		Summary: []responses.ResponseReasoningItemSummaryParam{
+			{Text: content.Text},
 		},
+		EncryptedContent: newOpenaiStrOpt(content.Signature),
+	}
+
+	if content.OpenAIExtension != nil && len(content.OpenAIExtension.Content) > 0 {
+		reasoningContent := make([]responses.ResponseReasoningItemContentParam, 0, len(content.OpenAIExtension.Content))
+		for _, c := range content.OpenAIExtension.Content {
+			if c == nil {
+				continue
+			}
+			reasoningContent = append(reasoningContent, responses.ResponseReasoningItemContentParam{
+				Text: c.Text,
+			})
+		}
+		reasoningItem.Content = reasoningContent
+	}
+
+	item = responses.ResponseInputItemUnionParam{
+		OfReasoning: reasoningItem,
 	}
 
 	return item, nil
@@ -2119,10 +2134,23 @@ func reasoningToContentBlocks(item responses.ResponseReasoningItem) (block *sche
 		text.WriteString(s.Text)
 	}
 
-	block = schema.NewContentBlock(&schema.Reasoning{
+	reasoning := &schema.Reasoning{
 		Text:      text.String(),
 		Signature: item.EncryptedContent,
-	})
+	}
+	if len(item.Content) > 0 {
+		ext := &openai.ReasoningExtension{
+			Content: make([]*openai.ReasoningContent, 0, len(item.Content)),
+		}
+		for _, c := range item.Content {
+			ext.Content = append(ext.Content, &openai.ReasoningContent{
+				Text: c.Text,
+			})
+		}
+		reasoning.OpenAIExtension = ext
+	}
+
+	block = schema.NewContentBlock(reasoning)
 
 	setItemID(block, item.ID)
 	if s := string(item.Status); s != "" {

--- a/components/model/agenticopenai/responses_convertor_test.go
+++ b/components/model/agenticopenai/responses_convertor_test.go
@@ -529,6 +529,26 @@ func TestReasoningToInputItem(t *testing.T) {
 		assert.Equal(t, "r", item.OfReasoning.ID)
 		assert.True(t, item.OfReasoning.EncryptedContent.Valid())
 		assert.Equal(t, "e", item.OfReasoning.EncryptedContent.Value)
+		assert.Empty(t, item.OfReasoning.Content)
+	})
+
+	mockey.PatchConvey("reasoningToInputItem with content", t, func() {
+		block := schema.NewContentBlock(&schema.Reasoning{
+			Text: "s",
+			OpenAIExtension: &openaischema.ReasoningExtension{
+				Content: []*openaischema.ReasoningContent{
+					{Text: "raw0", Index: ptrOf(0)},
+					{Text: "raw1", Index: ptrOf(1)},
+				},
+			},
+		})
+		setItemID(block, "r")
+		item, err := reasoningToInputItem(block)
+		assert.NoError(t, err)
+		assert.NotNil(t, item.OfReasoning)
+		assert.Len(t, item.OfReasoning.Content, 2)
+		assert.Equal(t, "raw0", item.OfReasoning.Content[0].Text)
+		assert.Equal(t, "raw1", item.OfReasoning.Content[1].Text)
 	})
 }
 
@@ -1000,6 +1020,27 @@ func TestReasoningToContentBlocks(t *testing.T) {
 		assert.Equal(t, "r1", id)
 		assert.NotNil(t, block.Reasoning)
 		assert.Equal(t, "s", block.Reasoning.Text)
+		// No raw reasoning content => no OpenAI extension.
+		assert.Nil(t, block.Reasoning.OpenAIExtension)
+	})
+
+	mockey.PatchConvey("reasoningToContentBlocks with content", t, func() {
+		item := responses.ResponseReasoningItem{
+			ID:      "r1",
+			Status:  "completed",
+			Summary: []responses.ResponseReasoningItemSummary{{Text: "s"}},
+			Content: []responses.ResponseReasoningItemContent{{Text: "raw0"}, {Text: "raw1"}},
+		}
+		block, err := reasoningToContentBlocks(item)
+		assert.NoError(t, err)
+		assert.NotNil(t, block.Reasoning)
+		assert.Equal(t, "s", block.Reasoning.Text)
+		assert.NotNil(t, block.Reasoning.OpenAIExtension)
+		assert.Len(t, block.Reasoning.OpenAIExtension.Content, 2)
+		assert.Equal(t, "raw0", block.Reasoning.OpenAIExtension.Content[0].Text)
+		assert.Nil(t, block.Reasoning.OpenAIExtension.Content[0].Index)
+		assert.Equal(t, "raw1", block.Reasoning.OpenAIExtension.Content[1].Text)
+		assert.Nil(t, block.Reasoning.OpenAIExtension.Content[1].Index)
 	})
 }
 

--- a/components/model/agenticopenai/responses_event_convertor.go
+++ b/components/model/agenticopenai/responses_event_convertor.go
@@ -99,6 +99,10 @@ func receivedStreamingResponse(sr *ssestream.Stream[responses.ResponseStreamEven
 			block, err := receiver.annotationAddedEventToContentBlock(variant)
 			sender.sendBlock(block, err)
 
+		case responses.ResponseReasoningTextDeltaEvent:
+			block := receiver.reasoningTextDeltaEventToContentBlock(variant)
+			sender.sendBlock(block, nil)
+
 		case responses.ResponseReasoningSummaryTextDeltaEvent:
 			block := receiver.reasoningSummaryTextDeltaEventToContentBlock(variant)
 			sender.sendBlock(block, nil)
@@ -781,7 +785,7 @@ func (r *streamReceiver) itemDoneEventShellOutputToContentBlock(outputIdx int64,
 }
 
 func (r *streamReceiver) contentPartAddedEventToContentBlock(ev responses.ResponseContentPartAddedEvent) (block *schema.ContentBlock, err error) {
-	switch ev.Part.AsAny().(type) {
+	switch part := ev.Part.AsAny().(type) {
 	case responses.ResponseOutputText, responses.ResponseOutputRefusal:
 		key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
 		blockIdx := r.getBlockIndex(key)
@@ -796,6 +800,20 @@ func (r *streamReceiver) contentPartAddedEventToContentBlock(ev responses.Respon
 
 		meta := &schema.StreamingMeta{Index: blockIdx}
 		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+
+	case responses.ResponseContentPartAddedEventPartReasoningText:
+		reasoning := &schema.Reasoning{
+			OpenAIExtension: &openai.ReasoningExtension{
+				Content: []*openai.ReasoningContent{
+					{
+						Text:  part.Text,
+						Index: ptrOf(int(ev.ContentIndex)),
+					},
+				},
+			},
+		}
+		meta := &schema.StreamingMeta{Index: r.getBlockIndex(makeReasoningIndexKey(ev.OutputIndex))}
+		block = schema.NewContentBlockChunk(reasoning, meta)
 
 	default:
 		// Unknown content part types are ignored rather than failing the stream.
@@ -823,6 +841,10 @@ func (r *streamReceiver) contentPartDoneEventToContentBlock(ev responses.Respons
 
 		meta := &schema.StreamingMeta{Index: blockIdx}
 		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+
+	case responses.ResponseContentPartDoneEventPartReasoningText:
+		meta := &schema.StreamingMeta{Index: r.getBlockIndex(makeReasoningIndexKey(ev.OutputIndex))}
+		block = schema.NewContentBlockChunk(&schema.Reasoning{}, meta)
 
 	default:
 		// Unknown content part types are ignored rather than failing the stream.
@@ -907,6 +929,28 @@ func (r *streamReceiver) reasoningSummaryTextDeltaEventToContentBlock(ev respons
 
 	reasoning := &schema.Reasoning{
 		Text: text,
+	}
+
+	meta := &schema.StreamingMeta{
+		Index: r.getBlockIndex(makeReasoningIndexKey(ev.OutputIndex)),
+	}
+	block := schema.NewContentBlockChunk(reasoning, meta)
+
+	setItemID(block, ev.ItemID)
+
+	return block
+}
+
+func (r *streamReceiver) reasoningTextDeltaEventToContentBlock(ev responses.ResponseReasoningTextDeltaEvent) *schema.ContentBlock {
+	reasoning := &schema.Reasoning{
+		OpenAIExtension: &openai.ReasoningExtension{
+			Content: []*openai.ReasoningContent{
+				{
+					Text:  ev.Delta,
+					Index: ptrOf(int(ev.ContentIndex)),
+				},
+			},
+		},
 	}
 
 	meta := &schema.StreamingMeta{

--- a/components/model/agenticopenai/responses_event_convertor_test.go
+++ b/components/model/agenticopenai/responses_event_convertor_test.go
@@ -442,6 +442,75 @@ func TestReasoningSummaryTextDeltaEventToContentBlock(t *testing.T) {
 	assert.Equal(t, "iid", id)
 }
 
+func TestReasoningTextDeltaEventToContentBlock(t *testing.T) {
+	r := newStreamReceiver(&model.Options{})
+	ev := responses.ResponseReasoningTextDeltaEvent{
+		ItemID:       "iid",
+		OutputIndex:  2,
+		ContentIndex: 1,
+		Delta:        "raw reasoning text",
+	}
+
+	block := r.reasoningTextDeltaEventToContentBlock(ev)
+	assert.NotNil(t, block.Reasoning)
+	// Raw reasoning text must go to the OpenAI extension, not the summary Text field.
+	assert.Equal(t, "", block.Reasoning.Text)
+	assert.NotNil(t, block.Reasoning.OpenAIExtension)
+	assert.Len(t, block.Reasoning.OpenAIExtension.Content, 1)
+	assert.Equal(t, "raw reasoning text", block.Reasoning.OpenAIExtension.Content[0].Text)
+	assert.NotNil(t, block.Reasoning.OpenAIExtension.Content[0].Index)
+	assert.Equal(t, 1, *block.Reasoning.OpenAIExtension.Content[0].Index)
+
+	id, ok := getItemID(block)
+	assert.True(t, ok)
+	assert.Equal(t, "iid", id)
+}
+
+func TestReasoningTextDeltaEventContentIndexAndSharedBlockIndex(t *testing.T) {
+	r := newStreamReceiver(&model.Options{})
+
+	// Two text deltas at different ContentIndex on the same OutputIndex.
+	b0 := r.reasoningTextDeltaEventToContentBlock(responses.ResponseReasoningTextDeltaEvent{
+		ItemID: "iid", OutputIndex: 2, ContentIndex: 0, Delta: "a",
+	})
+	b1 := r.reasoningTextDeltaEventToContentBlock(responses.ResponseReasoningTextDeltaEvent{
+		ItemID: "iid", OutputIndex: 2, ContentIndex: 1, Delta: "b",
+	})
+	assert.Equal(t, 0, *b0.Reasoning.OpenAIExtension.Content[0].Index)
+	assert.Equal(t, 1, *b1.Reasoning.OpenAIExtension.Content[0].Index)
+
+	// A summary delta and a text delta on the same OutputIndex share the block index,
+	// so they concatenate into one logical reasoning block.
+	summary := r.reasoningSummaryTextDeltaEventToContentBlock(responses.ResponseReasoningSummaryTextDeltaEvent{
+		ItemID: "iid", OutputIndex: 2, SummaryIndex: 0, Delta: "s",
+	})
+	raw0 := r.reasoningTextDeltaEventToContentBlock(responses.ResponseReasoningTextDeltaEvent{
+		ItemID: "iid", OutputIndex: 2, ContentIndex: 0, Delta: "t0",
+	})
+	raw1 := r.reasoningTextDeltaEventToContentBlock(responses.ResponseReasoningTextDeltaEvent{
+		ItemID: "iid", OutputIndex: 2, ContentIndex: 1, Delta: "t1",
+	})
+	assert.Equal(t, summary.StreamingMeta.Index, raw0.StreamingMeta.Index)
+	assert.Equal(t, summary.StreamingMeta.Index, raw1.StreamingMeta.Index)
+
+	// End-to-end concat: the summary and the indexed raw reasoning chunks must
+	// merge into a single reasoning block, with the summary in Reasoning.Text and
+	// the raw content reassembled in order under OpenAIExtension.Content.
+	got, err := schema.ConcatAgenticMessages([]*schema.AgenticMessage{
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{summary}},
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{raw0}},
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{raw1}},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got.ContentBlocks, 1)
+	assert.NotNil(t, got.ContentBlocks[0].Reasoning)
+	assert.Equal(t, "s", got.ContentBlocks[0].Reasoning.Text)
+	assert.NotNil(t, got.ContentBlocks[0].Reasoning.OpenAIExtension)
+	assert.Len(t, got.ContentBlocks[0].Reasoning.OpenAIExtension.Content, 2)
+	assert.Equal(t, "t0", got.ContentBlocks[0].Reasoning.OpenAIExtension.Content[0].Text)
+	assert.Equal(t, "t1", got.ContentBlocks[0].Reasoning.OpenAIExtension.Content[1].Text)
+}
+
 func TestContentPartDoneEventToContentBlockRefusal(t *testing.T) {
 	mockey.PatchConvey("TestContentPartDoneEventToContentBlockRefusal", t, func() {
 		r := newStreamReceiver(&model.Options{})
@@ -461,6 +530,57 @@ func TestContentPartDoneEventToContentBlockRefusal(t *testing.T) {
 		block, err := r.contentPartDoneEventToContentBlock(ev)
 		assert.NoError(t, err)
 		assert.NotNil(t, block.AssistantGenText)
+	})
+}
+
+func TestContentPartAddedEventToContentBlockReasoningText(t *testing.T) {
+	mockey.PatchConvey("TestContentPartAddedEventToContentBlockReasoningText", t, func() {
+		r := newStreamReceiver(&model.Options{})
+		ev := responses.ResponseContentPartAddedEvent{
+			ItemID:       "iid",
+			OutputIndex:  1,
+			ContentIndex: 2,
+		}
+
+		mockey.Mock(responses.ResponseContentPartAddedEventPartUnion.AsAny).
+			Return(responses.ResponseContentPartAddedEventPartReasoningText{Text: "raw"}).Build()
+
+		block, err := r.contentPartAddedEventToContentBlock(ev)
+		assert.NoError(t, err)
+		assert.NotNil(t, block.Reasoning)
+		assert.NotNil(t, block.Reasoning.OpenAIExtension)
+		assert.Len(t, block.Reasoning.OpenAIExtension.Content, 1)
+		assert.Equal(t, "raw", block.Reasoning.OpenAIExtension.Content[0].Text)
+		assert.Equal(t, 2, *block.Reasoning.OpenAIExtension.Content[0].Index)
+
+		id, ok := getItemID(block)
+		assert.True(t, ok)
+		assert.Equal(t, "iid", id)
+	})
+}
+
+func TestContentPartDoneEventToContentBlockReasoningText(t *testing.T) {
+	mockey.PatchConvey("TestContentPartDoneEventToContentBlockReasoningText", t, func() {
+		r := newStreamReceiver(&model.Options{})
+		ev := responses.ResponseContentPartDoneEvent{
+			ItemID:       "iid",
+			OutputIndex:  1,
+			ContentIndex: 2,
+		}
+
+		mockey.Mock(responses.ResponseContentPartDoneEventPartUnion.AsAny).
+			Return(responses.ResponseContentPartDoneEventPartReasoningText{}).Build()
+
+		block, err := r.contentPartDoneEventToContentBlock(ev)
+		assert.NoError(t, err)
+		assert.NotNil(t, block.Reasoning)
+		// Terminator chunk carries no text; deltas already streamed it.
+		assert.Nil(t, block.Reasoning.OpenAIExtension)
+		assert.Equal(t, "", block.Reasoning.Text)
+
+		status, ok := GetItemStatus(block)
+		assert.True(t, ok)
+		assert.Equal(t, string(responses.ResponseStatusCompleted), status)
 	})
 }
 


### PR DESCRIPTION
## Summary

The OpenAI Responses API exposes two distinct reasoning channels: the human-readable **summary** and the model's full **reasoning text**. Previously only the summary was mapped to `schema.Reasoning.Text`; the raw reasoning text channel was dropped. This change maps that channel into eino's `schema.Reasoning.OpenAIExtension` across the streaming, non-streaming, and request-encoding paths, and aligns the Ark (`agenticark`) DoubaoApp block metadata with the same `Index *int` convention required by the bumped eino dependency.

## Breaking Changes

1. **`agenticark`: removed the exported `DoubaoAppStreamingMeta` type.** Callers referencing this type must drop it.
2. **`agenticark`: replaced `DoubaoAppBlock.StreamingMeta *DoubaoAppStreamingMeta` with `DoubaoAppBlock.Index *int`.** The JSON/mapstructure tag changed from `streaming_meta` to `index`. Callers reading or constructing a block's streaming index must use `block.Index` (a `*int`) instead of `block.StreamingMeta.Index`, and any persisted/serialized payloads relying on the `streaming_meta` key must migrate to `index`.

## Key Changes

1. **agenticopenai — reasoning text decode (streaming)**: Added `reasoningTextDeltaEventToContentBlock` to route `ResponseReasoningTextDeltaEvent` into `OpenAIExtension.Content` (with per-part `Index`), keeping it separate from the summary→`Text` mapping. Handled the `content_part.added`/`content_part.done` reasoning-text parts (the former opens the extension block at the correct content index; the latter emits a completion terminator). This also fixes a latent nil-block path for the reasoning-text content part.

2. **agenticopenai — reasoning text decode (non-streaming)**: `reasoningToContentBlocks` now populates `OpenAIExtension.Content` from `ResponseReasoningItem.Content`. Non-streaming content leaves `Index` unset, since there are no chunks to reassemble.

3. **agenticopenai — reasoning text encode (request)**: `reasoningToInputItem` now round-trips `OpenAIExtension.Content` back into `ResponseReasoningItemParam.Content`, so raw reasoning can be passed back to models that require it.

4. **agenticark — DoubaoApp block index**: Replaced `DoubaoAppBlock.StreamingMeta *DoubaoAppStreamingMeta` with `Index *int` and removed the `DoubaoAppStreamingMeta` type, matching the new eino `ReasoningContent.Index *int` convention. Streaming concat logic and index maps updated accordingly.

5. **Dependencies**: Bumped `github.com/cloudwego/eino` in both modules to the revision exposing `ReasoningContent.Index *int` (replacing the removed `StreamingMeta` field).

Test coverage added for the streaming/non-streaming/request reasoning-text paths and the DoubaoApp block index concat.