### PR TITLE
fix(local): follow directory symlinks in GlobInfo

### DIFF
--- a/adk/backend/local/README.md
+++ b/adk/backend/local/README.md
@@ -136,7 +136,7 @@ See the following examples for more usage:
 - **`Write(ctx, req)`** - Write file content; creates the file if it doesn't exist, otherwise **overwrites** existing content (parent directories are created automatically).
 - **`Edit(ctx, req)`** - Search and replace in file
 - **`GrepRaw(ctx, req)`** - Search pattern in files
-- **`GlobInfo(ctx, req)`** - Find files by glob pattern
+- **`GlobInfo(ctx, req)`** - Find files by glob pattern, following directory symlinks while preventing cycles
 
 ### Additional Methods
 

--- a/adk/backend/local/README_zh.md
+++ b/adk/backend/local/README_zh.md
@@ -132,7 +132,7 @@ backend, _ := local.NewBackend(ctx, &local.Config{
 - **`Write(ctx, req)`** - 写入文件内容；文件不存在时创建，否则**覆盖**现有内容（父目录会自动创建）。
 - **`Edit(ctx, req)`** - 在文件中搜索和替换
 - **`GrepRaw(ctx, req)`** - 在文件中搜索模式
-- **`GlobInfo(ctx, req)`** - 按 glob 模式查找文件
+- **`GlobInfo(ctx, req)`** - 按 glob 模式查找文件，跟随目录软链接并防止循环遍历
 
 ### 其他方法
 

--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -839,20 +839,7 @@ func (s *Local) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) (
 	path := filepath.Clean(req.Path)
 
 	var matches []string
-	err := filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		if err != nil {
-			if os.IsPermission(err) {
-				return filepath.SkipDir
-			}
-			return err
-		}
-
+	err := walkDirFollowSymlinks(ctx, path, func(p string, _ os.DirEntry) error {
 		relPath, err := filepath.Rel(path, p)
 		if err != nil {
 			return fmt.Errorf("failed to get relative path: %w", err)
@@ -886,6 +873,122 @@ func (s *Local) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) (
 	}
 
 	return files, nil
+}
+
+// walkDirFollowSymlinks visits every entry under root, descending into both
+// regular directories and directory symlinks. Symlinks are traversed through
+// their logical paths so callers continue to see paths rooted at the symlink
+// rather than the physical target.
+func walkDirFollowSymlinks(
+	ctx context.Context,
+	root string,
+	visit func(path string, entry os.DirEntry) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	rootInfo, err := os.Stat(root)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if err != nil {
+		if os.IsPermission(err) {
+			return nil
+		}
+		// WalkDir visits a broken root symlink as an entry without following
+		// it. Preserve the equivalent empty result for that case.
+		if linkInfo, linkErr := os.Lstat(root); linkErr == nil && linkInfo.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		return err
+	}
+	if !rootInfo.IsDir() {
+		return nil
+	}
+
+	return walkDirChildren(ctx, root, []os.FileInfo{rootInfo}, visit)
+}
+
+func walkDirChildren(
+	ctx context.Context,
+	dir string,
+	ancestors []os.FileInfo,
+	visit func(path string, entry os.DirEntry) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if err != nil {
+		if os.IsPermission(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		entryPath := filepath.Join(dir, entry.Name())
+		if err := visit(entryPath, entry); err != nil {
+			return err
+		}
+
+		dirInfo, err := followedDirectoryInfo(entryPath, entry)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			// A broken, looping, or inaccessible symlink remains a matchable
+			// entry, but there is no directory we can safely descend into.
+			if entry.Type()&os.ModeSymlink != 0 || os.IsPermission(err) {
+				continue
+			}
+			return err
+		}
+		if dirInfo == nil || isAncestorDirectory(ancestors, dirInfo) {
+			continue
+		}
+
+		if err := walkDirChildren(ctx, entryPath, append(ancestors, dirInfo), visit); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func followedDirectoryInfo(path string, entry os.DirEntry) (os.FileInfo, error) {
+	if entry.Type()&os.ModeSymlink == 0 && !entry.IsDir() {
+		return nil, nil
+	}
+	// Stat the current path instead of trusting the type cached by ReadDir.
+	// Besides following symlinks, this handles a directory being replaced
+	// between ReadDir and descent without using stale identity information.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return info, nil
+	}
+	return nil, nil
+}
+
+func isAncestorDirectory(ancestors []os.FileInfo, candidate os.FileInfo) bool {
+	for _, ancestor := range ancestors {
+		if os.SameFile(ancestor, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Local) Write(ctx context.Context, req *filesystem.WriteRequest) error {

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -23,7 +23,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -39,6 +41,21 @@ func setupTestDir(t *testing.T) string {
 	dir, err := os.MkdirTemp("", "sandbox-test")
 	assert.NoError(t, err)
 	return dir
+}
+
+func createSymlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+	err := os.Symlink(target, link)
+	if err == nil {
+		return
+	}
+	if runtime.GOOS == "windows" {
+		var errno syscall.Errno
+		if errors.Is(err, os.ErrPermission) || (errors.As(err, &errno) && errno == syscall.Errno(1314)) {
+			t.Skipf("symlink privilege is not available: %v", err)
+		}
+	}
+	require.NoError(t, err)
 }
 
 func TestLsInfo(t *testing.T) {
@@ -363,6 +380,69 @@ func TestGlobInfo(t *testing.T) {
 			actual = append(actual, f.Path)
 		}
 		assert.ElementsMatch(t, expected, actual)
+	})
+
+	t.Run("glob follows directory symlinks", func(t *testing.T) {
+		dir := t.TempDir()
+		targetDir := t.TempDir()
+
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "SKILL.md"), []byte(""), 0644))
+		createSymlinkOrSkip(t, targetDir, filepath.Join(dir, "linked-skill"))
+		createSymlinkOrSkip(t, targetDir, filepath.Join(dir, "second-skill"))
+
+		files, err := s.GlobInfo(ctx, &filesystem.GlobInfoRequest{Path: dir, Pattern: "*/SKILL.md"})
+		assert.NoError(t, err)
+		assert.Equal(t, []filesystem.FileInfo{
+			{Path: "linked-skill/SKILL.md"},
+			{Path: "second-skill/SKILL.md"},
+		}, files)
+	})
+
+	t.Run("glob follows a symlink root", func(t *testing.T) {
+		dir := t.TempDir()
+		targetDir := t.TempDir()
+		skillDir := filepath.Join(targetDir, "eino-guide")
+
+		assert.NoError(t, os.Mkdir(skillDir, 0755))
+		assert.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(""), 0644))
+		symlinkRoot := filepath.Join(dir, "skills")
+		createSymlinkOrSkip(t, targetDir, symlinkRoot)
+
+		files, err := s.GlobInfo(ctx, &filesystem.GlobInfoRequest{Path: symlinkRoot, Pattern: "*/SKILL.md"})
+		assert.NoError(t, err)
+		assert.Equal(t, []filesystem.FileInfo{{Path: "eino-guide/SKILL.md"}}, files)
+	})
+
+	t.Run("glob stops directory symlink cycles", func(t *testing.T) {
+		dir := t.TempDir()
+		targetDir := t.TempDir()
+
+		assert.NoError(t, os.WriteFile(filepath.Join(targetDir, "SKILL.md"), []byte(""), 0644))
+		createSymlinkOrSkip(t, targetDir, filepath.Join(targetDir, "loop"))
+		createSymlinkOrSkip(t, targetDir, filepath.Join(dir, "skill"))
+
+		cycleCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		files, err := s.GlobInfo(cycleCtx, &filesystem.GlobInfoRequest{Path: dir, Pattern: "**/SKILL.md"})
+		assert.NoError(t, err)
+		assert.Equal(t, []filesystem.FileInfo{{Path: "skill/SKILL.md"}}, files)
+	})
+
+	t.Run("glob preserves file and broken symlinks", func(t *testing.T) {
+		dir := t.TempDir()
+
+		target := filepath.Join(dir, "target.txt")
+		assert.NoError(t, os.WriteFile(target, []byte(""), 0644))
+		createSymlinkOrSkip(t, target, filepath.Join(dir, "linked.txt"))
+		createSymlinkOrSkip(t, filepath.Join(dir, "missing.txt"), filepath.Join(dir, "broken.txt"))
+
+		files, err := s.GlobInfo(ctx, &filesystem.GlobInfoRequest{Path: dir, Pattern: "*.txt"})
+		assert.NoError(t, err)
+		assert.Equal(t, []filesystem.FileInfo{
+			{Path: "broken.txt"},
+			{Path: "linked.txt"},
+			{Path: "target.txt"},
+		}, files)
 	})
 
 	t.Run("glob with question mark", func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] User-facing module documentation is updated in this PR; no separate docs-repository change is needed.

#### (Optional) Translate the PR title into Chinese.

fix(local): 让 GlobInfo 跟随目录软链接

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`Local.GlobInfo` currently uses `filepath.WalkDir`, which treats a directory symlink as a leaf. As a result, skill discovery such as `*/SKILL.md` returns nothing when the skills root or an individual skill directory is symlinked.

This change:

- follows directory symlinks while keeping returned paths under their logical symlink aliases;
- detects cycles against the current ancestor chain with `os.SameFile`, so self/ancestor links terminate without suppressing independent aliases to the same target;
- preserves existing matching behavior for file and broken symlinks;
- keeps context cancellation and unreadable-directory handling aligned with the previous walker;
- documents the behavior in the English and Chinese module READMEs.

Tests cover a symlink root, multiple directory aliases, a directory cycle, and file/broken symlinks. The earlier #863 attempt was closed unmerged without review; this implementation is deliberately narrower (no `GrepRaw` change) and avoids its global visited set, which could drop valid alias paths.

Validation:

- `go test -race . -run '^TestGlobInfo$' -count=1`
- `go test ./... -run '^TestGlobInfo$' -count=1`
- `go vet ./...`
- incremental `golangci-lint` (`0 issues`)
- Linux/amd64 test-binary cross-compilation

The local Windows account lacks symlink-creation privilege, so real symlink subtests are skipped there; the repository's Linux CI executes them. A full Windows module run was also attempted and reached existing Unix-specific failures in `TestLsInfo` and `TestGrepRaw`.

zh(optional):

为 `GlobInfo` 增加目录软链接跟随能力，保留软链接逻辑路径，并以当前递归祖先链检测循环；同时保持文件软链接和坏链接原有的匹配语义。

#### (Optional) Which issue(s) this PR fixes:

Fixes #746

#### (optional) The PR that updates user documentation:

The module-level English and Chinese READMEs are updated in this PR.