### PR TITLE
fix(claude): map output_tokens_details.thinking_tokens in usage

### DIFF
--- a/components/model/claude/claude.go
+++ b/components/model/claude/claude.go
@@ -1014,6 +1014,9 @@ func (cm *ChatModel) getCallbackOutput(output *schema.Message) *model.CallbackOu
 			},
 			CompletionTokens: output.ResponseMeta.Usage.CompletionTokens,
 			TotalTokens:      output.ResponseMeta.Usage.TotalTokens,
+			CompletionTokensDetails: model.CompletionTokensDetails{
+				ReasoningTokens: output.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens,
+			},
 		}
 	}
 	return result
@@ -1385,6 +1388,11 @@ func toTokenUsage(u anthropic.Usage) *schema.TokenUsage {
 		},
 		CompletionTokens: completionTokens,
 		TotalTokens:      promptTokens + completionTokens,
+		// Map Anthropic output_tokens_details.thinking_tokens so Langfuse
+		// completion_tokens_details.reasoning_tokens / output_reasoning_tokens is populated.
+		CompletionTokensDetails: schema.CompletionTokensDetails{
+			ReasoningTokens: int(u.OutputTokensDetails.ThinkingTokens),
+		},
 	}
 }
 
@@ -1399,6 +1407,9 @@ func toDeltaTokenUsage(u anthropic.MessageDeltaUsage) *schema.TokenUsage {
 		},
 		CompletionTokens: completionTokens,
 		TotalTokens:      promptTokens + completionTokens,
+		CompletionTokensDetails: schema.CompletionTokensDetails{
+			ReasoningTokens: int(u.OutputTokensDetails.ThinkingTokens),
+		},
 	}
 }
 

--- a/components/model/claude/claude_test.go
+++ b/components/model/claude/claude_test.go
@@ -180,6 +180,9 @@ func TestClaude(t *testing.T) {
 			Usage: anthropic.Usage{
 				InputTokens:  10,
 				OutputTokens: 5,
+				OutputTokensDetails: anthropic.OutputTokensDetails{
+					ThinkingTokens: 3,
+				},
 			},
 		}, nil).Build().UnPatch()
 
@@ -195,6 +198,7 @@ func TestClaude(t *testing.T) {
 		assert.Equal(t, schema.Assistant, resp.Role)
 		assert.Equal(t, 10, resp.ResponseMeta.Usage.PromptTokens)
 		assert.Equal(t, 5, resp.ResponseMeta.Usage.CompletionTokens)
+		assert.Equal(t, 3, resp.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	mockey.PatchConvey("function calling", t, func() {
@@ -327,6 +331,9 @@ func TestConvStreamEvent(t *testing.T) {
 				Usage: anthropic.Usage{
 					InputTokens:  5,
 					OutputTokens: 2,
+					OutputTokensDetails: anthropic.OutputTokensDetails{
+						ThinkingTokens: 1,
+					},
 				},
 			},
 		}).Build().UnPatch()
@@ -337,6 +344,7 @@ func TestConvStreamEvent(t *testing.T) {
 		assert.Equal(t, schema.Assistant, message.Role)
 		assert.Equal(t, 5, message.ResponseMeta.Usage.PromptTokens)
 		assert.Equal(t, 2, message.ResponseMeta.Usage.CompletionTokens)
+		assert.Equal(t, 1, message.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	mockey.PatchConvey("content block delta event - text", t, func() {
@@ -392,6 +400,9 @@ func TestConvStreamEvent(t *testing.T) {
 				CacheReadInputTokens:     3,
 				CacheCreationInputTokens: 2,
 				OutputTokens:             10,
+				OutputTokensDetails: anthropic.OutputTokensDetails{
+					ThinkingTokens: 4,
+				},
 			},
 		}).Build().UnPatch()
 
@@ -402,6 +413,7 @@ func TestConvStreamEvent(t *testing.T) {
 		assert.Equal(t, 3, message.ResponseMeta.Usage.PromptTokenDetails.CachedTokens)
 		assert.Equal(t, 10, message.ResponseMeta.Usage.CompletionTokens)
 		assert.Equal(t, 23, message.ResponseMeta.Usage.TotalTokens)
+		assert.Equal(t, 4, message.ResponseMeta.Usage.CompletionTokensDetails.ReasoningTokens)
 	})
 
 	mockey.PatchConvey("content block start event", t, func() {


### PR DESCRIPTION
## Summary
- Map Anthropic `usage.output_tokens_details.thinking_tokens` into Eino `CompletionTokensDetails.ReasoningTokens` for both non-stream (`toTokenUsage`) and stream delta (`toDeltaTokenUsage`) paths.
- Propagate the same field through `getCallbackOutput` so callback consumers (including Langfuse) see reasoning token counts.
- Extend unit tests to assert reasoning token mapping on generate / message-start / message-delta.

Without this, Langfuse `output_reasoning_tokens` stayed 0 even when Claude returned thinking tokens (same class of issue as #921 for deepseek).

## Test plan
- [x] `cd components/model/claude && go test ./... -count=1 -gcflags="all=-N -l"`
- [ ] Smoke a Claude thinking request and confirm Langfuse generation `usageDetails.completion_tokens_details.reasoning_tokens` is non-zero


Made with [Cursor](https://cursor.com)