### PR TITLE
feat(libs/acl/langfuse): expose max event size option

### DIFF
--- a/libs/acl/langfuse/consumer.go
+++ b/libs/acl/langfuse/consumer.go
@@ -38,8 +38,8 @@ const (
 	defaultFlushInterval     = time.Millisecond * 500
 	defaultMaxRetry          = 3
 
-	maxEventSizeBytes = 1_000_000
-	maxBatchSizeBytes = 2_500_000
+	defaultMaxEventSizeBytes = 1_000_000
+	maxBatchSizeBytes        = 2_500_000
 
 	ingestionPath    = "/api/public/ingestion"
 	getUploadURLPath = "/api/public/media"
@@ -51,6 +51,7 @@ const (
 func newIngestionConsumer(
 	cli *client,
 	q *queue,
+	maxEventSizeBytes int,
 	flushAt int,
 	flushInterval time.Duration,
 	sampleRate float64,
@@ -72,16 +73,20 @@ func newIngestionConsumer(
 	if maxRetry <= 0 {
 		maxRetry = defaultMaxRetry
 	}
+	if maxEventSizeBytes <= 0 {
+		maxEventSizeBytes = defaultMaxEventSizeBytes
+	}
 
 	return &ingestionConsumer{
-		cli:           cli,
-		eventQueue:    q,
-		flushAt:       flushAt,
-		flushInterval: flushInterval,
-		sampleRate:    sampleRate,
-		logMessage:    logMessage,
-		maskFunc:      maskFunc,
-		mediaWG:       mediaWG,
+		cli:               cli,
+		eventQueue:        q,
+		maxEventSizeBytes: maxEventSizeBytes,
+		flushAt:           flushAt,
+		flushInterval:     flushInterval,
+		sampleRate:        sampleRate,
+		logMessage:        logMessage,
+		maskFunc:          maskFunc,
+		mediaWG:           mediaWG,
 
 		sdkName:        sdkName,
 		sdkVersion:     sdkVersion,
@@ -94,14 +99,15 @@ func newIngestionConsumer(
 }
 
 type ingestionConsumer struct {
-	cli           *client
-	eventQueue    *queue
-	flushAt       int
-	flushInterval time.Duration
-	sampleRate    float64
-	logMessage    string
-	maskFunc      func(string) string
-	mediaWG       *sync.WaitGroup
+	cli               *client
+	eventQueue        *queue
+	maxEventSizeBytes int
+	flushAt           int
+	flushInterval     time.Duration
+	sampleRate        float64
+	logMessage        string
+	maskFunc          func(string) string
+	mediaWG           *sync.WaitGroup
 	// batch metadata
 	sdkName        string
 	sdkVersion     string
@@ -241,7 +247,7 @@ func (i *ingestionConsumer) truncate(ev *event) int {
 	}
 
 	sumSize := metadataLen + len(ev.Body.getInput()) + len(ev.Body.getOutput())
-	if sumSize <= maxEventSizeBytes {
+	if sumSize <= i.maxEventSizeBytes {
 		return sumSize
 	}
 
@@ -266,7 +272,7 @@ func (i *ingestionConsumer) truncate(ev *event) int {
 		}
 		c.clear()
 		sumSize -= c.len
-		if sumSize <= maxEventSizeBytes {
+		if sumSize <= i.maxEventSizeBytes {
 			break
 		}
 	}

--- a/libs/acl/langfuse/event_test.go
+++ b/libs/acl/langfuse/event_test.go
@@ -17,6 +17,7 @@
 package langfuse
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,24 @@ func TestEventBodyUnion(t *testing.T) {
 	assert.Equal(t, input, generationUnion.getInput())
 	assert.Equal(t, observationID, generationUnion.getObservationID())
 	assert.Equal(t, map[string]string{"key": "value"}, generationUnion.getMetadata())
+}
+
+func TestIngestionConsumerMaxEventSizeBytes(t *testing.T) {
+	consumer := newIngestionConsumer(nil, nil, 20, 0, 0, 0, "truncated", nil, "", "", "", "", 0, nil)
+	ev := &event{Body: eventBodyUnion{Trace: &TraceEventBody{
+		Input:  strings.Repeat("i", 30),
+		Output: strings.Repeat("o", 10),
+	}}}
+
+	size := consumer.truncate(ev)
+
+	assert.LessOrEqual(t, size, 20)
+	assert.Equal(t, "truncated", ev.Body.getInput())
+	assert.Equal(t, strings.Repeat("o", 10), ev.Body.getOutput())
+}
+
+func TestIngestionConsumerDefaultMaxEventSizeBytes(t *testing.T) {
+	consumer := newIngestionConsumer(nil, nil, 0, 0, 0, 0, "", nil, "", "", "", "", 0, nil)
+
+	assert.Equal(t, defaultMaxEventSizeBytes, consumer.maxEventSizeBytes)
 }

--- a/libs/acl/langfuse/langfuse.go
+++ b/libs/acl/langfuse/langfuse.go
@@ -74,6 +74,7 @@ func NewLangfuse(
 		&http.Client{Timeout: o.timeout},
 		host,
 		o.maxTaskQueueSize,
+		o.maxEventSizeBytes,
 		o.flushAt,
 		o.flushInterval,
 		o.sampleRate,

--- a/libs/acl/langfuse/option.go
+++ b/libs/acl/langfuse/option.go
@@ -19,15 +19,16 @@ package langfuse
 import "time"
 
 type options struct {
-	threads          int
-	timeout          time.Duration
-	maxTaskQueueSize int
-	flushAt          int
-	flushInterval    time.Duration
-	sampleRate       float64
-	logMessage       string
-	maskFunc         func(string) string
-	maxRetry         uint64
+	threads           int
+	timeout           time.Duration
+	maxTaskQueueSize  int
+	maxEventSizeBytes int
+	flushAt           int
+	flushInterval     time.Duration
+	sampleRate        float64
+	logMessage        string
+	maskFunc          func(string) string
+	maxRetry          uint64
 }
 
 type Option func(*options)
@@ -47,6 +48,12 @@ func WithTimeout(timeout time.Duration) Option {
 func WithMaxTaskQueueSize(maxTaskQueueSize int) Option {
 	return func(o *options) {
 		o.maxTaskQueueSize = maxTaskQueueSize
+	}
+}
+
+func WithMaxEventSizeBytes(maxEventSizeBytes int) Option {
+	return func(o *options) {
+		o.maxEventSizeBytes = maxEventSizeBytes
 	}
 }
 

--- a/libs/acl/langfuse/task.go
+++ b/libs/acl/langfuse/task.go
@@ -28,6 +28,7 @@ func newTaskManager(
 	cli *http.Client,
 	host string,
 	maxTaskQueueSize int,
+	maxEventSizeBytes int,
 	flushAt int,
 	flushInterval time.Duration,
 	sampleRate float64,
@@ -47,7 +48,7 @@ func newTaskManager(
 	}
 	wg := &sync.WaitGroup{}
 	for i := 0; i < threads; i++ {
-		newIngestionConsumer(langfuseCli, q, flushAt, flushInterval, sampleRate, logMessage, maskFunc, sdkName, sdkVersion, sdkIntegration, publicKey, maxRetry, wg).run()
+		newIngestionConsumer(langfuseCli, q, maxEventSizeBytes, flushAt, flushInterval, sampleRate, logMessage, maskFunc, sdkName, sdkVersion, sdkIntegration, publicKey, maxRetry, wg).run()
 	}
 
 	return &taskManager{q: q, mediaWG: wg}


### PR DESCRIPTION
## Summary
- Add `WithMaxEventSizeBytes` to `libs/acl/langfuse`.
- Keep the existing 1MB default truncation threshold when the option is not set.
- Cover custom and default max event size behavior with tests.

## Test plan
- `go test ./...` in `libs/acl/langfuse`

Made with [Cursor](https://cursor.com)