### PR TITLE
fix(local): use native shell on Windows

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -262,11 +262,10 @@ var defaultValidateCommand = func(string) error {
 
 // NewBackend creates a new local filesystem Local instance.
 //
-// IMPORTANT - System Compatibility:
-//   - Supported: Unix/MacOS only
-//   - NOT Supported: Windows (requires custom implementation of filesystem.Backend)
-//   - Command Execution: Uses /bin/sh by default for Execute method
-//   - If /bin/sh does not meet your requirements, please implement your own filesystem.Backend
+// IMPORTANT - Command Execution:
+//   - Unix/macOS use /bin/sh.
+//   - Windows uses cmd.exe.
+//   - If the system shell does not meet your requirements, implement your own filesystem.Backend.
 func NewBackend(_ context.Context, cfg *Config) (*Local, error) {
 	if cfg == nil {
 		return nil, errors.New("config is required")
@@ -987,7 +986,7 @@ func (s *Local) Execute(ctx context.Context, input *filesystem.ExecuteRequest) (
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", input.Command)
+	cmd := newShellCmd(ctx, input.Command)
 
 	var stdoutBuf, stderrBuf strings.Builder
 	cmd.Stdout = &stdoutBuf
@@ -1023,7 +1022,7 @@ func (s *Local) Execute(ctx context.Context, input *filesystem.ExecuteRequest) (
 
 // initStreamingCmd creates command with stdout and stderr pipes.
 func (s *Local) initStreamingCmd(ctx context.Context, command string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+	cmd := newShellCmd(ctx, command)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -1037,6 +1036,13 @@ func (s *Local) initStreamingCmd(ctx context.Context, command string) (*exec.Cmd
 	}
 
 	return cmd, stdout, stderr, nil
+}
+
+func newShellCmd(ctx context.Context, command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd.exe", "/C", command)
+	}
+	return exec.CommandContext(ctx, "/bin/sh", "-c", command)
 }
 
 // runCmdInBackground executes command in background without waiting for completion.

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -791,6 +792,21 @@ func TestExecuteStreaming(t *testing.T) {
 
 		assert.Less(t, elapsed, 2*time.Second, "background command should return immediately without waiting")
 	})
+}
+
+func TestNewShellCmd(t *testing.T) {
+	command := "echo hello"
+	cmd := newShellCmd(context.Background(), command)
+
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, []string{"cmd.exe", "/C", command}, cmd.Args)
+	} else {
+		assert.Equal(t, []string{"/bin/sh", "-c", command}, cmd.Args)
+	}
+
+	output, err := cmd.Output()
+	require.NoError(t, err)
+	assert.Equal(t, "hello", strings.TrimSpace(string(output)))
 }
 
 func TestExecute(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

fix(local): 在 Windows 上使用原生 shell

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`Local.Execute` and `Local.ExecuteStreaming` always started `/bin/sh -c`, so both paths failed on Windows before a command could run. This change centralizes shell selection: Windows uses `cmd.exe /C`, while Unix and macOS keep `/bin/sh -c`.

The regression test verifies the platform-specific arguments and executes the selected shell. On Windows, targeted synchronous and streaming cases pass for successful output, stderr, non-zero exit codes, missing commands, and stream completion.

Validation:

- `go test -run '^(TestNewShellCmd|TestExecuteStreaming/(ExecuteStreaming_with_echo|ExecuteStreaming_with_command_failure|ExecuteStreaming_with_stderr_output|ExecuteStreaming_with_empty_command|ExecuteStreaming_with_normal_completion)|TestExecute/(empty_command|non-zero_exit_code|non-zero_exit_code_with_stderr|command_not_found))$' ./...`
- The full Windows suite still stops in pre-existing Unix-specific tests: `TestLsInfo/path_is_a_file,_not_a_directory` and `TestGrepRaw/grep_successfully` (hard-coded `/tmp/test`).

zh(optional):

`Local.Execute` 和 `Local.ExecuteStreaming` 原先都固定调用 `/bin/sh -c`，导致 Windows 在命令启动前直接失败。本修复统一选择系统 shell：Windows 使用 `cmd.exe /C`，Unix 和 macOS 保持 `/bin/sh -c`。

#### (Optional) Which issue(s) this PR fixes:

Fixes #896

#### (optional) The PR that updates user documentation:

N/A
