### PR TITLE
fix(local): add IsDir checks to Read/Write/Edit to prevent directory-as-file errors

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -322,6 +322,9 @@ func (s *Local) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesys
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat file: %w", err)
 	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("path is a directory, not a file: %s", path)
+	}
 	if info.Size() == 0 {
 		return &filesystem.FileContent{}, nil
 	}
@@ -891,6 +894,10 @@ func (s *Local) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) (
 func (s *Local) Write(ctx context.Context, req *filesystem.WriteRequest) error {
 	path := filepath.Clean(req.FilePath)
 
+	if fi, statErr := os.Stat(path); statErr == nil && fi.IsDir() {
+		return fmt.Errorf("path is a directory, not a file: %s", path)
+	}
+
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return fmt.Errorf("failed to create parent directory: %w", err)
@@ -918,6 +925,10 @@ func (s *Local) Edit(ctx context.Context, req *filesystem.EditRequest) error {
 
 	if req.OldString == req.NewString {
 		return fmt.Errorf("new string must be different from old string")
+	}
+
+	if fi, statErr := os.Stat(path); statErr == nil && fi.IsDir() {
+		return fmt.Errorf("path is a directory, not a file: %s", path)
 	}
 
 	content, err := os.ReadFile(path)


### PR DESCRIPTION
## Problem

When a user passes a directory path to `Local.Read()`, `Local.Write()`, or `Local.Edit()`, the methods attempt to use the path as a file — opening, reading, or writing it — which produces confusing low-level errors (e.g. `is a directory` from the OS) or silent failures instead of a clear explanation.

## Changes

Added a guard check in each of the three methods that returns a clear error message when the target path is a directory rather than a file:

### `Read()`
- Calls `file.Stat()` before `info.Size() == 0` check
- Returns `"path is a directory, not a file: <path>"`

### `Write()`
- Calls `os.Stat(path)` before `MkdirAll`/`OpenFile`
- Returns `"path is a directory, not a file: <path>"`

### `Edit()`
- Calls `os.Stat(path)` before `os.ReadFile(path)`
- Returns `"path is a directory, not a file: <path>"`

## Testing

- [ ] Run existing test suite to confirm no regressions
- [ ] Verify each method returns the directory error when given a directory path