### PR TITLE
feat(callbacks/langfuse): expose max event size config

### DIFF
--- a/callbacks/langfuse/README.md
+++ b/callbacks/langfuse/README.md
@@ -89,6 +89,10 @@ type Config struct {
     // MaxTaskQueueSize is the max number of events to buffer (Optional)
     // Default: 100
     MaxTaskQueueSize int
+
+    // MaxEventSizeBytes is the maximum size of an event before large fields are truncated (Optional)
+    // Default: 1_000_000
+    MaxEventSizeBytes int
     
     // FlushAt is the number of events to batch before sending (Optional)
     // Default: 15

--- a/callbacks/langfuse/README_zh.md
+++ b/callbacks/langfuse/README_zh.md
@@ -89,6 +89,10 @@ type Config struct {
     // 事件缓冲区最大大小 (选填)
     // 默认值: 100
     MaxTaskQueueSize int
+
+    // 事件大字段被截断前允许的最大事件大小，单位字节 (选填)
+    // 默认值: 1_000_000
+    MaxEventSizeBytes int
     
     // 批量发送前的事件数量 (选填)
     // 默认值: 15

--- a/callbacks/langfuse/go.mod
+++ b/callbacks/langfuse/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytedance/mockey v1.2.13
 	github.com/bytedance/sonic v1.14.1
 	github.com/cloudwego/eino v0.7.13
-	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.1
+	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.2-0.20260707092125-9c48c30a9c41
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/callbacks/langfuse/go.sum
+++ b/callbacks/langfuse/go.sum
@@ -24,6 +24,8 @@ github.com/cloudwego/eino v0.7.13 h1:Ku7hY+83gGJJjf4On3UgqjC57UcA+DXe0tqAZiNDDew
 github.com/cloudwego/eino v0.7.13/go.mod h1:nA8Vacmuqv3pqKBQbTWENBLQ8MmGmPt/WqiyLeB8ohQ=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.1 h1:y7LwRyPGcSLPkt/A9HJf+06Z+Jp4yj67zCDpd24762w=
 github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.1/go.mod h1:mQDhDvELAUjbAl/iJkFqMa1dM8y152OGUpCsy3wBCis=
+github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.2-0.20260707092125-9c48c30a9c41 h1:/DltE7tqzysS2UKqsCUGvptK45ixYUo02R0cCPdgqk8=
+github.com/cloudwego/eino-ext/libs/acl/langfuse v0.1.2-0.20260707092125-9c48c30a9c41/go.mod h1:mQDhDvELAUjbAl/iJkFqMa1dM8y152OGUpCsy3wBCis=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/callbacks/langfuse/langfuse.go
+++ b/callbacks/langfuse/langfuse.go
@@ -59,6 +59,11 @@ type Config struct {
 	// Example: 1000
 	MaxTaskQueueSize int
 
+	// MaxEventSizeBytes is the maximum size of an event before large fields are truncated (Optional)
+	// Default: 1_000_000
+	// Example: 2_000_000
+	MaxEventSizeBytes int
+
 	// FlushAt is the number of events to batch before sending (Optional)
 	// Default: 15
 	// Example: 50
@@ -130,6 +135,9 @@ func NewLangfuseHandler(cfg *Config) (handler *CallbackHandler, flusher func()) 
 	}
 	if cfg.MaxTaskQueueSize > 0 {
 		langfuseOpts = append(langfuseOpts, langfuse.WithMaxTaskQueueSize(cfg.MaxTaskQueueSize))
+	}
+	if cfg.MaxEventSizeBytes > 0 {
+		langfuseOpts = append(langfuseOpts, langfuse.WithMaxEventSizeBytes(cfg.MaxEventSizeBytes))
 	}
 	if cfg.FlushAt > 0 {
 		langfuseOpts = append(langfuseOpts, langfuse.WithFlushAt(cfg.FlushAt))


### PR DESCRIPTION
## Summary
- Add `MaxEventSizeBytes` to `callbacks/langfuse.Config`.
- Pass the value through to `libs/acl/langfuse.WithMaxEventSizeBytes`.
- Update the ACL Langfuse dependency to the main commit from #910 and document the new config option.

## Context
- Follows #910, which added the underlying ACL option.

## Test plan
- `go test ./...` in `callbacks/langfuse`

Made with [Cursor](https://cursor.com)