### PR TITLE
feat(callbacks/langfuse): expose max event size option

### DIFF
--- a/callbacks/langfuse/README.md
+++ b/callbacks/langfuse/README.md
@@ -89,6 +89,10 @@ type Config struct {
     // MaxTaskQueueSize is the max number of events to buffer (Optional)
     // Default: 100
     MaxTaskQueueSize int
+
+    // MaxEventSizeBytes is the maximum size of an event before large fields are truncated (Optional)
+    // Default: 1_000_000
+    MaxEventSizeBytes int
     
     // FlushAt is the number of events to batch before sending (Optional)
     // Default: 15

--- a/callbacks/langfuse/README_zh.md
+++ b/callbacks/langfuse/README_zh.md
@@ -89,6 +89,10 @@ type Config struct {
     // 事件缓冲区最大大小 (选填)
     // 默认值: 100
     MaxTaskQueueSize int
+
+    // 事件大字段被截断前允许的最大事件大小，单位字节 (选填)
+    // 默认值: 1_000_000
+    MaxEventSizeBytes int
     
     // 批量发送前的事件数量 (选填)
     // 默认值: 15

--- a/callbacks/langfuse/go.mod
+++ b/callbacks/langfuse/go.mod
@@ -47,3 +47,5 @@ require (
 	golang.org/x/term v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/cloudwego/eino-ext/libs/acl/langfuse => ../../libs/acl/langfuse

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -59,6 +59,11 @@ type Config struct {
 	// Example: 1000
 	MaxTaskQueueSize int
 
+	// MaxEventSizeBytes is the maximum size of an event before large fields are truncated (Optional)
+	// Default: 1_000_000
+	// Example: 2_000_000
+	MaxEventSizeBytes int
+
 	// FlushAt is the number of events to batch before sending (Optional)
 	// Default: 15
 	// Example: 50
@@ -130,6 +135,9 @@ func NewLangfuseHandler(cfg *Config) (handler *CallbackHandler, flusher func()) 
 	}
 	if cfg.MaxTaskQueueSize > 0 {
 		langfuseOpts = append(langfuseOpts, langfuse.WithMaxTaskQueueSize(cfg.MaxTaskQueueSize))
+	}
+	if cfg.MaxEventSizeBytes > 0 {
+		langfuseOpts = append(langfuseOpts, langfuse.WithMaxEventSizeBytes(cfg.MaxEventSizeBytes))
 	}
 	if cfg.FlushAt > 0 {
 		langfuseOpts = append(langfuseOpts, langfuse.WithFlushAt(cfg.FlushAt))

--- a/libs/acl/langfuse/consumer.go
+++ b/libs/acl/langfuse/consumer.go
@@ -38,8 +38,8 @@ const (
 	defaultFlushInterval     = time.Millisecond * 500
 	defaultMaxRetry          = 3
 
-	maxEventSizeBytes = 1_000_000
-	maxBatchSizeBytes = 2_500_000
+	defaultMaxEventSizeBytes = 1_000_000
+	maxBatchSizeBytes        = 2_500_000
 
 	ingestionPath    = "/api/public/ingestion"
 	getUploadURLPath = "/api/public/media"
@@ -51,6 +51,7 @@ const (
 func newIngestionConsumer(
 	cli *client,
 	q *queue,
+	maxEventSizeBytes int,
 	flushAt int,
 	flushInterval time.Duration,
 	sampleRate float64,
@@ -72,16 +73,20 @@ func newIngestionConsumer(
 	if maxRetry <= 0 {
 		maxRetry = defaultMaxRetry
 	}
+	if maxEventSizeBytes <= 0 {
+		maxEventSizeBytes = defaultMaxEventSizeBytes
+	}
 
 	return &ingestionConsumer{
-		cli:           cli,
-		eventQueue:    q,
-		flushAt:       flushAt,
-		flushInterval: flushInterval,
-		sampleRate:    sampleRate,
-		logMessage:    logMessage,
-		maskFunc:      maskFunc,
-		mediaWG:       mediaWG,
+		cli:               cli,
+		eventQueue:        q,
+		maxEventSizeBytes: maxEventSizeBytes,
+		flushAt:           flushAt,
+		flushInterval:     flushInterval,
+		sampleRate:        sampleRate,
+		logMessage:        logMessage,
+		maskFunc:          maskFunc,
+		mediaWG:           mediaWG,
 
 		sdkName:        sdkName,
 		sdkVersion:     sdkVersion,
@@ -94,14 +99,15 @@ func newIngestionConsumer(
 }
 
 type ingestionConsumer struct {
-	cli           *client
-	eventQueue    *queue
-	flushAt       int
-	flushInterval time.Duration
-	sampleRate    float64
-	logMessage    string
-	maskFunc      func(string) string
-	mediaWG       *sync.WaitGroup
+	cli               *client
+	eventQueue        *queue
+	maxEventSizeBytes int
+	flushAt           int
+	flushInterval     time.Duration
+	sampleRate        float64
+	logMessage        string
+	maskFunc          func(string) string
+	mediaWG           *sync.WaitGroup
 	// batch metadata
 	sdkName        string
 	sdkVersion     string
@@ -241,7 +247,7 @@ func (i *ingestionConsumer) truncate(ev *event) int {
 	}
 
 	sumSize := metadataLen + len(ev.Body.getInput()) + len(ev.Body.getOutput())
-	if sumSize <= maxEventSizeBytes {
+	if sumSize <= i.maxEventSizeBytes {
 		return sumSize
 	}
 
@@ -266,7 +272,7 @@ func (i *ingestionConsumer) truncate(ev *event) int {
 		}
 		c.clear()
 		sumSize -= c.len
-		if sumSize <= maxEventSizeBytes {
+		if sumSize <= i.maxEventSizeBytes {
 			break
 		}
 	}

--- a/libs/acl/langfuse/event_test.go
+++ b/libs/acl/langfuse/event_test.go
@@ -17,6 +17,7 @@
 package langfuse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,24 @@ func TestEventBodyUnion(t *testing.T) {
 	assert.Equal(t, input, generationUnion.getInput())
 	assert.Equal(t, observationID, generationUnion.getObservationID())
 	assert.Equal(t, map[string]string{"key": "value"}, generationUnion.getMetadata())
+}
+
+func TestIngestionConsumerMaxEventSizeBytes(t *testing.T) {
+	consumer := newIngestionConsumer(nil, nil, 20, 0, 0, 0, "truncated", nil, "", "", "", "", 0, nil)
+	ev := &event{Body: eventBodyUnion{Trace: &TraceEventBody{
+		Input:  strings.Repeat("i", 30),
+		Output: strings.Repeat("o", 10),
+	}}}
+
+	size := consumer.truncate(ev)
+
+	assert.LessOrEqual(t, size, 20)
+	assert.Equal(t, "truncated", ev.Body.getInput())
+	assert.Equal(t, strings.Repeat("o", 10), ev.Body.getOutput())
+}
+
+func TestIngestionConsumerDefaultMaxEventSizeBytes(t *testing.T) {
+	consumer := newIngestionConsumer(nil, nil, 0, 0, 0, 0, "", nil, "", "", "", "", 0, nil)
+
+	assert.Equal(t, defaultMaxEventSizeBytes, consumer.maxEventSizeBytes)
 }

--- a/libs/acl/langfuse/langfuse.go
+++ b/libs/acl/langfuse/langfuse.go
@@ -74,6 +74,7 @@ func NewLangfuse(
 		&http.Client{Timeout: o.timeout},
 		host,
 		o.maxTaskQueueSize,
+		o.maxEventSizeBytes,
 		o.flushAt,
 		o.flushInterval,
 		o.sampleRate,

--- a/libs/acl/langfuse/option.go
+++ b/libs/acl/langfuse/option.go
@@ -19,15 +19,16 @@ package langfuse
 import "time"
 
 type options struct {
-	threads          int
-	timeout          time.Duration
-	maxTaskQueueSize int
-	flushAt          int
-	flushInterval    time.Duration
-	sampleRate       float64
-	logMessage       string
-	maskFunc         func(string) string
-	maxRetry         uint64
+	threads           int
+	timeout           time.Duration
+	maxTaskQueueSize  int
+	maxEventSizeBytes int
+	flushAt           int
+	flushInterval     time.Duration
+	sampleRate        float64
+	logMessage        string
+	maskFunc          func(string) string
+	maxRetry          uint64
 }
 
 type Option func(*options)
@@ -47,6 +48,12 @@ func WithTimeout(timeout time.Duration) Option {
 func WithMaxTaskQueueSize(maxTaskQueueSize int) Option {
 	return func(o *options) {
 		o.maxTaskQueueSize = maxTaskQueueSize
+	}
+}
+
+func WithMaxEventSizeBytes(maxEventSizeBytes int) Option {
+	return func(o *options) {
+		o.maxEventSizeBytes = maxEventSizeBytes
 	}
 }
 

--- a/libs/acl/langfuse/task.go
+++ b/libs/acl/langfuse/task.go
@@ -28,6 +28,7 @@ func newTaskManager(
 	cli *http.Client,
 	host string,
 	maxTaskQueueSize int,
+	maxEventSizeBytes int,
 	flushAt int,
 	flushInterval time.Duration,
 	sampleRate float64,
@@ -47,7 +48,7 @@ func newTaskManager(
 	}
 	wg := &sync.WaitGroup{}
 	for i := 0; i < threads; i++ {
-		newIngestionConsumer(langfuseCli, q, flushAt, flushInterval, sampleRate, logMessage, maskFunc, sdkName, sdkVersion, sdkIntegration, publicKey, maxRetry, wg).run()
+		newIngestionConsumer(langfuseCli, q, maxEventSizeBytes, flushAt, flushInterval, sampleRate, logMessage, maskFunc, sdkName, sdkVersion, sdkIntegration, publicKey, maxRetry, wg).run()
 	}
 
 	return &taskManager{q: q, mediaWG: wg}


### PR DESCRIPTION
## Summary
- Add `WithMaxEventSizeBytes` to `libs/acl/langfuse` so callers can configure the per-event truncation threshold.
- Expose `MaxEventSizeBytes` on `callbacks/langfuse.Config` and pass it through to the ACL client.
- Document the new option and cover custom/default truncation behavior with tests.

## Notes
- `callbacks/langfuse` uses a local replace for `libs/acl/langfuse` so this cross-module PR can compile against the sibling ACL change before a new ACL tag is published.

## Test plan
- `go test ./...` in `libs/acl/langfuse`
- `go test ./...` in `callbacks/langfuse`

Made with [Cursor](https://cursor.com)