### PR TITLE
fix(langsmith): Remove runinfo fmt.Printf after run creation

### DIFF
--- a/callbacks/langsmith/langsmith.go
+++ b/callbacks/langsmith/langsmith.go
@@ -133,7 +133,6 @@ func (c *CallbackHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, 
 	if err != nil {
 		log.Printf("[langsmith] failed to create run: %v", err)
 	}
-	fmt.Printf("[langsmith] runinfo: %+v\n", run)
 	var newSyncMap = &sync.Map{}
 	for k, v := range run.Extra {
 		newSyncMap.Store(k, v)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [X] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:

removes debug `fmt.Printf("[langsmith] runinfo: %+v\n", run)` from code. This prints runinfo on every execution
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
