### PR TITLE
fix(tool_mcp): fix InvokableRun crash on empty arguments #923

### DIFF
--- a/components/tool/mcp/mcp.go
+++ b/components/tool/mcp/mcp.go
@@ -128,6 +128,9 @@ func (m *toolHelper) InvokableRun(ctx context.Context, argumentsInJSON string, o
 			headers.Set(k, v)
 		}
 	}
+	if argumentsInJSON == "" {
+		argumentsInJSON = "{}"
+	}
 
 	result, err := m.cli.CallTool(ctx, mcp.CallToolRequest{
 		Request: mcp.Request{

--- a/components/tool/mcp/mcp_test.go
+++ b/components/tool/mcp/mcp_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"encoding/json"
 	"github.com/cloudwego/eino/components/tool"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,19 @@ func TestTool(t *testing.T) {
 	assert.Equal(t, 1, len(tools))
 	helper := tools[0].(*toolHelper)
 	assert.Equal(t, map[string]string{"key": "value"}, helper.customHeaders)
+
+	t.Run("call tools without arguments", func(t *testing.T) {
+		tools, err := GetTools(ctx, &Config{
+			Cli:          cli,
+			ToolNameList: []string{"name2"},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(tools))
+		result, err := tools[0].(tool.InvokableTool).InvokableRun(ctx, "")
+		assert.NoError(t, err)
+		assert.Equal(t, "{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}", result)
+
+	})
 }
 
 type mockMCPClient struct{}
@@ -137,6 +151,9 @@ func (m *mockMCPClient) ListTools(ctx context.Context, request mcp.ListToolsRequ
 }
 
 func (m *mockMCPClient) CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if _, err := json.Marshal(request); err != nil {
+		return nil, err
+	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
fix: 调用无参 MCP 工具时 arguments 为空导致 InvokableRun 崩溃

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:

This fixes #923 .

When a model invokes a **parameter-less** MCP tool (e.g. `get_all_items` from mcp-jenkins), it omits the `arguments` field, so `argumentsInJSON` arrives at `InvokableRun` as an empty string. The current code assigns it directly:

```go
Arguments: json.RawMessage(argumentsInJSON)
```

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
