### PR TITLE
feat(claude): support Vertex service account JSON credentials

### DIFF
--- a/components/model/claude/README.md
+++ b/components/model/claude/README.md
@@ -58,6 +58,13 @@ func main() {
 		// AccessKey:       "",
 		// SecretAccessKey: "",
 		// Region:          "us-west-2",
+
+		// if you want to use Google Vertex AI, set ByVertex: true.
+		// For BYOS, pass raw service account JSON via VertexServiceAccountJSON.
+		// ByVertex:                 true,
+		// VertexProjectID:          "my-gcp-project",
+		// VertexRegion:             "us-east5",
+		// VertexServiceAccountJSON: serviceAccountJSON,
 		APIKey: apiKey,
 		// Model:     "claude-3-5-sonnet-20240620",
 		BaseURL:   baseURLPtr,
@@ -137,6 +144,22 @@ type Config struct {
     // Obtain from: https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html
     // Optional for Bedrock
     Region string
+
+    // ByVertex indicates whether to use Google Vertex AI
+    ByVertex bool
+
+    // VertexProjectID is your Google Cloud project ID.
+    // If not set, auto-detected from ANTHROPIC_VERTEX_PROJECT_ID, GOOGLE_CLOUD_PROJECT, or GCLOUD_PROJECT
+    VertexProjectID string
+
+    // VertexRegion is the Vertex AI region (e.g., "us-east5").
+    // If not set, auto-detected from CLOUD_ML_REGION environment variable.
+    VertexRegion string
+
+    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex BYOS.
+    // When non-empty, credentials are built in-memory and passed to vertex.WithCredentials.
+    // When empty and ByVertex is true, vertex.WithGoogleAuth (ADC) is used instead.
+    VertexServiceAccountJSON []byte
     
     // BaseURL is the custom API endpoint URL
     // Use this to specify a different API endpoint, e.g., for proxies or enterprise setups
@@ -199,6 +222,12 @@ For direct Anthropic API access, authentication resolution works as follows:
 - Otherwise, it falls back to environment variables.
 - Within the chosen source, `APIKey` and `AuthToken` can both be set and will both be passed through as-is.
 - If neither source provides auth, client creation still succeeds and auth errors surface later when requests are sent.
+
+For Google Vertex AI, authentication resolution works as follows:
+
+- Set `ByVertex: true` and provide `VertexProjectID` / `VertexRegion`, or rely on the environment variables documented on `Config`.
+- When `VertexServiceAccountJSON` is set, credentials are built in-memory via `google.CredentialsFromJSON` and passed to `vertex.WithCredentials` (no ADC or env vars required for auth).
+- When `VertexServiceAccountJSON` is empty, `vertex.WithGoogleAuth` (Application Default Credentials) is used.
 
 
 

--- a/components/model/claude/README.md
+++ b/components/model/claude/README.md
@@ -60,7 +60,7 @@ func main() {
 		// Region:          "us-west-2",
 
 		// if you want to use Google Vertex AI, set ByVertex: true.
-		// For BYOS, pass raw service account JSON via VertexServiceAccountJSON.
+		// Pass raw service account JSON via VertexServiceAccountJSON for explicit credentials.
 		// ByVertex:                 true,
 		// VertexProjectID:          "my-gcp-project",
 		// VertexRegion:             "us-east5",
@@ -156,7 +156,7 @@ type Config struct {
     // If not set, auto-detected from CLOUD_ML_REGION environment variable.
     VertexRegion string
 
-    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex BYOS.
+    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex.
     // When non-empty, credentials are built in-memory and passed to vertex.WithCredentials.
     // When empty and ByVertex is true, vertex.WithGoogleAuth (ADC) is used instead.
     VertexServiceAccountJSON []byte

--- a/components/model/claude/README_zh.md
+++ b/components/model/claude/README_zh.md
@@ -60,7 +60,7 @@ func main() {
 		// Region:          "us-west-2",
 
 		// 如需使用 Google Vertex AI，设置 ByVertex: true。
-		// BYOS 场景可通过 VertexServiceAccountJSON 传入原始 service account JSON。
+		// 可通过 VertexServiceAccountJSON 传入原始 service account JSON 以显式配置凭证。
 		// ByVertex:                 true,
 		// VertexProjectID:          "my-gcp-project",
 		// VertexRegion:             "us-east5",
@@ -155,7 +155,7 @@ type Config struct {
     // If not set, auto-detected from CLOUD_ML_REGION environment variable.
     VertexRegion string
 
-    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex BYOS.
+    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex.
     // When non-empty, credentials are built in-memory and passed to vertex.WithCredentials.
     // When empty and ByVertex is true, vertex.WithGoogleAuth (ADC) is used instead.
     VertexServiceAccountJSON []byte

--- a/components/model/claude/README_zh.md
+++ b/components/model/claude/README_zh.md
@@ -53,11 +53,18 @@ func main() {
 
 	// Create a Claude model
 	cm, err := claude.NewChatModel(ctx, &claude.Config{
-		// if you want to use Aws Bedrock Service, set these four field.
+		// 如需使用 AWS Bedrock，设置以下字段。
 		// ByBedrock:       true,
 		// AccessKey:       "",
 		// SecretAccessKey: "",
 		// Region:          "us-west-2",
+
+		// 如需使用 Google Vertex AI，设置 ByVertex: true。
+		// BYOS 场景可通过 VertexServiceAccountJSON 传入原始 service account JSON。
+		// ByVertex:                 true,
+		// VertexProjectID:          "my-gcp-project",
+		// VertexRegion:             "us-east5",
+		// VertexServiceAccountJSON: serviceAccountJSON,
 		APIKey: apiKey,
 		// Model:     "claude-3-5-sonnet-20240620",
 		BaseURL:   baseURLPtr,
@@ -136,6 +143,22 @@ type Config struct {
     // Obtain from: https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html
     // Optional for Bedrock
     Region string
+
+    // ByVertex indicates whether to use Google Vertex AI
+    ByVertex bool
+
+    // VertexProjectID is your Google Cloud project ID.
+    // If not set, auto-detected from ANTHROPIC_VERTEX_PROJECT_ID, GOOGLE_CLOUD_PROJECT, or GCLOUD_PROJECT
+    VertexProjectID string
+
+    // VertexRegion is the Vertex AI region (e.g., "us-east5").
+    // If not set, auto-detected from CLOUD_ML_REGION environment variable.
+    VertexRegion string
+
+    // VertexServiceAccountJSON is raw GCP service account JSON for Vertex BYOS.
+    // When non-empty, credentials are built in-memory and passed to vertex.WithCredentials.
+    // When empty and ByVertex is true, vertex.WithGoogleAuth (ADC) is used instead.
+    VertexServiceAccountJSON []byte
     
     // BaseURL is the custom API endpoint URL
     // Use this to specify a different API endpoint, e.g., for proxies or enterprise setups
@@ -198,6 +221,12 @@ type Config struct {
 - 如果 `Config` 中未配置鉴权，则回退使用环境变量中的配置
 - 在被选中的来源内，`APIKey` 和 `AuthToken` 可以同时存在，并会原样一起透传
 - 如果两边都没有配置鉴权，client 仍可创建成功，鉴权错误会在后续实际发请求时暴露
+
+对于 Google Vertex AI，鉴权解析规则如下：
+
+- 设置 `ByVertex: true` 并提供 `VertexProjectID` / `VertexRegion`，或依赖 `Config` 中说明的环境变量自动检测。
+- 当设置了 `VertexServiceAccountJSON` 时，通过 `google.CredentialsFromJSON` 在内存中构建凭证，并传给 `vertex.WithCredentials`（无需 ADC 或环境变量鉴权）。
+- 当 `VertexServiceAccountJSON` 为空时，使用 `vertex.WithGoogleAuth`（Application Default Credentials）。
 
 ## 示例
 

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -83,7 +83,7 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 			return nil, errors.New("ByVertex is true but no region provided; set VertexRegion or CLOUD_ML_REGION")
 		}
 		if len(config.VertexServiceAccountJSON) > 0 {
-			googleCreds, err := google.CredentialsFromJSONWithType(ctx, config.VertexServiceAccountJSON, google.ServiceAccount,
+			googleCreds, err := google.CredentialsFromJSON(ctx, config.VertexServiceAccountJSON,
 				"https://www.googleapis.com/auth/cloud-platform")
 			if err != nil {
 				return nil, fmt.Errorf("create vertex credentials from service account JSON: %w", err)

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -83,6 +83,9 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 			return nil, errors.New("ByVertex is true but no region provided; set VertexRegion or CLOUD_ML_REGION")
 		}
 		if len(config.VertexServiceAccountJSON) > 0 {
+			// CredentialsFromJSON requires an explicit scope; cloud-platform covers Vertex AI.
+			// The ADC path (WithGoogleAuth) omits scopes and lets FindDefaultCredentials
+			// resolve them from the runtime environment instead.
 			googleCreds, err := google.CredentialsFromJSON(ctx, config.VertexServiceAccountJSON,
 				"https://www.googleapis.com/auth/cloud-platform")
 			if err != nil {

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -34,6 +34,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/vertex"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"golang.org/x/oauth2/google"
 	"github.com/eino-contrib/jsonschema"
 
 	"github.com/cloudwego/eino/components"
@@ -81,7 +82,16 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 		if region == "" {
 			return nil, errors.New("ByVertex is true but no region provided; set VertexRegion or CLOUD_ML_REGION")
 		}
-		cli = anthropic.NewClient(vertex.WithGoogleAuth(ctx, region, projectID))
+		if len(config.VertexServiceAccountJSON) > 0 {
+			googleCreds, err := google.CredentialsFromJSONWithType(ctx, config.VertexServiceAccountJSON, google.ServiceAccount,
+				"https://www.googleapis.com/auth/cloud-platform")
+			if err != nil {
+				return nil, fmt.Errorf("create vertex credentials from service account JSON: %w", err)
+			}
+			cli = anthropic.NewClient(vertex.WithCredentials(ctx, region, projectID, googleCreds))
+		} else {
+			cli = anthropic.NewClient(vertex.WithGoogleAuth(ctx, region, projectID))
+		}
 	} else if config.ByBedrock {
 		// Use AWS Bedrock
 		var opts []func(*awsConfig.LoadOptions) error
@@ -204,6 +214,12 @@ type Config struct {
 	// If not set, auto-detected from CLOUD_ML_REGION environment variable.
 	// See: https://claude.ai/docs/en/google-vertex-ai
 	VertexRegion string
+
+	// VertexServiceAccountJSON is raw GCP service account JSON for Vertex.
+	// When non-empty, credentials are built in-memory and passed to vertex.WithCredentials.
+	// When empty and ByVertex is true, vertex.WithGoogleAuth (ADC) is used instead.
+	// Optional for Vertex.
+	VertexServiceAccountJSON []byte
 
 	// BaseURL is the custom API endpoint URL
 	// Use this to specify a different API endpoint, e.g., for proxies or enterprise setups

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1207,3 +1207,28 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 		assert.Len(t, params.Messages[2].Content, 2)
 	})
 }
+
+func TestVertexServiceAccountJSON(t *testing.T) {
+	ctx := context.Background()
+	base := &Config{
+		ByVertex:        true,
+		VertexProjectID: "test-project",
+		VertexRegion:    "us-east5",
+		Model:           "claude-3-opus-20240229",
+		MaxTokens:       1,
+	}
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		cfg := *base
+		cfg.VertexServiceAccountJSON = []byte(`not-json`)
+		_, err := NewChatModel(ctx, &cfg)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "create vertex credentials from service account JSON")
+	})
+
+	t.Run("ADC path when service account JSON empty", func(t *testing.T) {
+		model, err := NewChatModel(ctx, base)
+		assert.NoError(t, err)
+		assert.NotNil(t, model)
+	})
+}

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1228,9 +1228,15 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 	})
 
 	t.Run("ADC path when service account JSON empty", func(t *testing.T) {
-		model, err := NewChatModel(ctx, base)
-		assert.NoError(t, err)
-		assert.NotNil(t, model)
+		mockey.PatchConvey("", t, func() {
+			mockey.Mock(google.FindDefaultCredentials).Return(&google.Credentials{
+				ProjectID: "from-adc",
+			}, nil).Build()
+
+			model, err := NewChatModel(ctx, base)
+			assert.NoError(t, err)
+			assert.NotNil(t, model)
+		})
 	})
 
 	t.Run("service account JSON uses WithCredentials path", func(t *testing.T) {

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -32,6 +32,7 @@ import (
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	"github.com/cloudwego/eino/schema"
+	"golang.org/x/oauth2/google"
 )
 
 func TestDirectAnthropicAuthSelection(t *testing.T) {
@@ -1230,5 +1231,19 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 		model, err := NewChatModel(ctx, base)
 		assert.NoError(t, err)
 		assert.NotNil(t, model)
+	})
+
+	t.Run("service account JSON uses WithCredentials path", func(t *testing.T) {
+		mockey.PatchConvey("", t, func() {
+			mockey.Mock(google.CredentialsFromJSON).Return(&google.Credentials{
+				ProjectID: "from-sa",
+			}, nil).Build()
+
+			cfg := *base
+			cfg.VertexServiceAccountJSON = []byte(`{"type":"service_account","project_id":"from-sa"}`)
+			model, err := NewChatModel(ctx, &cfg)
+			assert.NoError(t, err)
+			assert.NotNil(t, model)
+		})
 	})
 }

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1231,26 +1231,45 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 
 	t.Run("ADC path when service account JSON empty", func(t *testing.T) {
 		mockey.PatchConvey("", t, func() {
-			mockey.Mock(vertex.WithGoogleAuth).Return(option.WithAPIKey("adc-test")).Build()
+			var calledWithGoogleAuth bool
+			mockey.Mock(vertex.WithGoogleAuth).To(func(ctx context.Context, region, projectID string, scopes ...string) option.RequestOption {
+				calledWithGoogleAuth = true
+				assert.Equal(t, "us-east5", region)
+				assert.Equal(t, "test-project", projectID)
+				return option.WithAPIKey("adc-test")
+			}).Build()
 
 			model, err := NewChatModel(ctx, base)
 			assert.NoError(t, err)
 			assert.NotNil(t, model)
+			assert.True(t, calledWithGoogleAuth, "expected vertex.WithGoogleAuth to be called for ADC path")
 		})
 	})
 
 	t.Run("service account JSON uses WithCredentials path", func(t *testing.T) {
 		mockey.PatchConvey("", t, func() {
-			mockey.Mock(google.CredentialsFromJSON).Return(&google.Credentials{
-				ProjectID: "from-sa",
-			}, nil).Build()
-			mockey.Mock(vertex.WithCredentials).Return(option.WithAPIKey("sa-test")).Build()
+			var calledCredentialsFromJSON bool
+			var calledWithCredentials bool
+			mockey.Mock(google.CredentialsFromJSON).To(func(ctx context.Context, jsonData []byte, scopes ...string) (*google.Credentials, error) {
+				calledCredentialsFromJSON = true
+				assert.Equal(t, []string{"https://www.googleapis.com/auth/cloud-platform"}, scopes)
+				return &google.Credentials{ProjectID: "from-sa"}, nil
+			}).Build()
+			mockey.Mock(vertex.WithCredentials).To(func(ctx context.Context, region, projectID string, creds *google.Credentials) option.RequestOption {
+				calledWithCredentials = true
+				assert.Equal(t, "us-east5", region)
+				assert.Equal(t, "test-project", projectID)
+				assert.Equal(t, "from-sa", creds.ProjectID)
+				return option.WithAPIKey("sa-test")
+			}).Build()
 
 			cfg := *base
 			cfg.VertexServiceAccountJSON = []byte(`{"type":"service_account","project_id":"from-sa"}`)
 			model, err := NewChatModel(ctx, &cfg)
 			assert.NoError(t, err)
 			assert.NotNil(t, model)
+			assert.True(t, calledCredentialsFromJSON, "expected google.CredentialsFromJSON to be called for service account path")
+			assert.True(t, calledWithCredentials, "expected vertex.WithCredentials to be called for service account path")
 		})
 	})
 }

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1248,13 +1248,10 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 
 	t.Run("service account JSON uses WithCredentials path", func(t *testing.T) {
 		mockey.PatchConvey("", t, func() {
-			var calledCredentialsFromJSON bool
 			var calledWithCredentials bool
-			mockey.Mock(google.CredentialsFromJSON).To(func(ctx context.Context, jsonData []byte, scopes ...string) (*google.Credentials, error) {
-				calledCredentialsFromJSON = true
-				assert.Equal(t, []string{"https://www.googleapis.com/auth/cloud-platform"}, scopes)
-				return &google.Credentials{ProjectID: "from-sa"}, nil
-			}).Build()
+			mockey.Mock(google.CredentialsFromJSON).Return(&google.Credentials{
+				ProjectID: "from-sa",
+			}, nil).Build()
 			mockey.Mock(vertex.WithCredentials).To(func(ctx context.Context, region, projectID string, creds *google.Credentials) option.RequestOption {
 				calledWithCredentials = true
 				assert.Equal(t, "us-east5", region)
@@ -1268,7 +1265,6 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 			model, err := NewChatModel(ctx, &cfg)
 			assert.NoError(t, err)
 			assert.NotNil(t, model)
-			assert.True(t, calledCredentialsFromJSON, "expected google.CredentialsFromJSON to be called for service account path")
 			assert.True(t, calledWithCredentials, "expected vertex.WithCredentials to be called for service account path")
 		})
 	})

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -23,8 +23,10 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+	"github.com/anthropics/anthropic-sdk-go/vertex"
 	"github.com/bytedance/mockey"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/eino-contrib/jsonschema"
@@ -1229,9 +1231,7 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 
 	t.Run("ADC path when service account JSON empty", func(t *testing.T) {
 		mockey.PatchConvey("", t, func() {
-			mockey.Mock(google.FindDefaultCredentials).Return(&google.Credentials{
-				ProjectID: "from-adc",
-			}, nil).Build()
+			mockey.Mock(vertex.WithGoogleAuth).Return(option.WithAPIKey("adc-test")).Build()
 
 			model, err := NewChatModel(ctx, base)
 			assert.NoError(t, err)
@@ -1244,6 +1244,7 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 			mockey.Mock(google.CredentialsFromJSON).Return(&google.Credentials{
 				ProjectID: "from-sa",
 			}, nil).Build()
+			mockey.Mock(vertex.WithCredentials).Return(option.WithAPIKey("sa-test")).Build()
 
 			cfg := *base
 			cfg.VertexServiceAccountJSON = []byte(`{"type":"service_account","project_id":"from-sa"}`)

--- a/components/model/claude/examples/generate/generate.go
+++ b/components/model/claude/examples/generate/generate.go
@@ -52,7 +52,7 @@ func main() {
 
 		// If you want to use Google Vertex AI, set ByVertex: true.
 		// Project ID and region are auto-detected from environment variables when omitted.
-		// For BYOS, pass raw service account JSON via VertexServiceAccountJSON instead of ADC.
+		// For explicit credentials, pass raw service account JSON via VertexServiceAccountJSON instead of ADC.
 		// See: https://claude.ai/docs/en/google-vertex-ai
 		// ByVertex:                true,
 		// VertexProjectID:         "my-gcp-project",

--- a/components/model/claude/examples/generate/generate.go
+++ b/components/model/claude/examples/generate/generate.go
@@ -51,9 +51,13 @@ func main() {
 		// Region:          "us-west-2",
 
 		// If you want to use Google Vertex AI, set ByVertex: true.
-		// Project ID and region are auto-detected from environment variables.
+		// Project ID and region are auto-detected from environment variables when omitted.
+		// For BYOS, pass raw service account JSON via VertexServiceAccountJSON instead of ADC.
 		// See: https://claude.ai/docs/en/google-vertex-ai
-		// ByVertex: true,
+		// ByVertex:                true,
+		// VertexProjectID:         "my-gcp-project",
+		// VertexRegion:            "us-east5",
+		// VertexServiceAccountJSON: serviceAccountJSON,
 
 		APIKey: apiKey,
 		// Model:     "claude-3-5-sonnet-20240620",


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

feat(claude): 支持通过 Vertex 服务账号 JSON 配置凭证

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
`components/model/claude` already supports explicit in-memory credentials for direct Anthropic API (`APIKey` / `AuthToken`) and AWS Bedrock (`AccessKey` / `SecretAccessKey`). Vertex was ADC-only via `vertex.WithGoogleAuth`.

This PR adds `Config.VertexServiceAccountJSON` so callers can pass raw GCP service account JSON and authenticate with `vertex.WithCredentials`, without Application Default Credentials or environment variables.

- When `VertexServiceAccountJSON` is non-empty: build credentials via `google.CredentialsFromJSON` and call `vertex.WithCredentials`.
- When empty: existing ADC behavior is unchanged (`vertex.WithGoogleAuth`).
- Mirrors the Bedrock credential pattern on `Config`.
- Adds `TestVertexServiceAccountJSON` (invalid JSON, ADC fallback, mocked explicit-credential success path).
- Documents the new field and auth rules in `README.md`, `README_zh.md`, and `examples/generate`.

zh:
`components/model/claude` 已支持直连 Anthropic（`APIKey` / `AuthToken`）和 AWS Bedrock（`AccessKey` / `SecretAccessKey`）的内存凭证；Vertex 此前仅支持通过 `vertex.WithGoogleAuth` 使用 ADC。

本 PR 新增 `Config.VertexServiceAccountJSON`，允许调用方传入原始 GCP service account JSON，并通过 `vertex.WithCredentials` 鉴权，无需 ADC 或环境变量。

- `VertexServiceAccountJSON` 非空：通过 `google.CredentialsFromJSON` 构建凭证并调用 `vertex.WithCredentials`。
- 为空：保持现有 ADC 行为（`vertex.WithGoogleAuth`）。
- 与 Bedrock 在 `Config` 上显式传凭证的模式一致。
- 新增 `TestVertexServiceAccountJSON`（非法 JSON、ADC 回退、mockey 覆盖的显式凭证成功路径）。
- 在 `README.md`、`README_zh.md` 和 `examples/generate` 中补充字段与鉴权说明。

#### (Optional) Which issue(s) this PR fixes:

Fixes #890

#### (optional) The PR that updates user documentation:

Updated component README files in this PR.