### PR TITLE
fix(claude): collapse invalid tool_call Arguments to empty object (not just empty)

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -1196,7 +1196,10 @@ func convSchemaMessage(message *schema.Message) (mp anthropic.MessageParam, err 
 		tc := message.ToolCalls[i]
 
 		args := tc.Function.Arguments
-		if args == "" {
+		// Empty or invalid (e.g. truncated streamed) Arguments would make
+		// ToolUseBlockParam.MarshalJSON fail on re-assembly; collapse both to a
+		// valid empty object (extends the empty-arg fix from #462).
+		if args == "" || !json.Valid([]byte(args)) {
 			args = "{}"
 		}
 		// Arguments are limited to object type.

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -1269,3 +1269,46 @@ func TestVertexServiceAccountJSON(t *testing.T) {
 		})
 	})
 }
+
+func Test_convSchemaMessage_ToolCallArguments(t *testing.T) {
+	// A tool call whose Function.Arguments is empty or invalid JSON (e.g. a
+	// streamed tool_use truncated mid-payload) must not crash request
+	// re-assembly: convSchemaMessage collapses it to a valid empty object so
+	// ToolUseBlockParam.MarshalJSON succeeds. Valid JSON passes through unchanged.
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{name: "valid passes through", args: `{"city":"Paris"}`, want: `{"city":"Paris"}`},
+		{name: "empty becomes empty object", args: "", want: "{}"},
+		{name: "truncated becomes empty object", args: `{"file_path":"/tmp/x.json","content":"{\"items\":[`, want: "{}"},
+		{name: "malformed becomes empty object", args: `{"a":}`, want: "{}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &schema.Message{
+				Role: schema.Assistant,
+				ToolCalls: []schema.ToolCall{{
+					ID: "call-1",
+					Function: schema.FunctionCall{
+						Name:      "write_file",
+						Arguments: tc.args,
+					},
+				}},
+			}
+
+			mp, err := convSchemaMessage(msg)
+			assert.NoError(t, err)
+			assert.Len(t, mp.Content, 1)
+
+			tu := mp.Content[0].OfToolUse
+			assert.NotNil(t, tu)
+			assert.Equal(t, tc.want, string(tu.Input.(json.RawMessage)))
+
+			// The whole message must marshal without "unexpected end of JSON input".
+			_, err = mp.MarshalJSON()
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### What

`convSchemaMessage` (`components/model/claude/claude.go`) only collapsed an **empty** tool-call `Arguments` to `"{}"` before wrapping it in `json.RawMessage`. A **non-empty but invalid** `Arguments` — typically a streamed `tool_use` truncated mid-payload (the `input_json_delta` chunks are cut before the JSON object closes) — was passed through raw, so `ToolUseBlockParam.MarshalJSON` failed on the next request re-assembly:

```
[NodeRunError] create new streaming message fail: ... *anthropic.ToolUseBlockParam:
json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input
```

This is the same crash as #462 (empty arg, already fixed by the `if args == ""` guard) and the same family as #304 — but for the invalid/truncated sub-case, which the guard didn't cover. Closes #894.

### How

Generalize the existing guard to **any** non-valid-JSON `Arguments` via `json.Valid`:

```go
if args == "" || !json.Valid([]byte(args)) {
    args = "{}"
}
```

Valid JSON passes through unchanged; empty/invalid both collapse to a valid empty object so marshaling succeeds and the run continues (the model gets a normal tool result and can retry) instead of crashing. `encoding/json` is already imported.

### Tests

Added `Test_convSchemaMessage_ToolCallArguments` covering: valid args pass through, empty → `{}`, truncated → `{}`, malformed → `{}`, and asserting the assembled `MessageParam` marshals without error.

Note: I couldn't run the package test binary locally — `mockey v1.2.13` fails to build on my toolchain (`go1.26 / darwin-arm64`: `relocation target runtime.duffcopy not defined`), which is unrelated to this change (it fails for any test in the package). The non-test package builds and `go vet` is clean; CI should exercise the new test on a compatible toolchain. The new test does not use mockey.

### Why it helps others

We hit this in production in a Go agent harness on Eino's DeepAgent: an agent asked to write a large JSON file in one `write_file` had its tool_use stream truncate, crashing the whole turn. We worked around it downstream by wrapping the public model interface and sanitizing `Arguments` on the model boundary — but that's a per-consumer patch for what is a one-line generalization here. Fixing it upstream protects every Eino+Claude streaming user against the same crash, exactly as the empty-arg guard already does.
