### PR TITLE
fix(agenticclaude): align direct anthropic auth precedence with sdk behavior

### DIFF
--- a/components/model/agenticclaude/README.md
+++ b/components/model/agenticclaude/README.md
@@ -114,10 +114,14 @@ type Config struct {
     // Optional.
     BaseURL string
 
-    // APIKey is your Anthropic API key
+    // APIKey is your Anthropic API key for direct Anthropic API access.
     // Obtain from: https://console.anthropic.com/account/keys
-    // Required for direct Anthropic API requests.
+    // Optional when AuthToken is set.
     APIKey string
+
+    // AuthToken is your Anthropic auth token for direct Anthropic API access.
+    // Optional when APIKey is set.
+    AuthToken string
 
     // Model specifies which Claude model to use.
     // Required.
@@ -175,6 +179,14 @@ type Config struct {
     CacheControl *anthropic.CacheControlEphemeralParam
 }
 ```
+
+For direct Anthropic API access, authentication resolution works as follows:
+
+- If `Config.APIKey` or `Config.AuthToken` is set, `Config` takes precedence and environment auth settings (e.g. `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`) are ignored.
+- Otherwise, it falls back to environment variables.
+- Within the chosen source, `APIKey` and `AuthToken` can both be set and will both be passed through as-is.
+- If neither source provides auth, client creation still succeeds and auth errors surface later when requests are sent.
+- `ANTHROPIC_BASE_URL` is still honored in both cases; `Config.BaseURL` takes precedence when set.
 
 ## Extension Fields
 

--- a/components/model/agenticclaude/README_zh.md
+++ b/components/model/agenticclaude/README_zh.md
@@ -114,10 +114,14 @@ type Config struct {
     // 可选。
     BaseURL string
 
-    // APIKey 是 Anthropic API 密钥。
+    // APIKey 是 Anthropic API 密钥，用于直连 Anthropic API。
     // 获取地址：https://console.anthropic.com/account/keys
-    // 直接使用 Anthropic API 时必填。
+    // 设置了 AuthToken 时可选。
     APIKey string
+
+    // AuthToken 是 Anthropic auth token，用于直连 Anthropic API。
+    // 设置了 APIKey 时可选。
+    AuthToken string
 
     // Model 指定使用的 Claude 模型。
     // 必填。
@@ -174,6 +178,14 @@ type Config struct {
     CacheControl *anthropic.CacheControlEphemeralParam
 }
 ```
+
+对于直连 Anthropic API 的场景，鉴权配置解析规则如下：
+
+- 如果在 `Config` 中配置了 `APIKey` 或 `AuthToken`，则以 `Config` 为准，并忽略环境变量中的鉴权配置（如 `ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`）
+- 如果 `Config` 中未配置鉴权，则回退使用环境变量中的配置
+- 在被选中的来源内，`APIKey` 和 `AuthToken` 可以同时存在，并会原样一起透传
+- 如果两边都没有配置鉴权，client 仍可创建成功，鉴权错误会在后续实际发请求时暴露
+- 两种情况下均仍支持 `ANTHROPIC_BASE_URL`；设置了 `Config.BaseURL` 时以 `Config.BaseURL` 为准
 
 ## 扩展字段说明
 

--- a/components/model/agenticclaude/model.go
+++ b/components/model/agenticclaude/model.go
@@ -60,10 +60,14 @@ type Config struct {
 	// Optional.
 	BaseURL string
 
-	// APIKey is your Anthropic API key
+	// APIKey is your Anthropic API key for direct Anthropic API access.
 	// Obtain from: https://console.anthropic.com/account/keys
-	// Required for direct Anthropic API requests.
+	// Optional when AuthToken is set.
 	APIKey string
+
+	// AuthToken is your Anthropic auth token for direct Anthropic API access.
+	// Optional when APIKey is set.
+	AuthToken string
 
 	// Model specifies which Claude model to use.
 	// Required.
@@ -197,9 +201,6 @@ func (cfg *Config) check() error {
 	if cfg.Model == "" {
 		return errors.New("model is required")
 	}
-	if cfg.ByBedrock == nil && cfg.ByGoogleVertexAI == nil && cfg.APIKey == "" {
-		return errors.New("api key is required for direct Anthropic API requests")
-	}
 	if cfg.MaxTokens <= 0 {
 		return errors.New("max_tokens must be positive")
 	}
@@ -272,8 +273,22 @@ func newClient(ctx context.Context, cfg *Config) (anthropic.Client, error) {
 
 	default:
 		var opts []option.RequestOption
+		if hasDirectAnthropicConfigAuth(cfg) {
+			// Explicit credential in Config takes precedence: disable the
+			// SDK's environment credential autoload (ANTHROPIC_API_KEY,
+			// ANTHROPIC_AUTH_TOKEN, profiles, etc.) so the environment cannot
+			// contribute a second, conflicting credential.
+			// ANTHROPIC_BASE_URL is still honored; cfg.BaseURL overrides it below.
+			opts = append(opts, option.WithoutEnvironmentDefaults())
+			if baseURL, ok := os.LookupEnv("ANTHROPIC_BASE_URL"); ok {
+				opts = append(opts, option.WithBaseURL(baseURL))
+			}
+		}
 		if cfg.APIKey != "" {
 			opts = append(opts, option.WithAPIKey(cfg.APIKey))
+		}
+		if cfg.AuthToken != "" {
+			opts = append(opts, option.WithAuthToken(cfg.AuthToken))
 		}
 		if cfg.BaseURL != "" {
 			opts = append(opts, option.WithBaseURL(cfg.BaseURL))
@@ -283,6 +298,10 @@ func newClient(ctx context.Context, cfg *Config) (anthropic.Client, error) {
 		}
 		return anthropic.NewClient(opts...), nil
 	}
+}
+
+func hasDirectAnthropicConfigAuth(cfg *Config) bool {
+	return cfg.APIKey != "" || cfg.AuthToken != ""
 }
 
 func (m *Model) Generate(ctx context.Context, input []*schema.AgenticMessage, opts ...model.Option) (outMsg *schema.AgenticMessage, err error) {

--- a/components/model/agenticclaude/model_test.go
+++ b/components/model/agenticclaude/model_test.go
@@ -18,6 +18,9 @@ package agenticclaude
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -499,7 +502,7 @@ func TestConfigAndModelBasics(t *testing.T) {
 		}
 
 		err = (&Config{Model: "claude-sonnet-4"}).check()
-		if err == nil || err.Error() != "api key is required for direct Anthropic API requests" {
+		if err == nil || err.Error() != "max_tokens must be positive" {
 			t.Fatalf("check() error = %v", err)
 		}
 
@@ -553,6 +556,106 @@ func TestConfigAndModelBasics(t *testing.T) {
 			t.Fatalf("newClient() error = %v", err)
 		}
 	})
+}
+
+func TestDirectAnthropicAuthSelection(t *testing.T) {
+	t.Run("config auth exists", func(t *testing.T) {
+		clearAnthropicAuthEnv(t)
+		if !hasDirectAnthropicConfigAuth(&Config{APIKey: "api-key"}) {
+			t.Fatalf("hasDirectAnthropicConfigAuth(APIKey) should be true")
+		}
+		if !hasDirectAnthropicConfigAuth(&Config{AuthToken: "auth-token"}) {
+			t.Fatalf("hasDirectAnthropicConfigAuth(AuthToken) should be true")
+		}
+		if !hasDirectAnthropicConfigAuth(&Config{APIKey: "api-key", AuthToken: "auth-token"}) {
+			t.Fatalf("hasDirectAnthropicConfigAuth(both) should be true")
+		}
+		if hasDirectAnthropicConfigAuth(&Config{}) {
+			t.Fatalf("hasDirectAnthropicConfigAuth(empty) should be false")
+		}
+	})
+
+	t.Run("env auth exists", func(t *testing.T) {
+		clearAnthropicAuthEnv(t)
+		t.Setenv("ANTHROPIC_API_KEY", "env-api-key")
+		m, err := New(context.Background(), &Config{
+			Model:     "claude-sonnet-4",
+			MaxTokens: 1024,
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if m == nil {
+			t.Fatalf("New() returned nil model")
+		}
+	})
+
+	t.Run("missing auth still allows creation", func(t *testing.T) {
+		clearAnthropicAuthEnv(t)
+		m, err := New(context.Background(), &Config{
+			Model:     "claude-sonnet-4",
+			MaxTokens: 1024,
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		if m == nil {
+			t.Fatalf("New() returned nil model")
+		}
+	})
+
+	t.Run("config auth shields env auth", func(t *testing.T) {
+		clearAnthropicAuthEnv(t)
+		t.Setenv("ANTHROPIC_AUTH_TOKEN", "env-auth-token")
+
+		var gotAuthorization, gotAPIKey string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuthorization = r.Header.Get("Authorization")
+			gotAPIKey = r.Header.Get("X-Api-Key")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+		}))
+		defer srv.Close()
+
+		m, err := New(context.Background(), &Config{
+			BaseURL:   srv.URL,
+			APIKey:    "config-api-key",
+			Model:     "claude-sonnet-4",
+			MaxTokens: 1024,
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+
+		_, err = m.Generate(context.Background(), []*schema.AgenticMessage{
+			schema.UserAgenticMessage("hello"),
+		})
+		if err != nil {
+			t.Fatalf("Generate() error = %v", err)
+		}
+
+		if gotAPIKey != "config-api-key" {
+			t.Fatalf("X-Api-Key = %q, want %q", gotAPIKey, "config-api-key")
+		}
+		if gotAuthorization != "" {
+			t.Fatalf("Authorization = %q, env credential should not leak into the request", gotAuthorization)
+		}
+	})
+}
+
+func clearAnthropicAuthEnv(t *testing.T) {
+	t.Helper()
+	// Use os.Unsetenv to truly remove the env vars, since the SDK uses
+	// os.LookupEnv — an empty string is still "present".
+	for _, key := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_PROFILE", "ANTHROPIC_BASE_URL"} {
+		prev, existed := os.LookupEnv(key)
+		os.Unsetenv(key)
+		if existed {
+			t.Cleanup(func() { os.Setenv(key, prev) })
+		} else {
+			t.Cleanup(func() { os.Unsetenv(key) })
+		}
+	}
 }
 
 func TestOptionAndUtilsHelpers(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

fix

## What this PR does / why we need it (en: English/zh: Chinese):

en: When `Config.APIKey` is explicitly set, `anthropic.NewClient` still auto-loads credentials from the environment (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, profiles, etc.). The worst case is `ANTHROPIC_AUTH_TOKEN`: it injects `Authorization: Bearer <env-token>` while `Config.APIKey` only sets `X-Api-Key` — two different headers — so the request carries two different credentials at once, and gateways that prefer `Authorization` silently authenticate with the environment token instead of the explicitly configured one.

This PR mirrors the fix already applied to the `claude` component in #759:

- Pass `option.WithoutEnvironmentDefaults()` whenever `Config` carries a credential, so explicit configuration always takes precedence and the environment cannot contribute a second credential (`ANTHROPIC_BASE_URL` is still honored; `Config.BaseURL` overrides it).
- Add `Config.AuthToken` (`Authorization: Bearer`, `option.WithAuthToken`) so gateway users can authenticate the standard bearer way without resorting to `CustomHeaders`.
- Relax `check()` to no longer require `APIKey` for direct API access: when `Config` carries no credential, the SDK falls back to environment variables, matching the `claude` component behavior.
- Add `TestDirectAnthropicAuthSelection`, including an httptest-based regression test asserting that an env `ANTHROPIC_AUTH_TOKEN` does not leak into requests when `Config.APIKey` is set.
- Document the auth resolution rules in README.md / README_zh.md.

Note: unlike #759 which had to hand-roll `newDirectAnthropicClient` (SDK v1.26.0 lacked the option), agenticclaude depends on SDK v1.42.0 where `option.WithoutEnvironmentDefaults()` is natively supported, so the implementation is simpler with equivalent behavior.

zh: 当显式设置 `Config.APIKey` 时，`anthropic.NewClient` 仍会从环境变量自动加载凭证（`ANTHROPIC_API_KEY`、`ANTHROPIC_AUTH_TOKEN`、profile 等）。最严重的情况是 `ANTHROPIC_AUTH_TOKEN`：它注入 `Authorization: Bearer` 头，而 `Config.APIKey` 只设置 `X-Api-Key` 头，两者互不覆盖，导致请求同时携带两份不同凭证，偏好 `Authorization` 的网关会静默使用环境变量中的 token 而非代码中显式配置的密钥。

本 PR 对标 #759 中对 `claude` 组件的修复：

- 当 `Config` 中携带凭证时传入 `option.WithoutEnvironmentDefaults()`，确保显式配置优先，环境变量不会注入第二份凭证（仍支持 `ANTHROPIC_BASE_URL`，`Config.BaseURL` 优先）。
- 新增 `Config.AuthToken`（`Authorization: Bearer`，`option.WithAuthToken`），网关用户无需通过 `CustomHeaders` 即可使用标准 bearer 鉴权。
- 放宽 `check()`：直连模式不再强制要求 `APIKey`，`Config` 无凭证时回退环境变量，与 `claude` 组件行为一致。
- 新增 `TestDirectAnthropicAuthSelection`，包含基于 httptest 的回归测试，断言设置 `Config.APIKey` 时环境变量 `ANTHROPIC_AUTH_TOKEN` 不会泄漏到请求中。
- 在 README.md / README_zh.md 中补充鉴权解析规则说明。

## Which issue(s) this PR fixes:

Fixes the issue where explicit `agenticclaude.Config.APIKey` is silently overridden by `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)