### PR TITLE
docs(skills): add copy-on-write guidance for shared stream elements

### DIFF
--- a/skills/eino-agent/SKILL.md
+++ b/skills/eino-agent/SKILL.md
@@ -309,6 +309,7 @@ Key pattern: tool returns `compose.Interrupt(ctx, info)` to pause, then `runner.
 - Default to `ChatModelAgent` for most use cases (single agent with tools)
 - Use `Runner` to execute agents -- never call `agent.Run()` directly in production
 - Middleware order matters: PatchToolCalls first, then Reduction, then Summarization
+- Never mutate messages received in middleware or stream callbacks in place (especially `msg.Extra[k] = v`) -- stream fan-out shares message pointers across consumers and in-place writes can cause concurrent map read/write panics; shallow-copy the message, clone the map/slice you change, and use the copy (see reference/middleware.md)
 - Use `DeepAgent` (`adk/prebuilt/deep`) when you need built-in planning + filesystem + sub-agents
 - Use `AgentAsTool` or DeepAgents' SubAgents when a sub-agent needs isolated context (no shared history)
 - Use `TurnLoop` when building interactive applications that need preemption, idle management, or push-based input

--- a/skills/eino-agent/reference/middleware.md
+++ b/skills/eino-agent/reference/middleware.md
@@ -21,6 +21,21 @@ type ChatModelAgentMiddleware = TypedChatModelAgentMiddleware[*schema.Message]
 
 Embed `*adk.BaseChatModelAgentMiddleware` to get default no-op implementations and only override what you need.
 
+**Never mutate received messages in place.** Messages reaching middleware (in state, model responses, or streams) may be shared with other consumers — stream fan-out (`StreamReader.Copy`) copies readers, not elements, so multiple branches hold the same `*schema.Message` / `*schema.AgenticMessage` pointer. Writing to one (especially map fields: `msg.Extra[k] = v`) can cause `concurrent map read/write` panics. To modify a message, use copy-on-write: shallow-copy it, clone the map/slice field you change, modify the clone, and use the copy:
+
+```go
+cp := *msg // shallow copy
+extra := make(map[string]any, len(msg.Extra)+1)
+for k, v := range msg.Extra {
+    extra[k] = v
+}
+extra["myKey"] = myValue
+cp.Extra = extra
+// use &cp downstream; do NOT touch msg
+```
+
+This applies especially to `WrapModel` wrappers that transform the response stream (e.g. via `schema.StreamReaderWithConvert`) and to `BeforeModelRewriteState`/`AfterModelRewriteState` handlers that edit messages in state.
+
 ## Execution Flow
 
 ```

--- a/skills/eino-compose/SKILL.md
+++ b/skills/eino-compose/SKILL.md
@@ -188,10 +188,11 @@ When helping users build orchestration:
 1. Default to **Graph** for most use cases. Use Chain only for simple linear pipelines. Use Workflow when field-level mapping between different struct types is needed.
 2. Always show the **Compile** step -- `g.Compile(ctx)` returns `Runnable[I,O]`.
 3. Always **close StreamReaders** -- use `defer sr.Close()` immediately after obtaining a stream.
-4. Upstream output type must match downstream input type (or use `WithInputKey`/`WithOutputKey` for map conversion).
-5. For cyclic graphs (e.g., ReAct agent), use default Pregel mode (`AnyPredecessor`). For DAGs, set `AllPredecessor`.
-6. Use `compose.WithCallbacks(handler)` to inject logging/tracing at runtime.
-7. Use `compose.WithCheckPointStore(store)` with interrupt nodes for pause/resume workflows.
+4. **Never mutate stream elements in place** -- `StreamReader.Copy` fan-out shares element pointers across branches, so writing to a received message (especially `msg.Extra[k] = v`) can cause concurrent map read/write panics. Use copy-on-write: shallow-copy the message, clone the map/slice you change, modify the clone, return the copy. See reference/stream.md.
+5. Upstream output type must match downstream input type (or use `WithInputKey`/`WithOutputKey` for map conversion).
+6. For cyclic graphs (e.g., ReAct agent), use default Pregel mode (`AnyPredecessor`). For DAGs, set `AllPredecessor`.
+7. Use `compose.WithCallbacks(handler)` to inject logging/tracing at runtime.
+8. Use `compose.WithCheckPointStore(store)` with interrupt nodes for pause/resume workflows.
 
 ## Reference Files
 

--- a/skills/eino-compose/reference/stream.md
+++ b/skills/eino-compose/reference/stream.md
@@ -53,6 +53,8 @@ copies := sr.Copy(n int) []*StreamReader[T]
 // Original reader becomes unusable after Copy
 ```
 
+**WARNING — Copy duplicates readers, NOT elements.** For pointer elements (e.g. `*schema.Message`), all branches receive the same object and may consume it concurrently. Treat received elements as read-only; never mutate them in place (especially map fields like `msg.Extra[k] = v`), or you risk concurrent map read/write panics. See "Never Mutate Stream Elements In Place" below.
+
 ### Merge (fan-in)
 
 ```go
@@ -78,6 +80,36 @@ strReader := schema.StreamReaderWithConvert(intReader,
     },
 )
 ```
+
+The convert callback must NOT modify its input in place — the element may be shared with other stream branches (see Copy above). Return a new value instead.
+
+### Never Mutate Stream Elements In Place
+
+Stream elements flowing through Graph/Chain/Workflow are routinely fanned out via `Copy` (callbacks, branches), so a `*schema.Message` / `*schema.AgenticMessage` you receive in a convert callback, callback handler, or middleware may be read concurrently by other goroutines. In-place writes — especially to map fields like `Extra` — cause `concurrent map read/write` panics.
+
+Always use copy-on-write:
+
+```go
+// WRONG: mutates a shared message
+schema.StreamReaderWithConvert(sr, func(msg *schema.Message) (*schema.Message, error) {
+    msg.Extra["trace_id"] = traceID // may panic: concurrent map read/write
+    return msg, nil
+})
+
+// RIGHT: shallow-copy the message, clone the map you change, modify the clone
+schema.StreamReaderWithConvert(sr, func(msg *schema.Message) (*schema.Message, error) {
+    cp := *msg // shallow copy
+    extra := make(map[string]any, len(msg.Extra)+1)
+    for k, v := range msg.Extra {
+        extra[k] = v
+    }
+    extra["trace_id"] = traceID
+    cp.Extra = extra
+    return &cp, nil
+})
+```
+
+The same rule applies to any map/slice field you modify (`ToolCalls`, `ContentBlocks`, nested `Extra` on `ToolCall`/`ContentBlock`, ...): clone the field before writing, and return the copy.
 
 ### From Array
 

--- a/skills/eino-guide/SKILL.md
+++ b/skills/eino-guide/SKILL.md
@@ -131,3 +131,4 @@ Shared data types used across all layers:
 3. For component implementation details, always read the provider's reference file before generating code. Do not assume constructor or config naming conventions.
 4. Prefer ADK (ChatModelAgent + Runner) for agent use cases over manually building ReAct loops with compose graphs. For interactive multi-turn applications needing preemption and lifecycle management, recommend TurnLoop.
 5. When showing streaming code, always include `defer stream.Close()`.
+6. When generating code that modifies messages received from streams, callbacks, or middleware, never mutate them in place (especially `msg.Extra[k] = v`) -- stream fan-out shares message pointers across consumers and in-place writes can cause concurrent map read/write panics. Use copy-on-write: shallow-copy the message, clone the map/slice you change, return the copy (see reference/schema.md).

--- a/skills/eino-guide/reference/schema.md
+++ b/skills/eino-guide/reference/schema.md
@@ -22,6 +22,8 @@ type Message struct {
 }
 ```
 
+A `*Message` received from a stream or shared pipeline may be read concurrently by other consumers -- treat it as read-only. Never write `msg.Extra[k] = v` on a message you did not create; shallow-copy the message and clone `Extra` first (see StreamReader Key Rules below).
+
 ### Roles
 
 | Role | Constant | Purpose |
@@ -71,6 +73,8 @@ type AgenticMessage struct {
     Extra         map[string]any
 }
 ```
+
+The same read-only rule as `Message` applies: an `*AgenticMessage` from a stream may be shared with concurrent consumers, so never mutate it (or its `Extra` / `ContentBlocks`) in place -- copy-on-write instead.
 
 ### Roles
 
@@ -242,3 +246,4 @@ reader := schema.StreamReaderFromArray(items)
 - **Always `defer stream.Close()`** -- failing to close causes resource leaks
 - **Single consumer** -- a StreamReader can only be read by one goroutine
 - **EOF signals completion** -- `errors.Is(err, io.EOF)` means the stream ended normally
+- **Treat received elements as read-only** -- `StreamReader.Copy` fan-out duplicates readers, not elements, so a `*Message`/`*AgenticMessage` received from a stream may be shared with other branches reading concurrently. Never write to it in place (especially `msg.Extra[k] = v` -- concurrent map read/write panic). To modify: shallow-copy the message, clone the map/slice field you change, modify the clone, pass the copy downstream


### PR DESCRIPTION
## What this PR does

Adds guidance to the eino skills (`skills/eino-compose`, `skills/eino-agent`, `skills/eino-guide`) about a recurring concurrency pitfall: eino's `StreamReader.Copy` fan-out duplicates **readers, not elements**, so `*schema.Message` / `*schema.AgenticMessage` pointers are shared across branches and may be consumed concurrently. Mutating a received message in place — especially map fields like `msg.Extra[k] = v` — causes `concurrent map read/write` panics.

The rule taught everywhere: **copy-on-write** — shallow-copy the message, clone the map/slice field you change, modify the clone, return the copy.

Docs-only change.

## Where the guidance was added

**eino-compose**
- `SKILL.md`: new rule in "Instructions to Agent" (list renumbered)
- `reference/stream.md`: warning on `Copy` (fan-out shares element pointers), note on `StreamReaderWithConvert` (convert must not mutate its input), and a new "Never Mutate Stream Elements In Place" section with WRONG/RIGHT code examples

**eino-agent**
- `SKILL.md`: new rule in "Instructions to Agent"
- `reference/middleware.md`: "Never mutate received messages in place" section after the interface definition, with a copy-on-write example, calling out `WrapModel` stream transforms and `Before/AfterModelRewriteState` handlers

**eino-guide**
- `SKILL.md`: new rule in "Instructions to Agent"
- `reference/schema.md`: read-only notes on the `Message` and `AgenticMessage` struct docs, plus a new entry in StreamReader "Key Rules"

## Why

Users (and agents following these skills) commonly attach metadata via `msg.Extra[k] = v` in stream convert callbacks and ADK middleware, which intermittently panics under fan-out. Whichever entry point they consult — schema types, stream API, or middleware — they now see the copy-on-write rule first.

Companion to cloudwego/eino#1074, which adds the same guidance to the GoDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)