### PR TITLE
fix(ark): support fast service tier in responses API

### DIFF
--- a/components/model/ark/go.mod
+++ b/components/model/ark/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.11.1
-	github.com/volcengine/volcengine-go-sdk v1.2.27
+	github.com/volcengine/volcengine-go-sdk v1.2.45
 )
 
 require (
@@ -26,6 +26,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -76,6 +76,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -137,8 +139,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.27 h1:azBueeKhhGQukss+ob6m3oJ5K8GGYbfDNj8RKAEXVTE=
-github.com/volcengine/volcengine-go-sdk v1.2.27/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.45 h1:83UhHcCYIcN6IYKE15XyiEC73ulh9AEqxeAgHs7CmF4=
+github.com/volcengine/volcengine-go-sdk v1.2.45/go.mod h1:5duonraYH9kPPB5/Ke2y63atELLRymBSgCo9ItIZqEM=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -447,6 +447,8 @@ func (cm *ResponsesAPIChatModel) prePopulateConfig(responseReq *responses.Respon
 			responseReq.ServiceTier = responses.ResponsesServiceTier_auto.Enum()
 		case "default":
 			responseReq.ServiceTier = responses.ResponsesServiceTier_default.Enum()
+		case "fast":
+			responseReq.ServiceTier = responses.ResponsesServiceTier_fast.Enum()
 		}
 	}
 

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -731,6 +731,7 @@ func TestResponsesAPIChatModelHandleGenRequestAndOptions(t *testing.T) {
 		maxTokens:   ptrOf(1),
 		model:       "model",
 		topP:        ptrOf(float32(1.0)),
+		serviceTier: ptrOf("fast"),
 		thinking: &arkModel.Thinking{
 			Type: arkModel.ThinkingTypeDisabled,
 		},
@@ -807,6 +808,7 @@ func TestResponsesAPIChatModelHandleGenRequestAndOptions(t *testing.T) {
 		assert.Equal(t, "user", reqParams.Input.GetListValue().ListValue[0].GetInputMessage().GetContent()[0].GetText().GetText())
 		assert.Len(t, reqParams.Tools, 1)
 		assert.Equal(t, "test tool", reqParams.Tools[0].GetToolFunction().Name)
+		assert.Equal(t, responses.ResponsesServiceTier_fast, *reqParams.ServiceTier)
 
 		assert.Equal(t, "json_schema", reqParams.Text.Format.GetName())
 	})


### PR DESCRIPTION
## Summary

- support `service_tier=fast` in the Ark Responses API
- upgrade `volcengine-go-sdk` to `v1.2.45` for the fast service-tier enum
- add request-generation regression coverage

Fixes #933

## Test plan

- `GOTOOLCHAIN=go1.25.5+auto go build ./...`
- `GOTOOLCHAIN=go1.25.5+auto go test -gcflags=\"all=-N -l\" -run '^TestResponsesAPIChatModelHandleGenRequestAndOptions$' .`

The full module test suite still has unrelated existing failures in mockey-dependent tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)