### PR TITLE
fix(local): implement plantask backend delete

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/cloudwego/eino/adk/filesystem"
+	"github.com/cloudwego/eino/adk/middlewares/plantask"
 	"github.com/cloudwego/eino/schema"
 	"github.com/klippa-app/go-pdfium"
 	"github.com/klippa-app/go-pdfium/references"
@@ -907,6 +908,14 @@ func (s *Local) Write(ctx context.Context, req *filesystem.WriteRequest) error {
 		return fmt.Errorf("failed to write to file: %w", err)
 	}
 
+	return nil
+}
+
+func (s *Local) Delete(ctx context.Context, req *plantask.DeleteRequest) error {
+	path := filepath.Clean(req.FilePath)
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("failed to delete file %s: %w", path, err)
+	}
 	return nil
 }
 

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -28,11 +28,17 @@ import (
 	"time"
 
 	"github.com/cloudwego/eino/adk/filesystem"
+	"github.com/cloudwego/eino/adk/middlewares/plantask"
 	"github.com/klippa-app/go-pdfium"
 	"github.com/klippa-app/go-pdfium/references"
 	"github.com/klippa-app/go-pdfium/requests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ filesystem.Backend = (*Local)(nil)
+	_ plantask.Backend   = (*Local)(nil)
 )
 
 func setupTestDir(t *testing.T) string {
@@ -184,6 +190,35 @@ func TestWrite(t *testing.T) {
 		err := s.Write(ctx, req)
 		assert.NoError(t, err)
 
+	})
+}
+
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+	s, err := NewBackend(ctx, &Config{})
+	assert.NoError(t, err)
+
+	t.Run("delete file successfully", func(t *testing.T) {
+		dir := setupTestDir(t)
+		defer os.RemoveAll(dir)
+		filePath := filepath.Join(dir, "delete.txt")
+		assert.NoError(t, os.WriteFile(filePath, []byte("content"), 0644))
+
+		err := s.Delete(ctx, &plantask.DeleteRequest{FilePath: filePath})
+		assert.NoError(t, err)
+
+		_, err = os.Stat(filePath)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("delete non-existent file", func(t *testing.T) {
+		dir := setupTestDir(t)
+		defer os.RemoveAll(dir)
+		filePath := filepath.Join(dir, "missing.txt")
+
+		err := s.Delete(ctx, &plantask.DeleteRequest{FilePath: filePath})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete file")
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

修复 local backend 未实现 plantask 后端删除能力的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

This PR makes `adk/backend/local.Local` implement `plantask.Backend` by adding the missing `Delete(ctx, *plantask.DeleteRequest)` method.

`Local` already implements `filesystem.Backend`, but `plantask.Backend` additionally requires `Delete` for task deletion and cleanup when all tasks are completed. Without this method, `*local.Local` cannot be used directly with the `plantask` middleware.

The implementation removes the target file via the local filesystem and returns contextual errors on failure. Tests now include compile-time interface assertions for both `filesystem.Backend` and `plantask.Backend`, plus delete success and missing-file error cases.

zh(optional):

本 PR 为 `adk/backend/local.Local` 补充缺失的 `Delete(ctx, *plantask.DeleteRequest)` 方法，使其实现 `plantask.Backend`。

`Local` 已经实现了 `filesystem.Backend`，但 `plantask.Backend` 额外要求 `Delete`，用于任务删除以及所有任务完成后的清理。缺少该方法时，`*local.Local` 无法直接用于 `plantask` middleware。

本实现通过本地文件系统删除目标文件，并在失败时返回带路径上下文的错误。测试中新增了 `filesystem.Backend` 和 `plantask.Backend` 的编译期接口断言，以及删除成功和文件不存在的错误场景。

#### (Optional) Which issue(s) this PR fixes:

Fixes #908

#### (optional) The PR that updates user documentation:

N/A
