### PR TITLE
chore: local.read return earlier when path is a dir

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -322,6 +322,9 @@ func (s *Local) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesys
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat file: %w", err)
 	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory, not a file", path)
+	}
 	if info.Size() == 0 {
 		return &filesystem.FileContent{}, nil
 	}

--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -625,6 +625,9 @@ func splitPagesRange(pages string) (startStr, endStr string, hasRange bool, err 
 	}
 	parts := strings.SplitN(trimmed, "-", 2)
 	startStr = strings.TrimSpace(parts[0])
+	if startStr == "" {
+		return "", "", false, fmt.Errorf("invalid pages parameter: %q (open-start range is not supported, start page is required)", pages)
+	}
 	if len(parts) == 1 {
 		return startStr, "", false, nil
 	}

--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -314,6 +314,9 @@ func (s *Local) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesys
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("file not found: %s", path)
 		}
+		if os.IsPermission(err) {
+			return nil, fmt.Errorf("permission denied: %s", path)
+		}
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -132,6 +132,18 @@ func TestRead(t *testing.T) {
 		assert.Contains(t, err.Error(), "file not found")
 	})
 
+	t.Run("read file but permission denied", func(t *testing.T) {
+		dir := setupTestDir(t)
+		defer os.RemoveAll(dir)
+		filePath := filepath.Join(dir, "test.txt")
+		assert.NoError(t, os.WriteFile(filePath, []byte(""), 0644))
+		assert.NoError(t, os.Chmod(filePath, 0000))
+		req := &filesystem.ReadRequest{FilePath: filePath}
+		_, err = s.Read(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+
 	t.Run("read directory", func(t *testing.T) {
 		dir := setupTestDir(t)
 		defer os.RemoveAll(dir)

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -132,6 +132,17 @@ func TestRead(t *testing.T) {
 		assert.Contains(t, err.Error(), "file not found")
 	})
 
+	t.Run("read directory", func(t *testing.T) {
+		dir := setupTestDir(t)
+		defer os.RemoveAll(dir)
+		subDir := filepath.Join(dir, "subdir")
+		os.Mkdir(subDir, 0755)
+		req := &filesystem.ReadRequest{FilePath: subDir}
+		_, err = s.Read(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is a directory, not a file")
+	})
+
 	t.Run("read large file with pagination", func(t *testing.T) {
 		dir := setupTestDir(t)
 		defer os.RemoveAll(dir)


### PR DESCRIPTION
local.Read 当要读取的文件是目录时，提前返回。