### PR TITLE
feat(callbacks_langfuse): expose trace id and observation id

### DIFF
--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -659,6 +659,7 @@ func getName(info *callbacks.RunInfo) string {
 	return info.Type + string(info.Component)
 }
 
+// Get the associated trace id
 func GetTraceId(ctx context.Context) (ret string, ok bool) {
 	var value *langfuseState
 	if value, ok = ctx.Value(langfuseStateKey{}).(*langfuseState); ok {
@@ -667,6 +668,7 @@ func GetTraceId(ctx context.Context) (ret string, ok bool) {
 	return
 }
 
+// Get the associated observation id
 func GetObservationID(ctx context.Context) (ret string, ok bool) {
 	var value *langfuseState
 	if value, ok = ctx.Value(langfuseStateKey{}).(*langfuseState); ok {

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -658,3 +658,19 @@ func getName(info *callbacks.RunInfo) string {
 	}
 	return info.Type + string(info.Component)
 }
+
+func GetTraceId(ctx context.Context) (ret string, ok bool) {
+	var value *langfuseState
+	if value, ok = ctx.Value(langfuseStateKey{}).(*langfuseState); ok {
+		ret = value.traceID
+	}
+	return
+}
+
+func GetObservationID(ctx context.Context) (ret string, ok bool) {
+	var value *langfuseState
+	if value, ok = ctx.Value(langfuseStateKey{}).(*langfuseState); ok {
+		ret = value.observationID
+	}
+	return
+}

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -660,7 +660,7 @@ func getName(info *callbacks.RunInfo) string {
 }
 
 // Get the associated trace id
-func GetTraceId(ctx context.Context) (ret string, ok bool) {
+func GetTraceID(ctx context.Context) (ret string, ok bool) {
 	var value *langfuseState
 	if value, ok = ctx.Value(langfuseStateKey{}).(*langfuseState); ok {
 		ret = value.traceID


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

提供暴露 langfuse trace id 和 observation id的 API

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:

I am working on agents created by different languages and frameworks. Currently, both trace id and observation id are internally managed by eino-ext. When incooperated with agents **NOT** managed by eino, or even not written in golang, such as opencode and claude code, there is no way to attach their traces to eino agent's. Exposing the trace id and observation id makes this binding possible, producing a more comprehensive trace graph on langfuse

zh(optional): 

目前 trace id 和 observation id 都是由 eino-ext 内部创建并管理的。当我想把其他非eino框架实现的agent，比如claude code或者opencode，编排到eino的工作流里的时候，我发现实际上是无法将它们的trace和eino的trace关联起来。

通过暴露 langfuse trace id 和 observation id，就可以将这些agent的trace挂到eino的observation之下，实现在同一条trace中展示所有agent的trace


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
