### PR TITLE
fix(ark): expose Responses API model name on messages

### DIFF
--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -998,6 +998,7 @@ func (cm *ResponsesAPIChatModel) toOutputMessage(resp *responses.ResponseObject,
 	}
 	setContextID(msg, resp.Id)
 	setResponseID(msg, resp.Id)
+	setModelName(msg, resp.Model)
 
 	if resp.ServiceTier != nil {
 		setServiceTier(msg, resp.ServiceTier.String())
@@ -1257,6 +1258,7 @@ func (cm *ResponsesAPIChatModel) setStreamChunkDefaultExtra(msg *schema.Message,
 	}
 	setContextID(msg, object.Id)
 	setResponseID(msg, object.Id)
+	setModelName(msg, object.Model)
 	if object.ServiceTier != nil {
 		setServiceTier(msg, object.ServiceTier.String())
 	}

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -75,6 +75,61 @@ func TestResponsesAPIChatModelGenerate(t *testing.T) {
 	})
 }
 
+func TestResponsesAPIChatModelPreservesModelName(t *testing.T) {
+	const modelName = "doubao-seed-2-0-lite"
+
+	cm := &ResponsesAPIChatModel{}
+
+	t.Run("non-streaming response", func(t *testing.T) {
+		msg, err := cm.toOutputMessage(&responses.ResponseObject{
+			Model:  modelName,
+			Status: responses.ResponseStatus_completed,
+			Usage:  &responses.Usage{},
+			Output: []*responses.OutputItem{
+				{
+					Union: &responses.OutputItem_OutputMessage{
+						OutputMessage: &responses.ItemOutputMessage{
+							Content: []*responses.OutputContentItem{
+								{
+									Union: &responses.OutputContentItem_Text{
+										Text: &responses.OutputContentItemText{Text: "hello"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, nil)
+		assert.NoError(t, err)
+
+		name, ok := GetModelName(msg)
+		assert.True(t, ok)
+		assert.Equal(t, modelName, name)
+	})
+
+	t.Run("concatenated streaming response", func(t *testing.T) {
+		metadataMsg := &schema.Message{Role: schema.Assistant}
+		cm.setStreamChunkDefaultExtra(metadataMsg, &responses.ResponseObject{
+			Model: modelName,
+		}, &cacheConfig{})
+
+		textMsg := &schema.Message{
+			Role:    schema.Assistant,
+			Content: "hello",
+		}
+		msg, err := schema.ConcatMessages([]*schema.Message{
+			metadataMsg,
+			textMsg,
+		})
+		assert.NoError(t, err)
+
+		name, ok := GetModelName(msg)
+		assert.True(t, ok)
+		assert.Equal(t, modelName, name)
+	})
+}
+
 func TestResponsesAPIChatModelStream(t *testing.T) {
 	PatchConvey("test Stream", t, func() {
 		ctx := context.Background()


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear.
- [x] No user documentation update is required; this makes the Responses API consistent with the existing Chat Completions message metadata.

#### (Optional) Translate the PR title into Chinese.

`fix(ark): 在 Responses API 消息中暴露模型名称`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The Ark Chat Completions path exposes the resolved model name on `schema.Message` through `ark.GetModelName`, while the Responses API currently reports it only through callback extra.

This change reuses the existing message-extra mechanism to preserve `ResponseObject.Model` on non-streaming output messages and streaming response metadata chunks. As a result, callers can retrieve the model name from both non-streaming messages and concatenated streaming messages through `ark.GetModelName`.

No public API or dependency changes are introduced.

Tests:

- `go test -gcflags="all=-N -l" ./...`
- `go vet ./...`
- `go test -race -gcflags="all=-N -l" . -run '^TestResponsesAPIChatModelPreservesModelName$' -count=1`

#### (Optional) Which issue(s) this PR fixes:

Fixes #941

#### (optional) The PR that updates user documentation:

N/A