### PR TITLE
fix(deepseek): map completion_tokens_details.reasoning_tokens in usage

### DIFF
--- a/components/model/deepseek/deepseek.go
+++ b/components/model/deepseek/deepseek.go
@@ -831,6 +831,9 @@ func toModelCallbackUsage(respMeta *schema.ResponseMeta) *model.TokenUsage {
 		},
 		CompletionTokens: usage.CompletionTokens,
 		TotalTokens:      usage.TotalTokens,
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: usage.CompletionTokensDetails.ReasoningTokens,
+		},
 	}
 }
 
@@ -885,18 +888,27 @@ func streamToEinoTokenUsage(usage *deepseek.StreamUsage) *schema.TokenUsage {
 		usage.TotalTokens == 0 {
 		return nil
 	}
-	return toEinoTokenUsage(&deepseek.Usage{
-		PromptTokens:         usage.PromptTokens,
-		PromptCacheHitTokens: usage.PromptCacheHitTokens,
-		CompletionTokens:     usage.CompletionTokens,
-		TotalTokens:          usage.TotalTokens,
-	})
+	// Map StreamUsage directly so completion_tokens_details.reasoning_tokens is preserved.
+	// deepseek-go v1.3.4's non-stream Usage omits that field; converting through it would drop it.
+	return &schema.TokenUsage{
+		PromptTokens: usage.PromptTokens,
+		PromptTokenDetails: schema.PromptTokenDetails{
+			CachedTokens: usage.PromptCacheHitTokens,
+		},
+		CompletionTokens: usage.CompletionTokens,
+		TotalTokens:      usage.TotalTokens,
+		CompletionTokensDetails: schema.CompletionTokensDetails{
+			ReasoningTokens: usage.CompletionTokensDetails.ReasoningTokens,
+		},
+	}
 }
 
 func toEinoTokenUsage(usage *deepseek.Usage) *schema.TokenUsage {
 	if usage == nil {
 		return nil
 	}
+	// Note: deepseek-go v1.3.4 Usage has no CompletionTokensDetails; non-stream
+	// Generate path cannot surface reasoning_tokens until the SDK dependency is upgraded.
 	return &schema.TokenUsage{
 		PromptTokens: usage.PromptTokens,
 		PromptTokenDetails: schema.PromptTokenDetails{
@@ -918,6 +930,9 @@ func toCallbackUsage(usage *schema.TokenUsage) *model.TokenUsage {
 		},
 		CompletionTokens: usage.CompletionTokens,
 		TotalTokens:      usage.TotalTokens,
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: usage.CompletionTokensDetails.ReasoningTokens,
+		},
 	}
 }
 

--- a/components/model/deepseek/deepseek_test.go
+++ b/components/model/deepseek/deepseek_test.go
@@ -663,6 +663,9 @@ func TestResolveStreamResponse(t *testing.T) {
 				PromptTokens:     10,
 				CompletionTokens: 20,
 				TotalTokens:      30,
+				CompletionTokensDetails: deepseek.CompletionTokensDetails{
+					ReasoningTokens: 12,
+				},
 			},
 		}
 		msg, found, err := resolveStreamResponse(resp)
@@ -670,6 +673,7 @@ func TestResolveStreamResponse(t *testing.T) {
 		assert.True(t, found)
 		assert.NotNil(t, msg.ResponseMeta)
 		assert.Equal(t, 10, msg.ResponseMeta.Usage.PromptTokens)
+		assert.Equal(t, 12, msg.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	t.Run("reasoning content in delta", func(t *testing.T) {
@@ -780,10 +784,14 @@ func TestTokenUsageConversions(t *testing.T) {
 				PromptTokens:     1,
 				CompletionTokens: 2,
 				TotalTokens:      3,
+				CompletionTokensDetails: schema.CompletionTokensDetails{
+					ReasoningTokens: 7,
+				},
 			},
 		})
 		assert.NotNil(t, result)
 		assert.Equal(t, 1, result.PromptTokens)
+		assert.Equal(t, 7, result.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	t.Run("streamToEinoTokenUsage nil", func(t *testing.T) {
@@ -799,10 +807,14 @@ func TestTokenUsageConversions(t *testing.T) {
 			PromptTokens:     5,
 			CompletionTokens: 10,
 			TotalTokens:      15,
+			CompletionTokensDetails: deepseek.CompletionTokensDetails{
+				ReasoningTokens: 8,
+			},
 		})
 		assert.NotNil(t, result)
 		assert.Equal(t, 5, result.PromptTokens)
 		assert.Equal(t, 15, result.TotalTokens)
+		assert.Equal(t, 8, result.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	t.Run("toEinoTokenUsage with cache hit", func(t *testing.T) {
@@ -822,9 +834,13 @@ func TestTokenUsageConversions(t *testing.T) {
 			CompletionTokens:   2,
 			TotalTokens:        3,
 			PromptTokenDetails: schema.PromptTokenDetails{CachedTokens: 1},
+			CompletionTokensDetails: schema.CompletionTokensDetails{
+				ReasoningTokens: 4,
+			},
 		})
 		assert.NotNil(t, result)
 		assert.Equal(t, 1, result.PromptTokenDetails.CachedTokens)
+		assert.Equal(t, 4, result.CompletionTokensDetails.ReasoningTokens)
 	})
 }
 


### PR DESCRIPTION
## Summary
- DeepSeek API returns `usage.completion_tokens_details.reasoning_tokens`, but the deepseek model component never mapped it into `schema.TokenUsage` / callback `TokenUsage`.
- Stream path previously converted `StreamUsage` through non-stream `deepseek.Usage`, which (in deepseek-go v1.3.4) has no `CompletionTokensDetails`, so reasoning tokens were dropped.
- Preserve `ReasoningTokens` in `streamToEinoTokenUsage`, `toCallbackUsage`, and `toModelCallbackUsage`, so consumers like Langfuse can populate `output_reasoning_tokens`.

## Notes
- Non-stream `Generate` still cannot surface `reasoning_tokens` until `github.com/cohesion-org/deepseek-go` is upgraded past v1.3.4 (v1.4.0 adds the field but requires Go 1.26). Stream + callback paths are fixed with the current dependency.

## Test plan
- [x] `go test ./...` under `components/model/deepseek`
- [x] Unit coverage for stream / callback usage conversions with non-zero `ReasoningTokens`
- [ ] Optional: live stream call against a thinking DeepSeek model and confirm Langfuse / callback usage shows non-zero reasoning tokens


Made with [Cursor](https://cursor.com)