### PR TITLE
feat(model): support mid-conversation system messages

### DIFF
--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -26,27 +26,40 @@ import (
 	"github.com/cloudwego/eino/schema/claude"
 )
 
-func toAnthropicMessages(input []*schema.AgenticMessage) (systemBlocks []anthropic.TextBlockParam, msgParams []anthropic.MessageParam, err error) {
+func toAnthropicMessages(input []*schema.AgenticMessage) (sysInstruction []anthropic.TextBlockParam, msgParams []anthropic.MessageParam, err error) {
 	if len(input) == 0 {
 		return nil, nil, fmt.Errorf("input is empty")
 	}
 
-	systemDone := false
+	firstNonSystem := 0
+	for i, msg := range input {
+		if msg.Role != schema.AgenticRoleTypeSystem {
+			firstNonSystem = i
+			break
+		}
+		if i == len(input)-1 {
+			return nil, nil, fmt.Errorf("input contains only system messages")
+		}
+	}
 
-	for _, msg := range input {
+	for _, msg := range input[:firstNonSystem] {
+		blocks, err := toSystemBlocks(msg)
+		if err != nil {
+			return nil, nil, err
+		}
+		sysInstruction = append(sysInstruction, blocks...)
+	}
+
+	for _, msg := range input[firstNonSystem:] {
 		switch msg.Role {
 		case schema.AgenticRoleTypeSystem:
-			if systemDone {
-				return nil, nil, fmt.Errorf("system message must appear before all non-system messages")
-			}
-			blocks, err := toSystemBlocks(msg)
+			msgParam, err := toSystemMessageParam(msg)
 			if err != nil {
 				return nil, nil, err
 			}
-			systemBlocks = append(systemBlocks, blocks...)
+			msgParams = append(msgParams, msgParam)
 
 		case schema.AgenticRoleTypeUser:
-			systemDone = true
 			msgParam, err := toUserMessageParam(msg)
 			if err != nil {
 				return nil, nil, err
@@ -54,7 +67,6 @@ func toAnthropicMessages(input []*schema.AgenticMessage) (systemBlocks []anthrop
 			msgParams = append(msgParams, msgParam)
 
 		case schema.AgenticRoleTypeAssistant:
-			systemDone = true
 			msgParam, err := toAssistantMessageParam(msg)
 			if err != nil {
 				return nil, nil, err
@@ -67,8 +79,9 @@ func toAnthropicMessages(input []*schema.AgenticMessage) (systemBlocks []anthrop
 	}
 
 	msgParams = mergeAdjacentToolResults(msgParams)
+	msgParams = mergeAdjacentSystemMessages(msgParams)
 
-	return systemBlocks, msgParams, nil
+	return sysInstruction, msgParams, nil
 }
 
 // mergeAdjacentToolResults merges adjacent tool-result user messages into one.
@@ -90,6 +103,25 @@ func mergeAdjacentToolResults(msgParams []anthropic.MessageParam) []anthropic.Me
 	return result
 }
 
+// mergeAdjacentSystemMessages merges consecutive system messages into a single
+// message with multiple content blocks, because Claude only allows a system
+// message immediately before a user or assistant message.
+func mergeAdjacentSystemMessages(msgParams []anthropic.MessageParam) []anthropic.MessageParam {
+	if len(msgParams) <= 1 {
+		return msgParams
+	}
+
+	result := make([]anthropic.MessageParam, 0, len(msgParams))
+	for _, mp := range msgParams {
+		if len(result) > 0 && mp.Role == anthropic.MessageParamRoleSystem && result[len(result)-1].Role == anthropic.MessageParamRoleSystem {
+			result[len(result)-1].Content = append(result[len(result)-1].Content, mp.Content...)
+		} else {
+			result = append(result, mp)
+		}
+	}
+	return result
+}
+
 // isToolResultMessage reports whether a message consists solely of tool_result
 // content blocks.
 func isToolResultMessage(mp anthropic.MessageParam) bool {
@@ -102,6 +134,21 @@ func isToolResultMessage(mp anthropic.MessageParam) bool {
 		}
 	}
 	return true
+}
+
+func toSystemMessageParam(msg *schema.AgenticMessage) (anthropic.MessageParam, error) {
+	blocks, err := toSystemBlocks(msg)
+	if err != nil {
+		return anthropic.MessageParam{}, err
+	}
+	contentBlocks := make([]anthropic.ContentBlockParamUnion, 0, len(blocks))
+	for _, b := range blocks {
+		contentBlocks = append(contentBlocks, anthropic.ContentBlockParamUnion{OfText: &b})
+	}
+	return anthropic.MessageParam{
+		Role:    anthropic.MessageParamRoleSystem,
+		Content: contentBlocks,
+	}, nil
 }
 
 func toSystemBlocks(msg *schema.AgenticMessage) ([]anthropic.TextBlockParam, error) {

--- a/components/model/agenticclaude/convertor_test.go
+++ b/components/model/agenticclaude/convertor_test.go
@@ -345,13 +345,22 @@ func TestToAnthropicMessagesErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("system after user", func(t *testing.T) {
-		_, _, err := toAnthropicMessages([]*schema.AgenticMessage{
+	t.Run("system after user is allowed inline", func(t *testing.T) {
+		sysInstruction, msgParams, err := toAnthropicMessages([]*schema.AgenticMessage{
 			schema.UserAgenticMessage("hello"),
 			schema.SystemAgenticMessage("late system"),
 		})
-		if err == nil || err.Error() != "system message must appear before all non-system messages" {
+		if err != nil {
 			t.Fatalf("toAnthropicMessages() error = %v", err)
+		}
+		if len(sysInstruction) != 0 {
+			t.Fatalf("expected no sysInstruction, got %d", len(sysInstruction))
+		}
+		if len(msgParams) != 2 {
+			t.Fatalf("expected 2 msgParams, got %d", len(msgParams))
+		}
+		if msgParams[1].Role != anthropic.MessageParamRoleSystem {
+			t.Fatalf("expected system role for msgParams[1], got %s", msgParams[1].Role)
 		}
 	})
 }

--- a/components/model/agenticclaude/go.mod
+++ b/components/model/agenticclaude/go.mod
@@ -1,9 +1,9 @@
 module github.com/cloudwego/eino-ext/components/model/agenticclaude
 
-go 1.23.0
+go 1.24
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.42.0
+	github.com/anthropics/anthropic-sdk-go v1.56.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/bytedance/sonic v1.15.0
@@ -43,18 +43,19 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nikolalohinski/gonja v1.5.3 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f // indirect
-	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829 // indirect
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -67,6 +68,7 @@ require (
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect

--- a/components/model/agenticclaude/go.sum
+++ b/components/model/agenticclaude/go.sum
@@ -9,6 +9,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
 github.com/anthropics/anthropic-sdk-go v1.42.0 h1:Zv882/dnrE4OHnwhMAsi9lwVVXRF8GtR3ofiBResYUw=
 github.com/anthropics/anthropic-sdk-go v1.42.0/go.mod h1:r4eaLX9tBolUrXLOrLj7eU8tmeBtoobCkM0kBsivBaY=
+github.com/anthropics/anthropic-sdk-go v1.56.0 h1:idVU14wOZ06D0GBNEvuhn927xXmBVEquo0469iDwLsc=
+github.com/anthropics/anthropic-sdk-go v1.56.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
 github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3 h1:tW1/Rkad38LA15X4UQtjXZXNKsCgkshC3EbmcUmghTg=
@@ -125,6 +127,8 @@ github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfre
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -157,6 +161,8 @@ github.com/nikolalohinski/gonja v1.5.3/go.mod h1:RmjwxNiXAEqcq1HeK5SSMmqFJvKOfTf
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -177,6 +183,8 @@ github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sS
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829 h1:zGlGD0Zfk2HaIo4EnUVBRhnXQ+cnGQz5X2PdBcplOyw=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -191,6 +199,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -221,6 +230,8 @@ go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGX
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/arch v0.11.0 h1:KXV8WWKCXm6tRpLirl2szsO5j/oOODwZf4hATmGVNs4=
 golang.org/x/arch v0.11.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/components/model/agenticclaude/model.go
+++ b/components/model/agenticclaude/model.go
@@ -463,11 +463,11 @@ func (m *Model) genRequestAndOptions(input []*schema.AgenticMessage, options *mo
 		req.Thinking = *m.thinking
 	}
 
-	system, messages, err := toAnthropicMessages(input)
+	sysInstruction, messages, err := toAnthropicMessages(input)
 	if err != nil {
 		return nil, nil, fmt.Errorf("convert input messages failed: %w", err)
 	}
-	req.System = system
+	req.System = sysInstruction
 	req.Messages = messages
 
 	err = m.populateTools(req, options, specOptions)

--- a/components/model/agenticgemini/conv.go
+++ b/components/model/agenticgemini/conv.go
@@ -88,9 +88,13 @@ func convAgenticMessage(message *schema.AgenticMessage) (*genai.Content, error) 
 
 	isSelfGenerated := isSelfGeneratedMessage(message)
 
-	var err error
+	role, err := toGeminiRole(message.Role)
+	if err != nil {
+		return nil, err
+	}
+
 	content := &genai.Content{
-		Role: toGeminiRole(message.Role),
+		Role: role,
 	}
 
 	for _, block := range message.ContentBlocks {
@@ -627,11 +631,18 @@ func convAgenticFileData(data *genai.FileData) (*schema.ContentBlock, error) {
 	}
 }
 
-func toGeminiRole(role schema.AgenticRoleType) string {
-	if role == schema.AgenticRoleTypeAssistant {
-		return roleModel
+func toGeminiRole(role schema.AgenticRoleType) (string, error) {
+	switch role {
+	case schema.AgenticRoleTypeAssistant:
+		return roleModel, nil
+	case schema.AgenticRoleTypeSystem:
+		// not documented but works in practice with correct priority
+		return "system", nil
+	case schema.AgenticRoleTypeUser:
+		return roleUser, nil
+	default:
+		return "", fmt.Errorf("unsupported role: %s", role)
 	}
-	return roleUser
 }
 
 func populateStreamingMeta(curBlocks []*schema.ContentBlock, curIndex int, lastType schema.ContentBlockType) (int, schema.ContentBlockType) {

--- a/components/model/agenticgemini/model_test.go
+++ b/components/model/agenticgemini/model_test.go
@@ -372,7 +372,7 @@ func TestPrefixCache(t *testing.T) {
 
 	ctx := context.Background()
 
-	ret, err := g.CreatePrefixCache(ctx, []*schema.AgenticMessage{{}})
+	ret, err := g.CreatePrefixCache(ctx, []*schema.AgenticMessage{{Role: schema.AgenticRoleTypeUser}})
 	assert.NoError(t, err)
 	assert.Equal(t, "name", ret.Name)
 }

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -558,26 +558,22 @@ func toAnthropicDeferredToolParam(tools []*schema.ToolInfo) ([]anthropic.ToolUni
 }
 
 func preProcessMessages(input []*schema.Message) ([]*schema.Message, []*schema.Message, error) {
-	userMsgIdx := -1
+	firstNonSystem := 0
 	for i, msg := range input {
 		if msg.Role != schema.System {
-			if msg.Role != schema.User {
-				// claude requires first message to be user msg
-				// as specified in https://docs.anthropic.com/en/api/messages:
-				// 'You can specify a single user-role message,
-				// or you can include multiple user and assistant messages.'
-				return nil, nil, errors.New("first non-system message should be user message")
-			}
-			userMsgIdx = i
+			firstNonSystem = i
 			break
+		}
+		if i == len(input)-1 {
+			return nil, nil, errors.New("only system message in input, require at least 1 user message")
 		}
 	}
 
-	if userMsgIdx == -1 {
-		return nil, nil, errors.New("only system message in input, require at least 1 user message")
+	if input[firstNonSystem].Role != schema.User {
+		return nil, nil, errors.New("first non-system message should be user message")
 	}
 
-	return input[:userMsgIdx], input[userMsgIdx:], nil
+	return input[:firstNonSystem], input[firstNonSystem:], nil
 }
 
 func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.Option) (
@@ -587,7 +583,7 @@ func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.
 		return anthropic.MessageNewParams{}, fmt.Errorf("input is empty")
 	}
 
-	system, msgs, err := preProcessMessages(input)
+	sysInstruction, msgs, err := preProcessMessages(input)
 	if err != nil {
 		return anthropic.MessageNewParams{}, err
 	}
@@ -658,7 +654,7 @@ func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.
 		return anthropic.MessageNewParams{}, err
 	}
 
-	if err = cm.populateInput(&params, system, msgs, specOptions); err != nil {
+	if err = cm.populateInput(&params, sysInstruction, msgs, specOptions); err != nil {
 		return anthropic.MessageNewParams{}, err
 	}
 
@@ -670,10 +666,10 @@ func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.
 	return params, nil
 }
 
-func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []*schema.Message, msgs []*schema.Message, specOptions *options) error {
+func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, sysInstruction []*schema.Message, msgs []*schema.Message, specOptions *options) error {
 	// populate system messages
 	hasSetSysBreakPoint := false
-	for _, m := range system {
+	for _, m := range sysInstruction {
 		block := anthropic.TextBlockParam{Text: m.Content}
 		if isBreakpointMessage(m) {
 			hasSetSysBreakPoint = true
@@ -706,6 +702,7 @@ func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, system []
 	}
 
 	msgParams = mergeAdjacentToolResults(msgParams)
+	msgParams = mergeAdjacentSystemMessages(msgParams)
 
 	if !hasSetMsgBreakPoint && specOptions.AutoCacheControl != nil {
 		lastMsgParam := msgParams[len(msgParams)-1]
@@ -729,6 +726,25 @@ func mergeAdjacentToolResults(msgParams []anthropic.MessageParam) []anthropic.Me
 	result := make([]anthropic.MessageParam, 0, len(msgParams))
 	for _, mp := range msgParams {
 		if len(result) > 0 && isToolResultMessage(mp) && isToolResultMessage(result[len(result)-1]) {
+			result[len(result)-1].Content = append(result[len(result)-1].Content, mp.Content...)
+		} else {
+			result = append(result, mp)
+		}
+	}
+	return result
+}
+
+// mergeAdjacentSystemMessages merges consecutive system messages into a single
+// message with multiple content blocks, because Claude only allows a system
+// message immediately before a user or assistant message.
+func mergeAdjacentSystemMessages(msgParams []anthropic.MessageParam) []anthropic.MessageParam {
+	if len(msgParams) <= 1 {
+		return msgParams
+	}
+
+	result := make([]anthropic.MessageParam, 0, len(msgParams))
+	for _, mp := range msgParams {
+		if len(result) > 0 && mp.Role == anthropic.MessageParamRoleSystem && result[len(result)-1].Role == anthropic.MessageParamRoleSystem {
 			result[len(result)-1].Content = append(result[len(result)-1].Content, mp.Content...)
 		} else {
 			result = append(result, mp)
@@ -1185,6 +1201,11 @@ func convSchemaMessage(message *schema.Message) (mp anthropic.MessageParam, err 
 		mp = anthropic.NewAssistantMessage(messageParams...)
 	case schema.User, schema.Tool:
 		mp = anthropic.NewUserMessage(messageParams...)
+	case schema.System:
+		mp = anthropic.MessageParam{
+			Role:    anthropic.MessageParamRoleSystem,
+			Content: messageParams,
+		}
 	default:
 		mp = anthropic.NewUserMessage(messageParams...)
 	}

--- a/components/model/claude/go.mod
+++ b/components/model/claude/go.mod
@@ -1,15 +1,15 @@
 module github.com/cloudwego/eino-ext/components/model/claude
 
-go 1.23.0
+go 1.24
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.37.0
+	github.com/anthropics/anthropic-sdk-go v1.56.0
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.54
 	github.com/bytedance/mockey v1.2.13
 	github.com/cloudwego/eino v0.9.1
 	github.com/eino-contrib/jsonschema v1.0.3
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 )
 
@@ -47,6 +47,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
@@ -54,6 +55,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nikolalohinski/gonja v1.5.3 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -61,6 +63,7 @@ require (
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f // indirect
 	github.com/smarty/assertions v1.15.0 // indirect
 	github.com/smartystreets/goconvey v1.8.1 // indirect
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -73,13 +76,14 @@ require (
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/api v0.189.0 // indirect

--- a/components/model/claude/go.sum
+++ b/components/model/claude/go.sum
@@ -9,6 +9,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
 github.com/anthropics/anthropic-sdk-go v1.37.0 h1:yBKUaBG3TCRb6das/Q5qNB9Fsafon09gu2yYVgvapKE=
 github.com/anthropics/anthropic-sdk-go v1.37.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
+github.com/anthropics/anthropic-sdk-go v1.56.0 h1:idVU14wOZ06D0GBNEvuhn927xXmBVEquo0469iDwLsc=
+github.com/anthropics/anthropic-sdk-go v1.56.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/aws/aws-sdk-go-v2 v1.33.0 h1:Evgm4DI9imD81V0WwD+TN4DCwjUMdc94TrduMLbgZJs=
 github.com/aws/aws-sdk-go-v2 v1.33.0/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3 h1:tW1/Rkad38LA15X4UQtjXZXNKsCgkshC3EbmcUmghTg=
@@ -123,6 +125,8 @@ github.com/goph/emperror v0.17.2/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -155,6 +159,8 @@ github.com/nikolalohinski/gonja v1.5.3/go.mod h1:RmjwxNiXAEqcq1HeK5SSMmqFJvKOfTf
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -173,6 +179,8 @@ github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGB
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -187,6 +195,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -219,6 +229,8 @@ go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/arch v0.11.0 h1:KXV8WWKCXm6tRpLirl2szsO5j/oOODwZf4hATmGVNs4=
 golang.org/x/arch v0.11.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -258,6 +270,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=
 golang.org/x/term v0.33.0/go.mod h1:s18+ql9tYWp1IfpV9DmCtQDDSRBUjKaw9M1eAv5UeF0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/components/model/gemini/gemini.go
+++ b/components/model/gemini/gemini.go
@@ -801,8 +801,13 @@ func convSchemaMessage(message *schema.Message) (*genai.Content, error) {
 		}, nil
 	}
 
+	role, err := toGeminiRole(message.Role)
+	if err != nil {
+		return nil, err
+	}
+
 	content := &genai.Content{
-		Role: toGeminiRole(message.Role),
+		Role: role,
 	}
 
 	// Restore reasoning content as a thought part (required for gemini-3-pro-preview and later)
@@ -1394,11 +1399,18 @@ const (
 	roleUser  = "user"
 )
 
-func toGeminiRole(role schema.RoleType) string {
-	if role == schema.Assistant {
-		return roleModel
+func toGeminiRole(role schema.RoleType) (string, error) {
+	switch role {
+	case schema.Assistant:
+		return roleModel, nil
+	case schema.System:
+		// not documented but works in practice with correct priority
+		return "system", nil
+	case schema.User, schema.Tool:
+		return roleUser, nil
+	default:
+		return "", fmt.Errorf("unsupported role: %s", role)
 	}
-	return roleUser
 }
 
 const typ = "Gemini"

--- a/components/model/qianfan/chatmodel.go
+++ b/components/model/qianfan/chatmodel.go
@@ -710,8 +710,10 @@ func resolveQianfanResponse(resp *qianfan.ChatCompletionV2Response) (*schema.Mes
 
 func toQianfanRole(role string) (string, error) {
 	switch role {
-	case "user", "system":
+	case "user":
 		return "user", nil
+	case "system":
+		return "system", nil
 	case "assistant":
 		return "assistant", nil
 	case "tool":


### PR DESCRIPTION
## Summary

Adds support for system messages appearing at any position in the conversation, not just at the beginning. This enables richer prompt engineering patterns where system instructions can be injected between user/assistant turns.

## API Changes

None. No exported types, functions, or fields were added, removed, or renamed.

## Key Changes

1. **Claude / AgenticClaude**: Leading system messages still go to the top-level `system` instruction field. Mid-conversation system messages are kept inline using `MessageParamRoleSystem` (SDK upgraded to v1.56.0). Consecutive inline system messages are merged into a single message with multiple content blocks.
2. **Gemini / AgenticGemini**: Leading system messages still populate `SystemInstruction`. Mid-conversation system messages are passed with role `"system"` directly in the content array. The `toGeminiRole` default case now returns an error instead of silently falling back to `"user"`.
3. **Qianfan**: The `toQianfanRole` function now passes `"system"` through as its own role instead of mapping it to `"user"`.