### PR TITLE
feat(claude): add RequestTimeout config and per-request option

### DIFF
--- a/components/model/agenticclaude/README.md
+++ b/components/model/agenticclaude/README.md
@@ -101,6 +101,10 @@ type Config struct {
     // Optional.
     HTTPClient *http.Client
 
+    // RequestTimeout specifies the timeout for each API request.
+    // Optional.
+    RequestTimeout time.Duration
+
     // ByBedrock specifies the configuration for using AWS Bedrock.
     // Optional.
     ByBedrock *BedrockConfig

--- a/components/model/agenticclaude/README_zh.md
+++ b/components/model/agenticclaude/README_zh.md
@@ -101,6 +101,10 @@ type Config struct {
     // 可选。
     HTTPClient *http.Client
 
+    // RequestTimeout 指定每次 API 请求的超时时间。
+    // 可选。
+    RequestTimeout time.Duration
+
     // ByBedrock 指定使用 AWS Bedrock 的配置。
     // 可选。
     ByBedrock *BedrockConfig

--- a/components/model/agenticclaude/model.go
+++ b/components/model/agenticclaude/model.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/bedrock"
@@ -46,6 +47,10 @@ type Config struct {
 	// It is not applied when using Google Vertex AI.
 	// Optional.
 	HTTPClient *http.Client
+
+	// RequestTimeout specifies the timeout for each API request.
+	// Optional.
+	RequestTimeout time.Duration
 
 	// ByBedrock specifies the configuration for using AWS Bedrock.
 	// Optional.
@@ -178,6 +183,7 @@ type Model struct {
 	extraFields            map[string]any
 	thinking               *anthropic.ThinkingConfigParamUnion
 	cacheControl           *anthropic.CacheControlEphemeralParam
+	requestTimeout         time.Duration
 }
 
 type ServerToolConfig struct {
@@ -227,6 +233,7 @@ func New(ctx context.Context, cfg *Config) (*Model, error) {
 		extraFields:            cfg.ExtraFields,
 		thinking:               cfg.Thinking,
 		cacheControl:           cfg.CacheControl,
+		requestTimeout:         cfg.RequestTimeout,
 	}, nil
 }
 
@@ -312,12 +319,12 @@ func (m *Model) Generate(ctx context.Context, input []*schema.AgenticMessage, op
 		return nil, err
 	}
 
-	req, reqOpts, err := m.genRequestAndOptions(input, options, specOptions)
+	msgParams, reqOpts, err := m.genParamsAndOptions(input, options, specOptions)
 	if err != nil {
 		return nil, fmt.Errorf("generate request failed: %w", err)
 	}
 
-	callbackConfig := toCallbackConfig(req)
+	callbackConfig := toCallbackConfig(&msgParams)
 
 	ctx = callbacks.OnStart(ctx, &model.AgenticCallbackInput{
 		Messages: input,
@@ -330,7 +337,7 @@ func (m *Model) Generate(ctx context.Context, input []*schema.AgenticMessage, op
 		}
 	}()
 
-	resp, err := m.cli.Messages.New(ctx, *req, reqOpts...)
+	resp, err := m.cli.Messages.New(ctx, msgParams, reqOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("create message failed: %w", err)
 	}
@@ -357,12 +364,12 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 		return nil, err
 	}
 
-	req, reqOpts, err := m.genRequestAndOptions(input, options, specOptions)
+	msgParams, reqOpts, err := m.genParamsAndOptions(input, options, specOptions)
 	if err != nil {
 		return nil, fmt.Errorf("generate request failed: %w", err)
 	}
 
-	callbackConfig := toCallbackConfig(req)
+	callbackConfig := toCallbackConfig(&msgParams)
 
 	ctx = callbacks.OnStart(ctx, &model.AgenticCallbackInput{
 		Messages: input,
@@ -375,7 +382,7 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 		}
 	}()
 
-	stream := m.cli.Messages.NewStreaming(ctx, *req, reqOpts...)
+	stream := m.cli.Messages.NewStreaming(ctx, msgParams, reqOpts...)
 	if stream.Err() != nil {
 		return nil, fmt.Errorf("create message stream failed: %w", stream.Err())
 	}
@@ -402,8 +409,9 @@ func (m *Model) Stream(ctx context.Context, input []*schema.AgenticMessage, opts
 			}
 
 			closed := sw.Send(&model.AgenticCallbackOutput{
-				Message: chunk,
-				Config:  callbackConfig,
+				Message:    chunk,
+				Config:     callbackConfig,
+				TokenUsage: toModelTokenUsage(chunk.ResponseMeta),
 			}, nil)
 			if closed {
 				return
@@ -440,47 +448,46 @@ func (m *Model) IsCallbacksEnabled() bool {
 	return true
 }
 
-func (m *Model) genRequestAndOptions(input []*schema.AgenticMessage, options *model.Options,
-	specOptions *claudeOptions) (req *anthropic.MessageNewParams, reqOpts []option.RequestOption, err error) {
+func (m *Model) genParamsAndOptions(input []*schema.AgenticMessage, options *model.Options,
+	specOptions *claudeOptions) (msgParams anthropic.MessageNewParams, reqOpts []option.RequestOption, err error) {
 
-	req = &anthropic.MessageNewParams{}
 	if options.Model != nil {
-		req.Model = *options.Model
+		msgParams.Model = *options.Model
 	}
 	if options.MaxTokens != nil {
-		req.MaxTokens = int64(*options.MaxTokens)
+		msgParams.MaxTokens = int64(*options.MaxTokens)
 	}
 	if options.Temperature != nil {
-		req.Temperature = param.NewOpt(float64(*options.Temperature))
+		msgParams.Temperature = param.NewOpt(float64(*options.Temperature))
 	}
 	if options.TopP != nil {
-		req.TopP = param.NewOpt(float64(*options.TopP))
+		msgParams.TopP = param.NewOpt(float64(*options.TopP))
 	}
 	if len(options.Stop) > 0 {
-		req.StopSequences = options.Stop
+		msgParams.StopSequences = options.Stop
 	}
 	if m.thinking != nil {
-		req.Thinking = *m.thinking
+		msgParams.Thinking = *m.thinking
 	}
 
 	sysInstruction, messages, err := toAnthropicMessages(input)
 	if err != nil {
-		return nil, nil, fmt.Errorf("convert input messages failed: %w", err)
+		err = fmt.Errorf("convert input messages failed: %w", err)
+		return msgParams, reqOpts, err
 	}
-	req.System = sysInstruction
-	req.Messages = messages
+	msgParams.System = sysInstruction
+	msgParams.Messages = messages
 
-	err = m.populateTools(req, options, specOptions)
-	if err != nil {
-		return nil, nil, err
+	if err = m.populateTools(&msgParams, options, specOptions); err != nil {
+		return msgParams, reqOpts, err
 	}
 
-	if err = m.populateToolChoice(req, options); err != nil {
-		return nil, nil, err
+	if err = m.populateToolChoice(&msgParams, options); err != nil {
+		return msgParams, reqOpts, err
 	}
 
 	if m.cacheControl != nil {
-		req.CacheControl = *m.cacheControl
+		msgParams.CacheControl = *m.cacheControl
 	}
 
 	reqOpts = appendCustomHeaders(reqOpts, specOptions.serverTools, specOptions.customHeaders)
@@ -488,7 +495,15 @@ func (m *Model) genRequestAndOptions(input []*schema.AgenticMessage, options *mo
 		reqOpts = append(reqOpts, option.WithJSONSet(k, v))
 	}
 
-	return req, reqOpts, nil
+	timeout := m.requestTimeout
+	if specOptions.requestTimeout > 0 {
+		timeout = specOptions.requestTimeout
+	}
+	if timeout > 0 {
+		reqOpts = append(reqOpts, option.WithRequestTimeout(timeout))
+	}
+
+	return msgParams, reqOpts, nil
 }
 
 func appendCustomHeaders(reqOpts []option.RequestOption, serverTools []*ServerToolConfig, customHeaders map[string]string) []option.RequestOption {

--- a/components/model/agenticclaude/model_test.go
+++ b/components/model/agenticclaude/model_test.go
@@ -388,12 +388,12 @@ func TestGenRequestAndOptions(t *testing.T) {
 		},
 	}
 
-	req, reqOpts, err := m.genRequestAndOptions([]*schema.AgenticMessage{
+	req, reqOpts, err := m.genParamsAndOptions([]*schema.AgenticMessage{
 		schema.SystemAgenticMessage("system prompt"),
 		schema.UserAgenticMessage("hello"),
 	}, options, specOptions)
 	if err != nil {
-		t.Fatalf("genRequestAndOptions() error = %v", err)
+		t.Fatalf("genParamsAndOptions() error = %v", err)
 	}
 	if req.Model != anthropic.Model(modelName) || req.MaxTokens != int64(maxTokens) {
 		t.Fatalf("request model/max_tokens = (%q, %d)", req.Model, req.MaxTokens)

--- a/components/model/agenticclaude/option.go
+++ b/components/model/agenticclaude/option.go
@@ -16,12 +16,17 @@
 
 package agenticclaude
 
-import "github.com/cloudwego/eino/components/model"
+import (
+	"time"
+
+	"github.com/cloudwego/eino/components/model"
+)
 
 type claudeOptions struct {
-	serverTools   []*ServerToolConfig
-	customHeaders map[string]string
-	extraFields   map[string]any
+	serverTools    []*ServerToolConfig
+	customHeaders  map[string]string
+	extraFields    map[string]any
+	requestTimeout time.Duration
 }
 
 // WithServerTools specifies server-side tools available to the model.
@@ -59,5 +64,13 @@ func WithCustomHeaders(headers map[string]string) model.Option {
 func WithExtraFields(fields map[string]any) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *claudeOptions) {
 		o.extraFields = fields
+	})
+}
+
+// WithRequestTimeout sets the timeout for each API request.
+// This overrides the RequestTimeout set in Config for a single call.
+func WithRequestTimeout(d time.Duration) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *claudeOptions) {
+		o.requestTimeout = d
 	})
 }

--- a/components/model/claude/README.md
+++ b/components/model/claude/README.md
@@ -211,6 +211,10 @@ type Config struct {
 
     // HTTPClient specifies the client to send HTTP requests.
     HTTPClient *http.Client `json:"http_client"`
+
+    // RequestTimeout specifies the timeout for each API request.
+    // Optional.
+    RequestTimeout time.Duration `json:"request_timeout"`
     
     DisableParallelToolUse *bool `json:"disable_parallel_tool_use"`
 }

--- a/components/model/claude/README_zh.md
+++ b/components/model/claude/README_zh.md
@@ -210,6 +210,10 @@ type Config struct {
 
     // HTTPClient specifies the client to send HTTP requests.
     HTTPClient *http.Client `json:"http_client"`
+
+    // RequestTimeout specifies the timeout for each API request.
+    // Optional.
+    RequestTimeout time.Duration `json:"request_timeout"`
     
     DisableParallelToolUse *bool `json:"disable_parallel_tool_use"`
 }

--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/bedrock"
@@ -170,6 +171,7 @@ func NewChatModel(ctx context.Context, config *Config) (*ChatModel, error) {
 		responseFormat:         config.ResponseFormat,
 		disableParallelToolUse: config.DisableParallelToolUse,
 		toolSearchAlgorithm:    config.ToolSearchAlgorithm,
+		requestTimeout:         config.RequestTimeout,
 	}, nil
 }
 
@@ -275,6 +277,10 @@ type Config struct {
 	// HTTPClient specifies the client to send HTTP requests.
 	HTTPClient *http.Client `json:"http_client"`
 
+	// RequestTimeout specifies the timeout for each API request.
+	// Optional.
+	RequestTimeout time.Duration `json:"request_timeout"`
+
 	DisableParallelToolUse *bool `json:"disable_parallel_tool_use"`
 
 	// ToolSearchAlgorithm specifies the server-side tool search algorithm.
@@ -330,6 +336,7 @@ type ChatModel struct {
 	disableParallelToolUse *bool
 	origDeferredTools      []*schema.ToolInfo
 	toolSearchAlgorithm    ToolSearchAlgorithm
+	requestTimeout         time.Duration
 }
 
 func hasDirectAnthropicConfigAuth(config *Config) bool {
@@ -361,12 +368,12 @@ func (cm *ChatModel) Generate(ctx context.Context, input []*schema.Message, opts
 		}
 	}()
 
-	msgParam, err := cm.genMessageNewParams(input, opts...)
+	msgParams, reqOpts, err := cm.genParamsAndOptions(input, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := cm.cli.Messages.New(ctx, msgParam)
+	resp, err := cm.cli.Messages.New(ctx, msgParams, reqOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("create new message fail: %w", err)
 	}
@@ -390,11 +397,12 @@ func (cm *ChatModel) Stream(ctx context.Context, input []*schema.Message, opts .
 		}
 	}()
 
-	msgParam, err := cm.genMessageNewParams(input, opts...)
+	msgParams, reqOpts, err := cm.genParamsAndOptions(input, opts...)
 	if err != nil {
 		return nil, err
 	}
-	stream := cm.cli.Messages.NewStreaming(ctx, msgParam)
+
+	stream := cm.cli.Messages.NewStreaming(ctx, msgParams, reqOpts...)
 	// the stream error that occurred at this time should be terminated and returned.
 	if stream.Err() != nil {
 		return nil, fmt.Errorf("create new streaming message fail: %w", stream.Err())
@@ -595,16 +603,17 @@ func preProcessMessages(input []*schema.Message) ([]*schema.Message, []*schema.M
 	return input[:firstNonSystem], input[firstNonSystem:], nil
 }
 
-func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.Option) (
-	anthropic.MessageNewParams, error,
+func (cm *ChatModel) genParamsAndOptions(input []*schema.Message, opts ...model.Option) (
+	msgParams anthropic.MessageNewParams, reqOpts []option.RequestOption, err error,
 ) {
 	if len(input) == 0 {
-		return anthropic.MessageNewParams{}, fmt.Errorf("input is empty")
+		err = fmt.Errorf("input is empty")
+		return msgParams, reqOpts, err
 	}
 
 	sysInstruction, msgs, err := preProcessMessages(input)
 	if err != nil {
-		return anthropic.MessageNewParams{}, err
+		return msgParams, reqOpts, err
 	}
 
 	commonOptions := model.GetCommonOptions(&model.Options{
@@ -625,28 +634,28 @@ func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.
 		ResponseFormat:         cm.responseFormat,
 	}, opts...)
 
-	params := anthropic.MessageNewParams{}
+	msgParams = anthropic.MessageNewParams{}
 	if commonOptions.Model != nil {
-		params.Model = anthropic.Model(*commonOptions.Model)
+		msgParams.Model = anthropic.Model(*commonOptions.Model)
 	}
 	if commonOptions.MaxTokens != nil {
-		params.MaxTokens = int64(*commonOptions.MaxTokens)
+		msgParams.MaxTokens = int64(*commonOptions.MaxTokens)
 	}
 	if commonOptions.Temperature != nil {
-		params.Temperature = param.NewOpt(float64(*commonOptions.Temperature))
+		msgParams.Temperature = param.NewOpt(float64(*commonOptions.Temperature))
 	}
 	if commonOptions.TopP != nil {
-		params.TopP = param.NewOpt(float64(*commonOptions.TopP))
+		msgParams.TopP = param.NewOpt(float64(*commonOptions.TopP))
 	}
 	if len(commonOptions.Stop) > 0 {
-		params.StopSequences = commonOptions.Stop
+		msgParams.StopSequences = commonOptions.Stop
 	}
 	if specOptions.TopK != nil {
-		params.TopK = param.NewOpt(int64(*specOptions.TopK))
+		msgParams.TopK = param.NewOpt(int64(*specOptions.TopK))
 	}
 
 	if specOptions.Thinking != nil && specOptions.Thinking.Enable {
-		params.Thinking = anthropic.ThinkingConfigParamUnion{
+		msgParams.Thinking = anthropic.ThinkingConfigParamUnion{
 			OfEnabled: &anthropic.ThinkingConfigEnabledParam{
 				Type:         "enabled",
 				BudgetTokens: int64(specOptions.Thinking.BudgetTokens),
@@ -654,35 +663,47 @@ func (cm *ChatModel) genMessageNewParams(input []*schema.Message, opts ...model.
 		}
 	}
 	if specOptions.ThinkingConfig != nil {
-		params.Thinking = *specOptions.ThinkingConfig
+		msgParams.Thinking = *specOptions.ThinkingConfig
 	}
 
 	if specOptions.ResponseFormat != nil && specOptions.ResponseFormat.Schema != nil {
 		schemaMap, mErr := jsonSchemaToMap(specOptions.ResponseFormat.Schema)
 		if mErr != nil {
-			return anthropic.MessageNewParams{}, fmt.Errorf("failed to marshal response format schema: %w", mErr)
+			err = fmt.Errorf("failed to marshal response format schema: %w", mErr)
+			return msgParams, reqOpts, err
 		}
-		params.OutputConfig = anthropic.OutputConfigParam{
+		msgParams.OutputConfig = anthropic.OutputConfigParam{
 			Format: anthropic.JSONOutputFormatParam{
 				Schema: schemaMap,
 			},
 		}
 	}
 
-	if err = cm.populateTools(&params, commonOptions, specOptions); err != nil {
-		return anthropic.MessageNewParams{}, err
+	if err = cm.populateTools(&msgParams, commonOptions, specOptions); err != nil {
+		return msgParams, reqOpts, err
 	}
 
-	if err = cm.populateInput(&params, sysInstruction, msgs, specOptions); err != nil {
-		return anthropic.MessageNewParams{}, err
+	if err = cm.populateInput(&msgParams, sysInstruction, msgs, specOptions); err != nil {
+		return msgParams, reqOpts, err
 	}
 
-	// Collect tools from ToolSearchResult in Tool-role messages and add to params.Tools
-	if err = populateToolSearchResultTools(&params, msgs); err != nil {
-		return anthropic.MessageNewParams{}, err
+	// Collect tools from ToolSearchResult in Tool-role messages and add to msgParams.Tools
+	if err = populateToolSearchResultTools(&msgParams, msgs); err != nil {
+		return msgParams, reqOpts, err
 	}
 
-	return params, nil
+	timeout := cm.requestTimeout
+	if specOptions.RequestTimeout > 0 {
+		timeout = specOptions.RequestTimeout
+	}
+	if timeout > 0 {
+		reqOpts = append(reqOpts, option.WithRequestTimeout(timeout))
+	}
+	for k, v := range specOptions.CustomHeaders {
+		reqOpts = append(reqOpts, option.WithHeaderAdd(k, v))
+	}
+
+	return msgParams, reqOpts, nil
 }
 
 func (cm *ChatModel) populateInput(params *anthropic.MessageNewParams, sysInstruction []*schema.Message, msgs []*schema.Message, specOptions *options) error {

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -76,7 +76,7 @@ func TestClaude(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockey.PatchConvey("requires at least 1 user msg", t, func() {
-		_, err := model.genMessageNewParams([]*schema.Message{
+		_, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.SystemMessage("hello"),
 		})
 		assert.Error(t, err)
@@ -84,7 +84,7 @@ func TestClaude(t *testing.T) {
 	})
 
 	mockey.PatchConvey("first non system msg should be user", t, func() {
-		_, err := model.genMessageNewParams([]*schema.Message{
+		_, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.SystemMessage("hello"),
 			schema.AssistantMessage("world", nil),
 		})
@@ -93,7 +93,7 @@ func TestClaude(t *testing.T) {
 	})
 
 	mockey.PatchConvey("multiple system msg", t, func() {
-		resp, err := model.genMessageNewParams([]*schema.Message{
+		resp, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.SystemMessage("hello"),
 			schema.SystemMessage("world"),
 			schema.UserMessage("again"),
@@ -125,7 +125,7 @@ func TestClaude(t *testing.T) {
 	})
 
 	mockey.PatchConvey("legacy thinking config", t, func() {
-		resp, err := model.genMessageNewParams([]*schema.Message{
+		resp, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 		}, WithThinking(&Thinking{
 			Enable:       true,
@@ -137,7 +137,7 @@ func TestClaude(t *testing.T) {
 	})
 
 	mockey.PatchConvey("native adaptive thinking config", t, func() {
-		resp, err := model.genMessageNewParams([]*schema.Message{
+		resp, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 		}, WithThinkingConfig(&anthropic.ThinkingConfigParamUnion{
 			OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{
@@ -150,7 +150,7 @@ func TestClaude(t *testing.T) {
 	})
 
 	mockey.PatchConvey("native thinking config overrides legacy thinking", t, func() {
-		resp, err := model.genMessageNewParams([]*schema.Message{
+		resp, _, err := model.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 		}, WithThinking(&Thinking{
 			Enable:       true,
@@ -921,7 +921,7 @@ func TestCacheTTL(t *testing.T) {
 		sysMsg := schema.SystemMessage("system")
 		bpSys := SetMessageCacheControl(sysMsg, &CacheControl{TTL: CacheTTL1h})
 
-		params, err := cm.genMessageNewParams([]*schema.Message{bpSys, msg})
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{bpSys, msg})
 		assert.NoError(t, err)
 		assert.Equal(t, CacheTTL1h, params.System[0].CacheControl.TTL)
 	})
@@ -931,7 +931,7 @@ func TestCacheTTL(t *testing.T) {
 		msg := schema.UserMessage("hello")
 		sysMsg := schema.SystemMessage("system")
 
-		params, err := cm.genMessageNewParams(
+		params, _, err := cm.genParamsAndOptions(
 			[]*schema.Message{sysMsg, msg},
 			WithAutoCacheControl(&CacheControl{TTL: CacheTTL1h}),
 		)
@@ -1127,7 +1127,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	}
 
 	t.Run("single tool message unchanged", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 			toolMsg("call_1", "tool1", "result1"),
 		})
@@ -1139,7 +1139,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	})
 
 	t.Run("two consecutive tool messages merged", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 			toolMsg("call_1", "tool1", "result1"),
 			toolMsg("call_2", "tool2", "result2"),
@@ -1152,7 +1152,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	})
 
 	t.Run("three consecutive tools merged", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 			toolMsg("call_1", "t1", "r1"),
 			toolMsg("call_2", "t2", "r2"),
@@ -1164,7 +1164,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	})
 
 	t.Run("tool messages separated by non-tool are not merged", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 			toolMsg("call_1", "t1", "r1"),
 			schema.AssistantMessage("ok", nil),
@@ -1178,7 +1178,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	})
 
 	t.Run("no tool messages unchanged", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("hello"),
 			schema.AssistantMessage("hi", nil),
 		})
@@ -1187,7 +1187,7 @@ func TestPopulateInputMergeConsecutiveTools(t *testing.T) {
 	})
 
 	t.Run("real world pattern: user assistant(tool_calls) tool tool", func(t *testing.T) {
-		params, err := cm.genMessageNewParams([]*schema.Message{
+		params, _, err := cm.genParamsAndOptions([]*schema.Message{
 			schema.UserMessage("what's the weather in Paris and London?"),
 			{
 				Role:    schema.Assistant,

--- a/components/model/claude/option.go
+++ b/components/model/claude/option.go
@@ -17,6 +17,8 @@
 package claude
 
 import (
+	"time"
+
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/cloudwego/eino/components/model"
 )
@@ -33,6 +35,10 @@ type options struct {
 	AutoCacheControl *CacheControl
 
 	ResponseFormat *ResponseFormat
+
+	RequestTimeout time.Duration
+
+	CustomHeaders map[string]string
 }
 
 func WithTopK(k int32) model.Option {
@@ -90,5 +96,20 @@ func WithAutoCacheControl(ctrl *CacheControl) model.Option {
 func WithResponseFormat(rf *ResponseFormat) model.Option {
 	return model.WrapImplSpecificOptFn(func(o *options) {
 		o.ResponseFormat = rf
+	})
+}
+
+// WithRequestTimeout sets the timeout for each API request.
+// This overrides the RequestTimeout set in Config for a single call.
+func WithRequestTimeout(d time.Duration) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.RequestTimeout = d
+	})
+}
+
+// WithCustomHeaders specifies custom HTTP headers to include in API requests.
+func WithCustomHeaders(headers map[string]string) model.Option {
+	return model.WrapImplSpecificOptFn(func(o *options) {
+		o.CustomHeaders = headers
 	})
 }


### PR DESCRIPTION
## Summary

Add `RequestTimeout *time.Duration` to both `claude.Config` and `agenticclaude.Config`, along with a per-request `WithRequestTimeout` option. The timeout is forwarded to the Anthropic SDK via `option.WithRequestTimeout` on each API call and is independent of `HTTPClient`.

## API Changes

1. **Added**: `Config.RequestTimeout *time.Duration` — client-level default timeout for both packages
2. **Added**: `claude.WithRequestTimeout(d)` / `agenticclaude.WithRequestTimeout(d)` — per-request override
3. **Added**: `claude.WithCustomHeaders(headers)` — per-request custom headers for the claude package

## Key Changes

1. Refactored `genMessageNewParams` → `genParamsAndOptions` in both packages to return `(MessageNewParams, []option.RequestOption, error)`, consolidating request option construction.
2. Fixed missing `TokenUsage` in `agenticclaude`'s Stream callback output — now matches the Generate path.