### PR TITLE
fix(openai): default empty tool arguments to JSON object

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -375,13 +375,17 @@ func toOpenAIToolCalls(toolCalls []schema.ToolCall) []openai.ToolCall {
 	ret := make([]openai.ToolCall, len(toolCalls))
 	for i := range toolCalls {
 		toolCall := toolCalls[i]
+		arguments := toolCall.Function.Arguments
+		if arguments == "" {
+			arguments = "{}"
+		}
 		ret[i] = openai.ToolCall{
 			Index: toolCall.Index,
 			ID:    toolCall.ID,
 			Type:  openai.ToolTypeFunction,
 			Function: openai.FunctionCall{
 				Name:      toolCall.Function.Name,
-				Arguments: toolCall.Function.Arguments,
+				Arguments: arguments,
 			},
 		}
 	}

--- a/libs/acl/openai/chat_model_test.go
+++ b/libs/acl/openai/chat_model_test.go
@@ -266,6 +266,18 @@ func TestToOpenAIToolCalls(t *testing.T) {
 		assert.Equal(t, fakeToolCall1.ID, toolCalls[0].ID)
 		assert.Equal(t, fakeToolCall1.Function.Name, toolCalls[0].Function.Name)
 	})
+
+	t.Run("empty arguments", func(t *testing.T) {
+		fakeToolCall := schema.ToolCall{
+			ID:       randStr(),
+			Function: schema.FunctionCall{Name: randStr()},
+		}
+
+		toolCalls := toOpenAIToolCalls([]schema.ToolCall{fakeToolCall})
+
+		assert.Len(t, toolCalls, 1)
+		assert.Equal(t, "{}", toolCalls[0].Function.Arguments)
+	})
 }
 
 func randStr() string {


### PR DESCRIPTION
## Summary
- normalize empty schema tool-call arguments to {} when building OpenAI requests
- preserve non-empty argument payloads
- add regression coverage for no-argument tool calls

## Why
OpenAI-compatible APIs reject assistant tool calls when the function arguments field is omitted. Streaming no-argument tool calls may be represented as an empty string, so the adapter should emit an empty JSON object.

Fixes cloudwego/eino#493

## Validation
- go test with the Mockey-required no-optimization gcflags from libs/acl/openai