### PR TITLE
docs(agentic): enrich cache section with mermaid flowchart and examples

### DIFF
--- a/components/model/agenticark/README.md
+++ b/components/model/agenticark/README.md
@@ -268,6 +268,46 @@ am, err := agenticark.New(ctx, &agenticark.Config{
 })
 ```
 
+The following diagram illustrates how the SDK resolves `PreviousResponseID` on each call, and how `InvalidateMessageCaches` resets the cache state:
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [User₁, Asst₁(resp_001), User₂, Asst₂(resp_002), User₃]<br/>opts = WithHeadPreviousResponseID(resp_abc) (optional)"]
+    Detail --> B{"Find cached<br/>Response ID<br/>in messages?"}
+    B -- "Yes (found resp_002 at Asst₂)" --> C["Send [User₃] only<br/>PreviousResponseID = resp_002"]
+    B -- No --> H{"WithHeadPreviousResponseID<br/>provided?"}
+    H -- "Yes (resp_abc)" --> I["Send full input<br/>PreviousResponseID = resp_abc"]
+    H -- No --> D["Send full input<br/>No cache reuse"]
+    C --> E["Response (resp_003) marked as cached<br/>— used as cache anchor in next turn"]
+    I --> E
+    D --> E
+
+    E -. "Model switched /<br/>history edited" .-> F["InvalidateMessageCaches(input)"]
+    F -. "Next call" .-> B
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style I fill:#d4edda,stroke:#28a745
+    style D fill:#fff3cd,stroke:#ffc107
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#f8d7da,stroke:#dc3545
+```
+
+**Example — switch model mid-conversation:**
+
+```go
+// Conversation built with model A: [User₁, Assistant₁(model_A), User₂]
+// Now switching to model B — the cached prefix from model A is invalid.
+
+input := []*schema.AgenticMessage{user1, assistant1, user2}
+agenticark.InvalidateMessageCaches(input)
+
+// Next Generate will skip the stale cache anchor and send full input.
+resp, err := modelB.Generate(ctx, input)
+```
+
 ### Tool Calling
 
 The `AgenticModel` supports tool calling, including Function Tools, MCP Tools, and Server Tools.

--- a/components/model/agenticark/README.zh_CN.md
+++ b/components/model/agenticark/README.zh_CN.md
@@ -267,6 +267,46 @@ am, err := agenticark.New(ctx, &agenticark.Config{
 })
 ```
 
+下图展示了 SDK 如何在每次调用时解析 `PreviousResponseID`，以及 `InvalidateMessageCaches` 如何重置缓存状态：
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [User₁, Asst₁(resp_001), User₂, Asst₂(resp_002), User₃]<br/>opts = WithHeadPreviousResponseID(resp_abc) (optional)"]
+    Detail --> B{"Find cached<br/>Response ID<br/>in messages?"}
+    B -- "Yes (found resp_002 at Asst₂)" --> C["Send [User₃] only<br/>PreviousResponseID = resp_002"]
+    B -- No --> H{"WithHeadPreviousResponseID<br/>provided?"}
+    H -- "Yes (resp_abc)" --> I["Send full input<br/>PreviousResponseID = resp_abc"]
+    H -- No --> D["Send full input<br/>No cache reuse"]
+    C --> E["Response (resp_003) marked as cached<br/>— used as cache anchor in next turn"]
+    I --> E
+    D --> E
+
+    E -. "Model switched /<br/>history edited" .-> F["InvalidateMessageCaches(input)"]
+    F -. "Next call" .-> B
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style I fill:#d4edda,stroke:#28a745
+    style D fill:#fff3cd,stroke:#ffc107
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#f8d7da,stroke:#dc3545
+```
+
+**示例 — 对话中途切换模型：**
+
+```go
+// 使用模型 A 构建的对话：[User₁, Assistant₁(model_A), User₂]
+// 现在切换到模型 B — 模型 A 的缓存前缀已失效。
+
+input := []*schema.AgenticMessage{user1, assistant1, user2}
+agenticark.InvalidateMessageCaches(input)
+
+// 下次 Generate 将跳过失效的缓存锚点，发送完整输入。
+resp, err := modelB.Generate(ctx, input)
+```
+
 ### 工具调用 (Tool Calling)
 
 `AgenticModel` 支持工具调用，包括函数工具、MCP 工具和服务器工具。

--- a/components/model/agenticclaude/README.md
+++ b/components/model/agenticclaude/README.md
@@ -271,9 +271,42 @@ result := block.ServerToolResult.Content.(*agenticclaude.ServerToolResult)
 
 ### Cache
 
-Use `CacheControl` to enable auto-caching for multi-turn conversations. When set (non-nil), the API automatically applies a cache_control marker to the last cacheable block in the request.
+Claude's prompt caching works by placing `cache_control` markers on content blocks. When the API sees a
+marker, it caches everything up to that point. Subsequent requests that share the same prefix get a cache hit,
+reducing latency and cost.
 
-For fine-grained control, use `SetContentBlockCacheControl` or `SetToolInfoCacheControl` to manually place cache breakpoints on specific blocks or tools.
+This package provides two caching strategies:
+
+| Strategy | Config / API | Use Case |
+|----------|-------------|----------|
+| Auto Cache | `CacheControl` in Config | Automatically marks the last cacheable block per request |
+| Manual Cache | `SetContentBlockCacheControl` / `SetToolInfoCacheControl` | Fine-grained control on specific blocks or tools |
+
+The following diagram illustrates how both strategies work:
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [System, User₁, Asst₁, User₂, ...]<br/>tools = [tool_A, tool_B, ...]"]
+    Detail --> B{"CacheControl<br/>set in Config?"}
+    B -- Yes --> C["Top-level cache_control set on request<br/>— SDK applies it to last cacheable block"]
+    B -- No --> D{"Manual markers via<br/>SetContentBlockCacheControl /<br/>SetToolInfoCacheControl?"}
+    D -- Yes --> E["Use manual cache_control markers<br/>on specified blocks/tools"]
+    D -- No --> F["No caching — full computation each call"]
+    C --> G["API caches prefix up to marker<br/>— subsequent calls get cache hit"]
+    E --> G
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#fff3cd,stroke:#ffc107
+    style G fill:#d4edda,stroke:#28a745
+```
+
+#### Auto Cache
+
+Use `CacheControl` in the config to set a top-level cache control on the request. The SDK automatically applies it to the last cacheable block:
 
 ```go
 cacheCtrl := anthropic.NewCacheControlEphemeralParam()
@@ -286,6 +319,23 @@ am, err := agenticclaude.New(ctx, &agenticclaude.Config{
     MaxTokens:    4096,
     CacheControl: &cacheCtrl,
 })
+```
+
+#### Manual Cache
+
+For fine-grained control, use `SetContentBlockCacheControl` or `SetToolInfoCacheControl` to manually
+place cache breakpoints on specific blocks or tools. When a manual marker is set, the top-level
+auto-cache will not override it.
+
+```go
+cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+cacheCtrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+
+// Cache a specific content block (e.g., a large system prompt).
+block = agenticclaude.SetContentBlockCacheControl(block, &cacheCtrl)
+
+// Cache a specific tool definition.
+toolInfo = agenticclaude.SetToolInfoCacheControl(toolInfo, &cacheCtrl)
 ```
 
 ### Tool Calling

--- a/components/model/agenticclaude/README_zh.md
+++ b/components/model/agenticclaude/README_zh.md
@@ -270,9 +270,41 @@ result := block.ServerToolResult.Content.(*agenticclaude.ServerToolResult)
 
 ### 缓存
 
-使用 `CacheControl` 为多轮对话启用自动缓存。设置后（非 nil），API 会自动在请求中最后一个可缓存的 block 上应用 cache_control 标记。
+Claude 的 prompt caching 通过在 content block 上放置 `cache_control` 标记来工作。当 API 看到标记时，
+会缓存该标记之前的所有内容。后续共享相同前缀的请求将命中缓存，降低延迟和成本。
 
-如需细粒度控制，可使用 `SetContentBlockCacheControl` 或 `SetToolInfoCacheControl` 手动在特定的 block 或 tool 上放置缓存断点。
+本包提供两种缓存策略：
+
+| 策略 | 配置 / API | 使用场景 |
+|------|-----------|---------|
+| 自动缓存 | Config 中的 `CacheControl` | 自动标记每个请求中最后一个可缓存的 block |
+| 手动缓存 | `SetContentBlockCacheControl` / `SetToolInfoCacheControl` | 在特定 block 或 tool 上精细控制 |
+
+下图展示了两种策略的工作方式：
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [System, User₁, Asst₁, User₂, ...]<br/>tools = [tool_A, tool_B, ...]"]
+    Detail --> B{"Config 中设置了<br/>CacheControl?"}
+    B -- Yes --> C["在请求上设置顶层 cache_control<br/>— SDK 自动将其应用到最后一个可缓存 block"]
+    B -- No --> D{"通过 SetContentBlockCacheControl /<br/>SetToolInfoCacheControl<br/>手动设置了标记?"}
+    D -- Yes --> E["使用手动设置的<br/>cache_control 标记"]
+    D -- No --> F["无缓存 — 每次调用完整计算"]
+    C --> G["API 缓存标记之前的前缀<br/>— 后续调用命中缓存"]
+    E --> G
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#fff3cd,stroke:#ffc107
+    style G fill:#d4edda,stroke:#28a745
+```
+
+#### 自动缓存
+
+在 Config 中设置 `CacheControl`，在请求上设置顶层缓存控制。SDK 会自动将其应用到最后一个可缓存的 block：
 
 ```go
 cacheCtrl := anthropic.NewCacheControlEphemeralParam()
@@ -285,6 +317,22 @@ am, err := agenticclaude.New(ctx, &agenticclaude.Config{
     MaxTokens:    4096,
     CacheControl: &cacheCtrl,
 })
+```
+
+#### 手动缓存
+
+如需细粒度控制，可使用 `SetContentBlockCacheControl` 或 `SetToolInfoCacheControl` 手动在特定的 block
+或 tool 上放置缓存断点。设置了手动标记后，顶层的自动缓存不会覆盖它。
+
+```go
+cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+cacheCtrl.TTL = anthropic.CacheControlEphemeralTTLTTL5m
+
+// 缓存特定的 content block（例如大型 system prompt）。
+block = agenticclaude.SetContentBlockCacheControl(block, &cacheCtrl)
+
+// 缓存特定的 tool 定义。
+toolInfo = agenticclaude.SetToolInfoCacheControl(toolInfo, &cacheCtrl)
 ```
 
 ### 工具调用 (Tool Calling)

--- a/components/model/agenticclaude/model.go
+++ b/components/model/agenticclaude/model.go
@@ -119,7 +119,7 @@ type Config struct {
 	ExtraFields map[string]any
 
 	// CacheControl configures automatic prompt caching behavior.
-	// When non-nil, automatically applies a cache_control marker to the last
+	// Top-level cache control automatically applies a cache_control marker to the last
 	// cacheable block in the request.
 	// Optional.
 	CacheControl *anthropic.CacheControlEphemeralParam

--- a/components/model/agenticopenai/README.md
+++ b/components/model/agenticopenai/README.md
@@ -486,6 +486,46 @@ am, err := agenticopenai.NewResponsesModel(ctx, &agenticopenai.ResponsesConfig{
 })
 ```
 
+The following diagram illustrates how the SDK resolves `PreviousResponseID` on each call, and how `InvalidateMessageCaches` resets the cache state:
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [User₁, Asst₁(resp_001), User₂, Asst₂(resp_002), User₃]<br/>opts = WithHeadPreviousResponseID(resp_abc) (optional)"]
+    Detail --> B{"Find cached<br/>Response ID<br/>in messages?"}
+    B -- "Yes (found resp_002 at Asst₂)" --> C["Send [User₃] only<br/>PreviousResponseID = resp_002"]
+    B -- No --> H{"WithHeadPreviousResponseID<br/>provided?"}
+    H -- "Yes (resp_abc)" --> I["Send full input<br/>PreviousResponseID = resp_abc"]
+    H -- No --> D["Send full input<br/>No cache reuse"]
+    C --> E["Response (resp_003) marked as cached<br/>— used as cache anchor in next turn"]
+    I --> E
+    D --> E
+
+    E -. "Model switched /<br/>history edited" .-> F["InvalidateMessageCaches(input)"]
+    F -. "Next call" .-> B
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style I fill:#d4edda,stroke:#28a745
+    style D fill:#fff3cd,stroke:#ffc107
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#f8d7da,stroke:#dc3545
+```
+
+**Example — switch model mid-conversation:**
+
+```go
+// Conversation built with model A: [User₁, Assistant₁(model_A), User₂]
+// Now switching to model B — the cached prefix from model A is invalid.
+
+input := []*schema.AgenticMessage{user1, assistant1, user2}
+agenticopenai.InvalidateMessageCaches(input)
+
+// Next Generate will skip the stale cache anchor and send full input.
+resp, err := modelB.Generate(ctx, input)
+```
+
 ### Tool Calling
 
 The `ResponsesModel` supports tool calling, including Function Tools, MCP Tools, and Server Tools.

--- a/components/model/agenticopenai/README.zh_CN.md
+++ b/components/model/agenticopenai/README.zh_CN.md
@@ -483,6 +483,46 @@ am, err := agenticopenai.NewResponsesModel(ctx, &agenticopenai.ResponsesConfig{
 })
 ```
 
+下图展示了 SDK 如何在每次调用时解析 `PreviousResponseID`，以及 `InvalidateMessageCaches` 如何重置缓存状态：
+
+```mermaid
+flowchart TD
+    Input["am.Generate(ctx, input, opts...)"] --> Detail
+    Detail["input = [User₁, Asst₁(resp_001), User₂, Asst₂(resp_002), User₃]<br/>opts = WithHeadPreviousResponseID(resp_abc) (optional)"]
+    Detail --> B{"Find cached<br/>Response ID<br/>in messages?"}
+    B -- "Yes (found resp_002 at Asst₂)" --> C["Send [User₃] only<br/>PreviousResponseID = resp_002"]
+    B -- No --> H{"WithHeadPreviousResponseID<br/>provided?"}
+    H -- "Yes (resp_abc)" --> I["Send full input<br/>PreviousResponseID = resp_abc"]
+    H -- No --> D["Send full input<br/>No cache reuse"]
+    C --> E["Response (resp_003) marked as cached<br/>— used as cache anchor in next turn"]
+    I --> E
+    D --> E
+
+    E -. "Model switched /<br/>history edited" .-> F["InvalidateMessageCaches(input)"]
+    F -. "Next call" .-> B
+
+    style Input fill:#e8f4fd,stroke:#4a90d9
+    style Detail fill:#e8f4fd,stroke:#4a90d9
+    style C fill:#d4edda,stroke:#28a745
+    style I fill:#d4edda,stroke:#28a745
+    style D fill:#fff3cd,stroke:#ffc107
+    style E fill:#d4edda,stroke:#28a745
+    style F fill:#f8d7da,stroke:#dc3545
+```
+
+**示例 — 对话中途切换模型：**
+
+```go
+// 使用模型 A 构建的对话：[User₁, Assistant₁(model_A), User₂]
+// 现在切换到模型 B — 模型 A 的缓存前缀已失效。
+
+input := []*schema.AgenticMessage{user1, assistant1, user2}
+agenticopenai.InvalidateMessageCaches(input)
+
+// 下次 Generate 将跳过失效的缓存锚点，发送完整输入。
+resp, err := modelB.Generate(ctx, input)
+```
+
 ### 工具调用 (Tool Calling)
 
 `ResponsesModel` 支持工具调用，包括函数工具、MCP 工具和服务器工具。


### PR DESCRIPTION
## Summary

Adds a mermaid flowchart and code examples to the Cache documentation section in both `agenticopenai` and `agenticark` READMEs (EN + zh_CN). The diagram visually explains how the SDK resolves `PreviousResponseID` — including auto-cache discovery, `WithHeadPreviousResponseID` fallback, and `InvalidateMessageCaches` reset flow.

## Key Changes

1. Added a color-coded mermaid flowchart showing the cache resolution logic with concrete input/output examples.
2. Added a code example demonstrating `InvalidateMessageCaches` usage when switching models mid-conversation.
3. Applied consistently across all four README files (agenticopenai EN/zh_CN, agenticark EN/zh_CN).