### PR TITLE
Feat/stdio mcp tunnel

### DIFF
--- a/components/tool/mcp/officialmcp/README.md
+++ b/components/tool/mcp/officialmcp/README.md
@@ -172,6 +172,8 @@ Custom transports can wrap a typed remote or uncertain error with
 failed operation must retain its original, non-replayable classification.
 Use `officialmcp.MarkSessionTerminal` for protocol or configuration failures
 that must close the logical session and reject all later operations.
+Use `officialmcp.MarkRequestRejected` for request-scoped overload or admission
+failures that must preserve the current connection.
 
 ## Examples
 

--- a/components/tool/mcp/officialmcp/README.md
+++ b/components/tool/mcp/officialmcp/README.md
@@ -167,6 +167,9 @@ returns `officialmcp.ErrorKindUncertainOutcome` and does not match
 `officialmcp.IsConnectionError`. A non-empty-cursor `ListTools` page returns
 `officialmcp.ErrorKindConnection` after reconnecting, so the caller can restart
 discovery from an empty cursor without replaying the generation-bound page.
+Custom transports can wrap a typed remote or uncertain error with
+`officialmcp.MarkConnectionInvalid` when the connection must be rebuilt but the
+failed operation must retain its original, non-replayable classification.
 
 ## Examples
 

--- a/components/tool/mcp/officialmcp/README.md
+++ b/components/tool/mcp/officialmcp/README.md
@@ -162,10 +162,11 @@ managed, err := session.Connect(ctx, session.ServerConfig{
 ```
 
 `ReplaySafe` retries `Ping` and an empty-cursor `ListTools` request, but never
-retries `CallTool` or a non-empty-cursor page. When a dispatched operation is
-not replayed after a connection failure, the returned error has
-`officialmcp.ErrorKindUncertainOutcome` and does not match
-`officialmcp.IsConnectionError`.
+retries `CallTool` or a non-empty-cursor page. A non-replayed `CallTool`
+returns `officialmcp.ErrorKindUncertainOutcome` and does not match
+`officialmcp.IsConnectionError`. A non-empty-cursor `ListTools` page returns
+`officialmcp.ErrorKindConnection` after reconnecting, so the caller can restart
+discovery from an empty cursor without replaying the generation-bound page.
 
 ## Examples
 

--- a/components/tool/mcp/officialmcp/README.md
+++ b/components/tool/mcp/officialmcp/README.md
@@ -170,6 +170,8 @@ discovery from an empty cursor without replaying the generation-bound page.
 Custom transports can wrap a typed remote or uncertain error with
 `officialmcp.MarkConnectionInvalid` when the connection must be rebuilt but the
 failed operation must retain its original, non-replayable classification.
+Use `officialmcp.MarkSessionTerminal` for protocol or configuration failures
+that must close the logical session and reject all later operations.
 
 ## Examples
 

--- a/components/tool/mcp/officialmcp/README.md
+++ b/components/tool/mcp/officialmcp/README.md
@@ -138,6 +138,35 @@ type Config struct {
 }
 ```
 
+### Custom reconnecting transports
+
+The `session` subpackage accepts a transport factory when a transport must be
+created from application-specific routing rather than a built-in URL or
+command. The factory is called once for the initial connection and again for
+each reconnect, and every returned transport is connected at most once.
+
+```go
+managed, err := session.Connect(ctx, session.ServerConfig{
+	Name: "remote-server",
+	Transport: session.TransportConfig{
+		Factory: func(ctx context.Context) (mcp.Transport, error) {
+			return newApplicationTransport(ctx)
+		},
+	},
+	Replay: session.ReplayPolicies{
+		ListTools: session.ReplaySafe,
+		CallTool:  session.ReplayNever,
+		Ping:      session.ReplaySafe,
+	},
+})
+```
+
+`ReplaySafe` retries `Ping` and an empty-cursor `ListTools` request, but never
+retries `CallTool` or a non-empty-cursor page. When a dispatched operation is
+not replayed after a connection failure, the returned error has
+`officialmcp.ErrorKindUncertainOutcome` and does not match
+`officialmcp.IsConnectionError`.
+
 ## Examples
 
 See the [examples](./examples/) directory for complete usage examples.

--- a/components/tool/mcp/officialmcp/README_zh.md
+++ b/components/tool/mcp/officialmcp/README_zh.md
@@ -170,6 +170,8 @@ managed, err := session.Connect(ctx, session.ServerConfig{
 分类，自定义 transport 可以用 `officialmcp.MarkConnectionInvalid` 包装该错误。
 协议或配置错误需要关闭逻辑 session 并拒绝所有后续操作时，使用
 `officialmcp.MarkSessionTerminal`。
+请求级 overload 或 admission failure 需要保留当前 connection 时，使用
+`officialmcp.MarkRequestRejected`。
 
 ## 示例
 

--- a/components/tool/mcp/officialmcp/README_zh.md
+++ b/components/tool/mcp/officialmcp/README_zh.md
@@ -138,6 +138,33 @@ type Config struct {
 }
 ```
 
+### 自定义可重连 transport
+
+当 transport 需要通过业务路由创建、不能使用内置 URL 或 command 时，可向
+`session` 子包传入 transport factory。首次连接和每次重连都会重新调用 factory，
+每个返回的 transport 最多只会被连接一次。
+
+```go
+managed, err := session.Connect(ctx, session.ServerConfig{
+	Name: "remote-server",
+	Transport: session.TransportConfig{
+		Factory: func(ctx context.Context) (mcp.Transport, error) {
+			return newApplicationTransport(ctx)
+		},
+	},
+	Replay: session.ReplayPolicies{
+		ListTools: session.ReplaySafe,
+		CallTool:  session.ReplayNever,
+		Ping:      session.ReplaySafe,
+	},
+})
+```
+
+`ReplaySafe` 会重试 `Ping` 和空 cursor 的 `ListTools`，但不会重试 `CallTool`
+或非空 cursor 的分页请求。连接失败后若已下发操作没有重放，返回错误会带有
+`officialmcp.ErrorKindUncertainOutcome`，且不会匹配
+`officialmcp.IsConnectionError`。
+
 ## 示例
 
 查看 [examples](./examples/) 目录获取完整的使用示例。

--- a/components/tool/mcp/officialmcp/README_zh.md
+++ b/components/tool/mcp/officialmcp/README_zh.md
@@ -168,6 +168,8 @@ managed, err := session.Connect(ctx, session.ServerConfig{
 重放绑定旧 generation 的分页请求。
 如果 connection 必须重建，但失败操作需要保留原有的 typed remote 或 uncertain
 分类，自定义 transport 可以用 `officialmcp.MarkConnectionInvalid` 包装该错误。
+协议或配置错误需要关闭逻辑 session 并拒绝所有后续操作时，使用
+`officialmcp.MarkSessionTerminal`。
 
 ## 示例
 

--- a/components/tool/mcp/officialmcp/README_zh.md
+++ b/components/tool/mcp/officialmcp/README_zh.md
@@ -166,6 +166,8 @@ managed, err := session.Connect(ctx, session.ServerConfig{
 `officialmcp.IsConnectionError`。非空 cursor 的 `ListTools` 在重建后返回
 `officialmcp.ErrorKindConnection`，调用方可以从空 cursor 重新开始发现，而不会
 重放绑定旧 generation 的分页请求。
+如果 connection 必须重建，但失败操作需要保留原有的 typed remote 或 uncertain
+分类，自定义 transport 可以用 `officialmcp.MarkConnectionInvalid` 包装该错误。
 
 ## 示例
 

--- a/components/tool/mcp/officialmcp/README_zh.md
+++ b/components/tool/mcp/officialmcp/README_zh.md
@@ -161,9 +161,11 @@ managed, err := session.Connect(ctx, session.ServerConfig{
 ```
 
 `ReplaySafe` 会重试 `Ping` 和空 cursor 的 `ListTools`，但不会重试 `CallTool`
-或非空 cursor 的分页请求。连接失败后若已下发操作没有重放，返回错误会带有
+或非空 cursor 的分页请求。未重放的 `CallTool` 返回
 `officialmcp.ErrorKindUncertainOutcome`，且不会匹配
-`officialmcp.IsConnectionError`。
+`officialmcp.IsConnectionError`。非空 cursor 的 `ListTools` 在重建后返回
+`officialmcp.ErrorKindConnection`，调用方可以从空 cursor 重新开始发现，而不会
+重放绑定旧 generation 的分页请求。
 
 ## 示例
 

--- a/components/tool/mcp/officialmcp/mcp.go
+++ b/components/tool/mcp/officialmcp/mcp.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/eino-contrib/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/cloudwego/eino/components/tool"
@@ -129,6 +130,27 @@ type sessionTerminalError struct {
 	err error
 }
 
+type requestRejectedError struct {
+	err error
+}
+
+func (e *requestRejectedError) Error() string {
+	if e == nil || e.err == nil {
+		return "official mcp request was rejected"
+	}
+	return e.err.Error()
+}
+
+func (e *requestRejectedError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	return []error{
+		e.err,
+		&jsonrpc.Error{Code: -32005, Message: "rejected by transport"},
+	}
+}
+
 func (e *sessionTerminalError) Error() string {
 	if e == nil || e.err == nil {
 		return "official mcp session failed terminally"
@@ -224,6 +246,23 @@ func MarkSessionTerminal(err error) error {
 func IsSessionTerminal(err error) bool {
 	var terminal *sessionTerminalError
 	return errors.As(err, &terminal)
+}
+
+// MarkRequestRejected reports a request-scoped transport rejection that leaves
+// the connection usable. The original typed error remains available through
+// errors.As while the Go SDK observes its transport rejection sentinel.
+func MarkRequestRejected(err error) error {
+	if err == nil || IsRequestRejected(err) {
+		return err
+	}
+	return &requestRejectedError{err: err}
+}
+
+// IsRequestRejected reports whether err is a request-scoped transport
+// rejection rather than a connection failure.
+func IsRequestRejected(err error) bool {
+	var rejected *requestRejectedError
+	return errors.As(err, &rejected)
 }
 
 // ClientSession is the anti-corruption boundary between officialmcp and the

--- a/components/tool/mcp/officialmcp/mcp.go
+++ b/components/tool/mcp/officialmcp/mcp.go
@@ -107,6 +107,24 @@ type Error struct {
 	Err             error
 }
 
+type connectionInvalidError struct {
+	err error
+}
+
+func (e *connectionInvalidError) Error() string {
+	if e == nil || e.err == nil {
+		return "official mcp connection is invalid"
+	}
+	return e.err.Error()
+}
+
+func (e *connectionInvalidError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
 func (e *Error) Error() string {
 	if e == nil {
 		return ""
@@ -153,6 +171,24 @@ func IsConnectionError(err error) bool {
 		}
 	}
 	return errors.Is(err, mcp.ErrConnectionClosed) || errors.Is(err, mcp.ErrSessionMissing)
+}
+
+// MarkConnectionInvalid reports that the current connection must be rebuilt
+// without changing whether err is replay-safe. Managed sessions reconnect
+// before returning the original error, so an uncertain or typed remote error
+// remains distinguishable from a replayable connection failure.
+func MarkConnectionInvalid(err error) error {
+	if err == nil || IsConnectionInvalid(err) {
+		return err
+	}
+	return &connectionInvalidError{err: err}
+}
+
+// IsConnectionInvalid reports whether err explicitly invalidates the current
+// connection without classifying the failed operation as replayable.
+func IsConnectionInvalid(err error) bool {
+	var invalid *connectionInvalidError
+	return errors.As(err, &invalid)
 }
 
 // ClientSession is the anti-corruption boundary between officialmcp and the

--- a/components/tool/mcp/officialmcp/mcp.go
+++ b/components/tool/mcp/officialmcp/mcp.go
@@ -125,6 +125,24 @@ func (e *connectionInvalidError) Unwrap() error {
 	return e.err
 }
 
+type sessionTerminalError struct {
+	err error
+}
+
+func (e *sessionTerminalError) Error() string {
+	if e == nil || e.err == nil {
+		return "official mcp session failed terminally"
+	}
+	return e.err.Error()
+}
+
+func (e *sessionTerminalError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
 func (e *Error) Error() string {
 	if e == nil {
 		return ""
@@ -189,6 +207,23 @@ func MarkConnectionInvalid(err error) error {
 func IsConnectionInvalid(err error) bool {
 	var invalid *connectionInvalidError
 	return errors.As(err, &invalid)
+}
+
+// MarkSessionTerminal reports that a protocol or configuration failure makes
+// the logical session permanently unusable. Managed sessions close themselves
+// before returning the original error and reject every subsequent operation.
+func MarkSessionTerminal(err error) error {
+	if err == nil || IsSessionTerminal(err) {
+		return err
+	}
+	return &sessionTerminalError{err: err}
+}
+
+// IsSessionTerminal reports whether err permanently invalidates the logical
+// session rather than only its current connection.
+func IsSessionTerminal(err error) bool {
+	var terminal *sessionTerminalError
+	return errors.As(err, &terminal)
 }
 
 // ClientSession is the anti-corruption boundary between officialmcp and the

--- a/components/tool/mcp/officialmcp/mcp.go
+++ b/components/tool/mcp/officialmcp/mcp.go
@@ -90,12 +90,13 @@ type DescriptionPolicy struct {
 type ErrorKind string
 
 const (
-	ErrorKindListTools       ErrorKind = "list_tools"
-	ErrorKindSchemaConvert   ErrorKind = "schema_convert"
-	ErrorKindCallTool        ErrorKind = "call_tool"
-	ErrorKindConnection      ErrorKind = "connection"
-	ErrorKindServerToolError ErrorKind = "server_tool_error"
-	ErrorKindResultPolicy    ErrorKind = "result_policy"
+	ErrorKindListTools        ErrorKind = "list_tools"
+	ErrorKindSchemaConvert    ErrorKind = "schema_convert"
+	ErrorKindCallTool         ErrorKind = "call_tool"
+	ErrorKindConnection       ErrorKind = "connection"
+	ErrorKindUncertainOutcome ErrorKind = "uncertain_outcome"
+	ErrorKindServerToolError  ErrorKind = "server_tool_error"
+	ErrorKindResultPolicy     ErrorKind = "result_policy"
 )
 
 type Error struct {
@@ -140,8 +141,16 @@ func IsConnectionError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if IsErrorKind(err, ErrorKindConnection) {
-		return true
+	var typed *Error
+	if errors.As(err, &typed) {
+		switch typed.Kind {
+		case ErrorKindConnection:
+			return true
+		case ErrorKindUncertainOutcome:
+			// An uncertain operation may wrap a terminal connection sentinel,
+			// but callers must not treat it as permission to replay the request.
+			return false
+		}
 	}
 	return errors.Is(err, mcp.ErrConnectionClosed) || errors.Is(err, mcp.ErrSessionMissing)
 }
@@ -300,7 +309,9 @@ func (m *toolHelper) InvokableRun(ctx context.Context, argumentsInJSON string, o
 	})
 	if err != nil {
 		kind := ErrorKindCallTool
-		if IsConnectionError(err) {
+		if IsErrorKind(err, ErrorKindUncertainOutcome) {
+			kind = ErrorKindUncertainOutcome
+		} else if IsConnectionError(err) {
 			kind = ErrorKindConnection
 		}
 		return "", &Error{Kind: kind, ServerName: m.serverName, RawToolName: m.rawToolName, ExposedToolName: m.exposedToolName, Err: fmt.Errorf("failed to call official mcp tool: %w", err)}

--- a/components/tool/mcp/officialmcp/mcp_test.go
+++ b/components/tool/mcp/officialmcp/mcp_test.go
@@ -495,3 +495,14 @@ func TestIsConnectionError(t *testing.T) {
 		Err:  fmt.Errorf("response lost: %w", mcp.ErrConnectionClosed),
 	}))
 }
+
+func TestConnectionInvalidMarkerPreservesErrorClassification(t *testing.T) {
+	uncertain := &Error{Kind: ErrorKindUncertainOutcome, Err: assert.AnError}
+	marked := MarkConnectionInvalid(uncertain)
+	assert.True(t, IsConnectionInvalid(marked))
+	assert.True(t, IsErrorKind(marked, ErrorKindUncertainOutcome))
+	assert.False(t, IsConnectionError(marked))
+	assert.ErrorIs(t, marked, assert.AnError)
+	assert.Same(t, MarkConnectionInvalid(marked), marked)
+	assert.NoError(t, MarkConnectionInvalid(nil))
+}

--- a/components/tool/mcp/officialmcp/mcp_test.go
+++ b/components/tool/mcp/officialmcp/mcp_test.go
@@ -506,3 +506,14 @@ func TestConnectionInvalidMarkerPreservesErrorClassification(t *testing.T) {
 	assert.Same(t, MarkConnectionInvalid(marked), marked)
 	assert.NoError(t, MarkConnectionInvalid(nil))
 }
+
+func TestSessionTerminalMarkerPreservesErrorClassification(t *testing.T) {
+	protocolErr := &Error{Kind: ErrorKindCallTool, Err: assert.AnError}
+	marked := MarkSessionTerminal(protocolErr)
+	assert.True(t, IsSessionTerminal(marked))
+	assert.True(t, IsErrorKind(marked, ErrorKindCallTool))
+	assert.False(t, IsConnectionError(marked))
+	assert.ErrorIs(t, marked, assert.AnError)
+	assert.Same(t, MarkSessionTerminal(marked), marked)
+	assert.NoError(t, MarkSessionTerminal(nil))
+}

--- a/components/tool/mcp/officialmcp/mcp_test.go
+++ b/components/tool/mcp/officialmcp/mcp_test.go
@@ -517,3 +517,14 @@ func TestSessionTerminalMarkerPreservesErrorClassification(t *testing.T) {
 	assert.Same(t, MarkSessionTerminal(marked), marked)
 	assert.NoError(t, MarkSessionTerminal(nil))
 }
+
+func TestRequestRejectedMarkerPreservesErrorClassification(t *testing.T) {
+	overload := &Error{Kind: ErrorKindCallTool, Err: assert.AnError}
+	marked := MarkRequestRejected(overload)
+	assert.True(t, IsRequestRejected(marked))
+	assert.True(t, IsErrorKind(marked, ErrorKindCallTool))
+	assert.False(t, IsConnectionError(marked))
+	assert.ErrorIs(t, marked, assert.AnError)
+	assert.Same(t, MarkRequestRejected(marked), marked)
+	assert.NoError(t, MarkRequestRejected(nil))
+}

--- a/components/tool/mcp/officialmcp/mcp_test.go
+++ b/components/tool/mcp/officialmcp/mcp_test.go
@@ -470,6 +470,19 @@ func TestInvokableRunClassifiesProtocolErrorAsCallTool(t *testing.T) {
 	assert.False(t, IsConnectionError(err))
 }
 
+func TestInvokableRunPreservesUncertainOutcome(t *testing.T) {
+	ctx := context.Background()
+	uncertain := &Error{
+		Kind: ErrorKindUncertainOutcome,
+		Err:  fmt.Errorf("response lost: %w", mcp.ErrConnectionClosed),
+	}
+	_, err := newStubTool(t, &stubSession{callErr: uncertain}).InvokableRun(ctx, "{}")
+	require.Error(t, err)
+	assert.True(t, IsErrorKind(err, ErrorKindUncertainOutcome))
+	assert.False(t, IsConnectionError(err), "uncertain calls must never be replayed as connection errors")
+	assert.ErrorIs(t, err, mcp.ErrConnectionClosed)
+}
+
 func TestIsConnectionError(t *testing.T) {
 	assert.False(t, IsConnectionError(nil))
 	assert.False(t, IsConnectionError(errors.New("plain")))
@@ -477,4 +490,8 @@ func TestIsConnectionError(t *testing.T) {
 	assert.True(t, IsConnectionError(fmt.Errorf("x: %w", mcp.ErrSessionMissing)))
 	assert.True(t, IsConnectionError(&Error{Kind: ErrorKindConnection}))
 	assert.False(t, IsConnectionError(&Error{Kind: ErrorKindCallTool}))
+	assert.False(t, IsConnectionError(&Error{
+		Kind: ErrorKindUncertainOutcome,
+		Err:  fmt.Errorf("response lost: %w", mcp.ErrConnectionClosed),
+	}))
 }

--- a/components/tool/mcp/officialmcp/session/factory_test.go
+++ b/components/tool/mcp/officialmcp/session/factory_test.go
@@ -295,8 +295,8 @@ func TestReplaySafeListToolsUsesCursorBoundary(t *testing.T) {
 
 		_, err = managed.ListTools(ctx, &mcp.ListToolsParams{Cursor: "generation-bound-cursor"})
 		require.Error(t, err)
-		assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindUncertainOutcome))
-		assert.False(t, officialmcp.IsConnectionError(err))
+		assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindConnection))
+		assert.True(t, officialmcp.IsConnectionError(err))
 		assert.Equal(t, int32(2), pf.callCount())
 
 		result, err := managed.ListTools(ctx, &mcp.ListToolsParams{})

--- a/components/tool/mcp/officialmcp/session/factory_test.go
+++ b/components/tool/mcp/officialmcp/session/factory_test.go
@@ -117,6 +117,43 @@ type terminalConnection struct {
 	inner mcp.Connection
 }
 
+type rejectOnceTransport struct {
+	inner mcp.Transport
+}
+
+func (t rejectOnceTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	connection, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &rejectOnceConnection{inner: connection}, nil
+}
+
+type rejectOnceConnection struct {
+	inner    mcp.Connection
+	rejected atomic.Bool
+}
+
+func (c *rejectOnceConnection) Read(ctx context.Context) (jsonrpc.Message, error) {
+	return c.inner.Read(ctx)
+}
+
+func (c *rejectOnceConnection) Write(ctx context.Context, message jsonrpc.Message) error {
+	if request, ok := message.(*jsonrpc.Request); ok &&
+		request.Method == "tools/call" &&
+		c.rejected.CompareAndSwap(false, true) {
+		return officialmcp.MarkRequestRejected(&officialmcp.Error{
+			Kind: officialmcp.ErrorKindCallTool,
+			Err:  errors.New("overloaded"),
+		})
+	}
+	return c.inner.Write(ctx, message)
+}
+
+func (c *rejectOnceConnection) Close() error { return c.inner.Close() }
+
+func (c *rejectOnceConnection) SessionID() string { return c.inner.SessionID() }
+
 func (c *terminalConnection) Read(ctx context.Context) (jsonrpc.Message, error) {
 	return c.inner.Read(ctx)
 }
@@ -458,6 +495,42 @@ func TestSessionTerminalErrorClosesManagedSession(t *testing.T) {
 	require.ErrorIs(t, err, ErrSessionClosed)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&factoryCalls), "terminal session must not reconnect")
 	require.NoError(t, managed.Close())
+}
+
+func TestRequestRejectedKeepsManagedConnectionUsable(t *testing.T) {
+	ctx := context.Background()
+	pf := &pipeFactory{server: newAddServer()}
+	var factoryCalls int32
+	managed, err := Connect(ctx, ServerConfig{
+		Name: "test",
+		Transport: TransportConfig{Factory: func(ctx context.Context) (mcp.Transport, error) {
+			transport, err := pf.factory(ctx)
+			if err != nil {
+				return nil, err
+			}
+			atomic.AddInt32(&factoryCalls, 1)
+			return rejectOnceTransport{inner: transport}, nil
+		}},
+	})
+	require.NoError(t, err)
+	defer managed.Close()
+
+	_, err = managed.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "add",
+		Arguments: map[string]any{"x": 1, "y": 2},
+	})
+	require.Error(t, err)
+	assert.True(t, officialmcp.IsRequestRejected(err))
+	assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindCallTool))
+
+	result, err := managed.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "add",
+		Arguments: map[string]any{"x": 4, "y": 5},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "9", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&factoryCalls))
+	assert.Equal(t, []int32{1}, pf.transportConnectCounts())
 }
 
 func TestCloseDoesNotWaitForBlockedReconnectFactory(t *testing.T) {

--- a/components/tool/mcp/officialmcp/session/factory_test.go
+++ b/components/tool/mcp/officialmcp/session/factory_test.go
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	officialmcp "github.com/cloudwego/eino-ext/components/tool/mcp/officialmcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newAddServer returns a server with an "add" tool, like newStreamableServerHandler
+// but transport-agnostic so it can be attached to in-memory pipes.
+func newAddServer() *mcp.Server {
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "add", Description: "add two numbers"}, func(ctx context.Context, req *mcp.CallToolRequest, args addParams) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("%d", args.X+args.Y)}},
+		}, nil, nil
+	})
+	return server
+}
+
+// pipeFactory builds transports that bridge the client to server over a fresh
+// in-memory pipe on every invocation, recording each server-side session so
+// tests can kill the current connection. The server is connected before the
+// client, as mcp.NewInMemoryTransports requires.
+type pipeFactory struct {
+	server *mcp.Server
+	calls  int32
+
+	mu               sync.Mutex
+	serverSession    []*mcp.ServerSession
+	clientTransports []*countingTransport
+}
+
+type countingTransport struct {
+	inner mcp.Transport
+	calls int32
+}
+
+func (t *countingTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	atomic.AddInt32(&t.calls, 1)
+	return t.inner.Connect(ctx)
+}
+
+func (f *pipeFactory) factory(ctx context.Context) (mcp.Transport, error) {
+	atomic.AddInt32(&f.calls, 1)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ss, err := f.server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return nil, err
+	}
+	countingClientTransport := &countingTransport{inner: clientTransport}
+	f.mu.Lock()
+	f.serverSession = append(f.serverSession, ss)
+	f.clientTransports = append(f.clientTransports, countingClientTransport)
+	f.mu.Unlock()
+	return countingClientTransport, nil
+}
+
+func (f *pipeFactory) callCount() int32 {
+	return atomic.LoadInt32(&f.calls)
+}
+
+func (f *pipeFactory) transportConnectCounts() []int32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	counts := make([]int32, len(f.clientTransports))
+	for index, transport := range f.clientTransports {
+		counts[index] = atomic.LoadInt32(&transport.calls)
+	}
+	return counts
+}
+
+// closeLastServerSession kills the server side of the most recent pipe,
+// breaking the current client connection.
+func (f *pipeFactory) closeLastServerSession() error {
+	f.mu.Lock()
+	ss := f.serverSession[len(f.serverSession)-1]
+	f.mu.Unlock()
+	return ss.Close()
+}
+
+func TestConnectViaFactory(t *testing.T) {
+	ctx := context.Background()
+	pf := &pipeFactory{server: newAddServer()}
+
+	managed, err := Connect(ctx, ServerConfig{
+		Name:      "test",
+		Transport: TransportConfig{Factory: pf.factory},
+	})
+	require.NoError(t, err)
+	defer managed.Close()
+
+	result, err := managed.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 1, "y": 2}})
+	require.NoError(t, err)
+	assert.Equal(t, "3", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, int32(1), pf.callCount())
+	assert.Equal(t, []int32{1}, pf.transportConnectCounts())
+}
+
+func TestConnectFactoryError(t *testing.T) {
+	_, err := Connect(context.Background(), ServerConfig{
+		Name: "bad",
+		Transport: TransportConfig{
+			Factory: func(context.Context) (mcp.Transport, error) {
+				return nil, errors.New("factory dial failed")
+			},
+		},
+	})
+	require.Error(t, err)
+	var startupErr *StartupError
+	require.ErrorAs(t, err, &startupErr)
+	assert.Contains(t, err.Error(), "factory dial failed")
+}
+
+func TestConnectFactoryRejectsNilTransport(t *testing.T) {
+	_, err := Connect(context.Background(), ServerConfig{
+		Name: "bad",
+		Transport: TransportConfig{
+			Factory: func(context.Context) (mcp.Transport, error) { return nil, nil },
+		},
+	})
+	require.Error(t, err)
+	var startupErr *StartupError
+	require.ErrorAs(t, err, &startupErr)
+	assert.Contains(t, err.Error(), "transport factory returned nil")
+}
+
+func TestConnectRejectsInvalidReplayPolicyBeforeFactory(t *testing.T) {
+	var factoryCalls int32
+	_, err := Connect(context.Background(), ServerConfig{
+		Name:   "bad",
+		Replay: ReplayPolicies{CallTool: ReplayPolicy(255)},
+		Transport: TransportConfig{Factory: func(context.Context) (mcp.Transport, error) {
+			atomic.AddInt32(&factoryCalls, 1)
+			return nil, errors.New("must not run")
+		}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid official mcp call tool replay policy")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&factoryCalls))
+}
+
+func TestReconnectReinvokesFactory(t *testing.T) {
+	ctx := context.Background()
+	pf := &pipeFactory{server: newAddServer()}
+
+	rs, err := Connect(ctx, ServerConfig{
+		Name:      "test",
+		Transport: TransportConfig{Factory: pf.factory},
+	})
+	require.NoError(t, err)
+	defer rs.Close()
+
+	res, err := rs.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 1, "y": 2}})
+	require.NoError(t, err)
+	assert.Equal(t, "3", res.Content[0].(*mcp.TextContent).Text)
+
+	stale, err := rs.current()
+	require.NoError(t, err)
+
+	// Kill the server side of the current pipe. The client notices the broken
+	// connection asynchronously, and only then do its calls fail
+	// connection-level (a write that wins the race against the teardown
+	// surfaces as a raw io error), so wait for that before triggering the
+	// reconnect. Ping the raw session directly to avoid Session's own retry.
+	require.NoError(t, pf.closeLastServerSession())
+	require.Eventually(t, func() bool {
+		return officialmcp.IsConnectionError(stale.Ping(ctx, nil))
+	}, 5*time.Second, time.Millisecond)
+
+	res, err = rs.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 4, "y": 5}})
+	require.NoError(t, err)
+	assert.Equal(t, "9", res.Content[0].(*mcp.TextContent).Text)
+
+	assert.Equal(t, int32(2), pf.callCount())
+	assert.Equal(t, []int32{1, 1}, pf.transportConnectCounts())
+	sessionAfter, err := rs.current()
+	require.NoError(t, err)
+	assert.NotSame(t, stale, sessionAfter, "expected a new underlying session after reconnect")
+}
+
+func TestReplaySafeCallToolReconnectsWithoutReplaying(t *testing.T) {
+	ctx := context.Background()
+	var toolCalls int32
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "add", Description: "add two numbers"}, func(ctx context.Context, req *mcp.CallToolRequest, args addParams) (*mcp.CallToolResult, any, error) {
+		atomic.AddInt32(&toolCalls, 1)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("%d", args.X+args.Y)}},
+		}, nil, nil
+	})
+	pf := &pipeFactory{server: server}
+
+	managed, err := Connect(ctx, ServerConfig{
+		Name:      "test",
+		Transport: TransportConfig{Factory: pf.factory},
+		Replay:    ReplayPolicies{CallTool: ReplaySafe},
+	})
+	require.NoError(t, err)
+	defer managed.Close()
+
+	result, err := managed.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 1, "y": 2}})
+	require.NoError(t, err)
+	assert.Equal(t, "3", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&toolCalls))
+
+	stale, err := managed.current()
+	require.NoError(t, err)
+	require.NoError(t, pf.closeLastServerSession())
+	require.Eventually(t, func() bool {
+		return officialmcp.IsConnectionError(stale.Ping(ctx, nil))
+	}, 5*time.Second, time.Millisecond)
+
+	_, err = managed.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 4, "y": 5}})
+	require.Error(t, err)
+	assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindUncertainOutcome))
+	assert.False(t, officialmcp.IsConnectionError(err))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&toolCalls), "failed call must not be replayed on the fresh connection")
+	assert.Equal(t, int32(2), pf.callCount())
+
+	result, err = managed.CallTool(ctx, &mcp.CallToolParams{Name: "add", Arguments: map[string]any{"x": 4, "y": 5}})
+	require.NoError(t, err)
+	assert.Equal(t, "9", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&toolCalls))
+	assert.Equal(t, []int32{1, 1}, pf.transportConnectCounts())
+}
+
+func TestReplaySafeListToolsUsesCursorBoundary(t *testing.T) {
+	t.Run("empty cursor replays", func(t *testing.T) {
+		ctx := context.Background()
+		pf := &pipeFactory{server: newAddServer()}
+		managed, err := Connect(ctx, ServerConfig{
+			Name:      "test",
+			Transport: TransportConfig{Factory: pf.factory},
+			Replay:    ReplayPolicies{ListTools: ReplaySafe},
+		})
+		require.NoError(t, err)
+		defer managed.Close()
+
+		stale, err := managed.current()
+		require.NoError(t, err)
+		require.NoError(t, pf.closeLastServerSession())
+		require.Eventually(t, func() bool {
+			return officialmcp.IsConnectionError(stale.Ping(ctx, nil))
+		}, 5*time.Second, time.Millisecond)
+
+		result, err := managed.ListTools(ctx, &mcp.ListToolsParams{})
+		require.NoError(t, err)
+		assert.Len(t, result.Tools, 1)
+		assert.Equal(t, int32(2), pf.callCount())
+	})
+
+	t.Run("nonempty cursor reconnects without replay", func(t *testing.T) {
+		ctx := context.Background()
+		pf := &pipeFactory{server: newAddServer()}
+		managed, err := Connect(ctx, ServerConfig{
+			Name:      "test",
+			Transport: TransportConfig{Factory: pf.factory},
+			Replay:    ReplayPolicies{ListTools: ReplaySafe},
+		})
+		require.NoError(t, err)
+		defer managed.Close()
+
+		stale, err := managed.current()
+		require.NoError(t, err)
+		require.NoError(t, pf.closeLastServerSession())
+		require.Eventually(t, func() bool {
+			return officialmcp.IsConnectionError(stale.Ping(ctx, nil))
+		}, 5*time.Second, time.Millisecond)
+
+		_, err = managed.ListTools(ctx, &mcp.ListToolsParams{Cursor: "generation-bound-cursor"})
+		require.Error(t, err)
+		assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindUncertainOutcome))
+		assert.False(t, officialmcp.IsConnectionError(err))
+		assert.Equal(t, int32(2), pf.callCount())
+
+		result, err := managed.ListTools(ctx, &mcp.ListToolsParams{})
+		require.NoError(t, err)
+		assert.Len(t, result.Tools, 1)
+		assert.Equal(t, int32(2), pf.callCount())
+	})
+}
+
+func TestReplaySafeMethodSemantics(t *testing.T) {
+	assert.True(t, shouldReplay(ReplayDefault, false))
+	assert.True(t, shouldReplay(ReplayAlways, false))
+	assert.False(t, shouldReplay(ReplayNever, true))
+	assert.True(t, shouldReplay(ReplaySafe, true))
+	assert.False(t, shouldReplay(ReplaySafe, false))
+}
+
+func TestCloseDoesNotWaitForBlockedReconnectFactory(t *testing.T) {
+	ctx := context.Background()
+	pf := &pipeFactory{server: newAddServer()}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls int32
+	factory := func(ctx context.Context) (mcp.Transport, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return pf.factory(ctx)
+		}
+		close(started)
+		<-release // Deliberately ignore ctx to model a misbehaving dialer.
+		return nil, errors.New("late reconnect failure")
+	}
+
+	managed, err := Connect(ctx, ServerConfig{
+		Name:      "test",
+		Transport: TransportConfig{Factory: factory},
+	})
+	require.NoError(t, err)
+	stale, err := managed.current()
+	require.NoError(t, err)
+
+	reconnectDone := make(chan error, 1)
+	go func() {
+		_, reconnectErr := managed.reconnect(ctx, stale)
+		reconnectDone <- reconnectErr
+	}()
+	<-started
+
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, reconnectErr := managed.reconnect(ctx, stale)
+		waiterDone <- reconnectErr
+	}()
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- managed.Close() }()
+	select {
+	case closeErr := <-closeDone:
+		require.NoError(t, closeErr)
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked behind reconnect factory")
+	}
+	select {
+	case waiterErr := <-waiterDone:
+		require.ErrorIs(t, waiterErr, ErrSessionClosed)
+	case <-time.After(time.Second):
+		t.Fatal("reconnect waiter did not observe Close")
+	}
+
+	close(release)
+	require.ErrorIs(t, <-reconnectDone, ErrSessionClosed)
+	_, err = managed.current()
+	require.ErrorIs(t, err, ErrSessionClosed)
+}

--- a/components/tool/mcp/officialmcp/session/factory_test.go
+++ b/components/tool/mcp/officialmcp/session/factory_test.go
@@ -101,6 +101,37 @@ func (c *invalidatingConnection) Close() error { return c.inner.Close() }
 
 func (c *invalidatingConnection) SessionID() string { return c.inner.SessionID() }
 
+type terminalTransport struct {
+	inner mcp.Transport
+}
+
+func (t terminalTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	connection, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &terminalConnection{inner: connection}, nil
+}
+
+type terminalConnection struct {
+	inner mcp.Connection
+}
+
+func (c *terminalConnection) Read(ctx context.Context) (jsonrpc.Message, error) {
+	return c.inner.Read(ctx)
+}
+
+func (c *terminalConnection) Write(ctx context.Context, message jsonrpc.Message) error {
+	if request, ok := message.(*jsonrpc.Request); ok && request.Method == "tools/call" {
+		return officialmcp.MarkSessionTerminal(errors.New("invalid tunnel response"))
+	}
+	return c.inner.Write(ctx, message)
+}
+
+func (c *terminalConnection) Close() error { return c.inner.Close() }
+
+func (c *terminalConnection) SessionID() string { return c.inner.SessionID() }
+
 func (f *pipeFactory) factory(ctx context.Context) (mcp.Transport, error) {
 	atomic.AddInt32(&f.calls, 1)
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -396,6 +427,37 @@ func TestConnectionInvalidRebuildsWithoutReplaying(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "9", result.Content[0].(*mcp.TextContent).Text)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&toolCalls))
+}
+
+func TestSessionTerminalErrorClosesManagedSession(t *testing.T) {
+	ctx := context.Background()
+	pf := &pipeFactory{server: newAddServer()}
+	var factoryCalls int32
+	managed, err := Connect(ctx, ServerConfig{
+		Name: "test",
+		Transport: TransportConfig{Factory: func(ctx context.Context) (mcp.Transport, error) {
+			transport, err := pf.factory(ctx)
+			if err != nil {
+				return nil, err
+			}
+			atomic.AddInt32(&factoryCalls, 1)
+			return terminalTransport{inner: transport}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = managed.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "add",
+		Arguments: map[string]any{"x": 1, "y": 2},
+	})
+	require.Error(t, err)
+	assert.True(t, officialmcp.IsSessionTerminal(err))
+	assert.False(t, officialmcp.IsConnectionError(err))
+
+	_, err = managed.CallTool(ctx, &mcp.CallToolParams{Name: "add"})
+	require.ErrorIs(t, err, ErrSessionClosed)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&factoryCalls), "terminal session must not reconnect")
+	require.NoError(t, managed.Close())
 }
 
 func TestCloseDoesNotWaitForBlockedReconnectFactory(t *testing.T) {

--- a/components/tool/mcp/officialmcp/session/factory_test.go
+++ b/components/tool/mcp/officialmcp/session/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	officialmcp "github.com/cloudwego/eino-ext/components/tool/mcp/officialmcp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,40 @@ func (t *countingTransport) Connect(ctx context.Context) (mcp.Connection, error)
 	atomic.AddInt32(&t.calls, 1)
 	return t.inner.Connect(ctx)
 }
+
+type invalidatingTransport struct {
+	inner mcp.Transport
+}
+
+func (t invalidatingTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	connection, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &invalidatingConnection{inner: connection}, nil
+}
+
+type invalidatingConnection struct {
+	inner mcp.Connection
+}
+
+func (c *invalidatingConnection) Read(ctx context.Context) (jsonrpc.Message, error) {
+	return c.inner.Read(ctx)
+}
+
+func (c *invalidatingConnection) Write(ctx context.Context, message jsonrpc.Message) error {
+	if request, ok := message.(*jsonrpc.Request); ok && request.Method == "tools/call" {
+		return officialmcp.MarkConnectionInvalid(&officialmcp.Error{
+			Kind: officialmcp.ErrorKindUncertainOutcome,
+			Err:  errors.New("response lost"),
+		})
+	}
+	return c.inner.Write(ctx, message)
+}
+
+func (c *invalidatingConnection) Close() error { return c.inner.Close() }
+
+func (c *invalidatingConnection) SessionID() string { return c.inner.SessionID() }
 
 func (f *pipeFactory) factory(ctx context.Context) (mcp.Transport, error) {
 	atomic.AddInt32(&f.calls, 1)
@@ -312,6 +347,55 @@ func TestReplaySafeMethodSemantics(t *testing.T) {
 	assert.False(t, shouldReplay(ReplayNever, true))
 	assert.True(t, shouldReplay(ReplaySafe, true))
 	assert.False(t, shouldReplay(ReplaySafe, false))
+}
+
+func TestConnectionInvalidRebuildsWithoutReplaying(t *testing.T) {
+	ctx := context.Background()
+	var toolCalls int32
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "add", Description: "add two numbers"}, func(ctx context.Context, req *mcp.CallToolRequest, args addParams) (*mcp.CallToolResult, any, error) {
+		atomic.AddInt32(&toolCalls, 1)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("%d", args.X+args.Y)}},
+		}, nil, nil
+	})
+	pf := &pipeFactory{server: server}
+	var factoryCalls int32
+	managed, err := Connect(ctx, ServerConfig{
+		Name: "test",
+		Transport: TransportConfig{Factory: func(ctx context.Context) (mcp.Transport, error) {
+			transport, err := pf.factory(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if atomic.AddInt32(&factoryCalls, 1) == 1 {
+				return invalidatingTransport{inner: transport}, nil
+			}
+			return transport, nil
+		}},
+		Replay: ReplayPolicies{CallTool: ReplaySafe},
+	})
+	require.NoError(t, err)
+	defer managed.Close()
+
+	_, err = managed.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "add",
+		Arguments: map[string]any{"x": 1, "y": 2},
+	})
+	require.Error(t, err)
+	assert.True(t, officialmcp.IsErrorKind(err, officialmcp.ErrorKindUncertainOutcome))
+	assert.True(t, officialmcp.IsConnectionInvalid(err))
+	assert.False(t, officialmcp.IsConnectionError(err))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&toolCalls), "failed call must not reach the server")
+	assert.Equal(t, int32(2), pf.callCount(), "connection should rebuild without replaying CallTool")
+
+	result, err := managed.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "add",
+		Arguments: map[string]any{"x": 4, "y": 5},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "9", result.Content[0].(*mcp.TextContent).Text)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&toolCalls))
 }
 
 func TestCloseDoesNotWaitForBlockedReconnectFactory(t *testing.T) {

--- a/components/tool/mcp/officialmcp/session/session.go
+++ b/components/tool/mcp/officialmcp/session/session.go
@@ -36,6 +36,29 @@ const (
 	TransportStreamableHTTP = "streamable-http"
 )
 
+// ReplayPolicy controls whether an operation is issued again after Session
+// replaces a failed connection. Reconnection still happens for ReplayNever;
+// only replay of the operation that observed the failure is suppressed.
+type ReplayPolicy uint8
+
+const (
+	// ReplayDefault preserves the historical behavior and replays once.
+	ReplayDefault ReplayPolicy = iota
+	ReplayAlways
+	ReplayNever
+	// ReplaySafe uses method-specific conservative semantics: Ping is safe,
+	// ListTools is safe only for an empty cursor, and CallTool is never safe.
+	ReplaySafe
+)
+
+// ReplayPolicies configures replay independently for each operation exposed by
+// Session. Zero values preserve the historical replay-once behavior.
+type ReplayPolicies struct {
+	ListTools ReplayPolicy
+	CallTool  ReplayPolicy
+	Ping      ReplayPolicy
+}
+
 // ErrorKindUnsupportedTransport tags an unsupported TransportConfig.Type. It
 // lives here rather than in the officialmcp package because only the session
 // layer constructs transports.
@@ -44,6 +67,7 @@ const ErrorKindUnsupportedTransport officialmcp.ErrorKind = "unsupported_transpo
 type ServerConfig struct {
 	Name              string
 	Transport         TransportConfig
+	Replay            ReplayPolicies
 	Client            *mcp.Implementation
 	ClientOptions     *mcp.ClientOptions
 	InitializeOptions *mcp.ClientSessionOptions
@@ -66,6 +90,11 @@ type TransportConfig struct {
 	// RoundTripper runs, so that RoundTripper sees them and may override them.
 	// Ignored for stdio.
 	HTTPClient *http.Client
+
+	// Factory builds a custom transport. When set, it takes precedence over the
+	// built-in transports selected by Type, and it is invoked again on every
+	// reconnect, so callers control redial semantics.
+	Factory func(ctx context.Context) (mcp.Transport, error)
 }
 
 var ErrSessionClosed = errors.New("official mcp session is closed")
@@ -95,6 +124,15 @@ type Session struct {
 	mu      sync.Mutex
 	session *mcp.ClientSession
 	closed  bool
+	closedC chan struct{}
+	attempt *reconnectAttempt
+}
+
+type reconnectAttempt struct {
+	done   chan struct{}
+	cancel context.CancelFunc
+	result *mcp.ClientSession
+	err    error
 }
 
 var _ officialmcp.ClientSession = (*Session)(nil)
@@ -120,12 +158,17 @@ func Connect(ctx context.Context, cfg ServerConfig) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Session{Name: cfg.Name, cfg: cfg, session: session}, nil
+	return &Session{Name: cfg.Name, cfg: cfg, session: session, closedC: make(chan struct{})}, nil
 }
 
-// connect builds the transport and dials a single go-sdk session.
+// connect builds the transport and dials a single go-sdk session. Reconnect
+// re-enters here with the same cfg, so a TransportConfig.Factory is invoked
+// again on every reconnect.
 func connect(ctx context.Context, cfg ServerConfig) (*mcp.ClientSession, error) {
-	transport, err := newTransport(cfg.Transport)
+	if err := validateReplayPolicies(cfg.Replay); err != nil {
+		return nil, startupError(cfg, err)
+	}
+	transport, err := newTransport(ctx, cfg.Transport)
 	if err != nil {
 		return nil, startupError(cfg, err)
 	}
@@ -156,7 +199,14 @@ func (s *Session) Close() error {
 	s.closed = true
 	cur := s.session
 	s.session = nil
+	attempt := s.attempt
+	if s.closedC != nil {
+		close(s.closedC)
+	}
 	s.mu.Unlock()
+	if attempt != nil {
+		attempt.cancel()
+	}
 	if cur == nil {
 		return nil
 	}
@@ -173,42 +223,83 @@ func (s *Session) current() (*mcp.ClientSession, error) {
 }
 
 // reconnect rebuilds the session, but only if stale is still the current one.
-// If another goroutine already reconnected (current != stale), it returns the
-// fresh session without connecting again, so once one goroutine reconnects
-// successfully a burst of concurrent connection errors reuses that single new
-// session. A reconnect that *fails* leaves stale installed, so each waiting
-// caller in the burst re-enters here and dials on its own until one succeeds.
+// Concurrent callers share one in-flight attempt. The potentially blocking
+// connect runs without holding s.mu, which lets Close cancel the attempt and
+// return without waiting for a transport that ignores cancellation. A late
+// successful connection is closed instead of being adopted after Close.
 func (s *Session) reconnect(ctx context.Context, stale *mcp.ClientSession) (*mcp.ClientSession, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.closed {
+		s.mu.Unlock()
 		return nil, ErrSessionClosed
 	}
 	if s.session != stale {
-		return s.session, nil
+		current := s.session
+		s.mu.Unlock()
+		return current, nil
 	}
-	// Connect first, then discard the stale session only once we have a working
-	// replacement. If connect fails we leave stale installed (unchanged, not
-	// closed) so a later retry re-enters here against the same sentinel and dials
-	// again — rather than closing stale now and leaving a dead session as current,
-	// which would make every retry re-close the same session.
-	cur, err := connect(ctx, s.cfg)
-	if err != nil {
-		// Tag the reconnect failure as connection-level so callers (and
-		// officialmcp.IsConnectionError) recognize an unreachable server as such,
-		// instead of the default classification treating it as a call/list
-		// protocol error. The StartupError is preserved as the cause.
-		return nil, &officialmcp.Error{Kind: officialmcp.ErrorKindConnection, ServerName: s.cfg.Name, Err: err}
+	if attempt := s.attempt; attempt != nil {
+		closedC := s.closedC
+		s.mu.Unlock()
+		select {
+		case <-attempt.done:
+			return attempt.result, attempt.err
+		case <-closedC:
+			return nil, ErrSessionClosed
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
-	if stale != nil {
-		_ = stale.Close()
+	attemptCtx, cancel := context.WithCancel(ctx)
+	attempt := &reconnectAttempt{
+		done:   make(chan struct{}),
+		cancel: cancel,
 	}
-	s.session = cur
-	return s.session, nil
+	s.attempt = attempt
+	cfg := s.cfg
+	s.mu.Unlock()
+
+	fresh, connectErr := connect(attemptCtx, cfg)
+
+	var closeFresh, closeStale *mcp.ClientSession
+	s.mu.Lock()
+	switch {
+	case s.closed:
+		attempt.err = ErrSessionClosed
+		closeFresh = fresh
+	case s.session != stale:
+		attempt.result = s.session
+		closeFresh = fresh
+	case connectErr != nil:
+		// Leave stale installed so a later operation can start a new attempt.
+		attempt.err = &officialmcp.Error{
+			Kind:       officialmcp.ErrorKindConnection,
+			ServerName: cfg.Name,
+			Err:        connectErr,
+		}
+	default:
+		s.session = fresh
+		attempt.result = fresh
+		closeStale = stale
+	}
+	if s.attempt == attempt {
+		s.attempt = nil
+	}
+	close(attempt.done)
+	s.mu.Unlock()
+	cancel()
+
+	if closeFresh != nil {
+		_ = closeFresh.Close()
+	}
+	if closeStale != nil {
+		_ = closeStale.Close()
+	}
+	return attempt.result, attempt.err
 }
 
-// ListTools calls the underlying session, reconnecting and retrying once on a
-// connection-level failure.
+// ListTools calls the underlying session and follows the configured replay
+// policy after a connection-level failure.
 func (s *Session) ListTools(ctx context.Context, params *mcp.ListToolsParams) (*mcp.ListToolsResult, error) {
 	cur, err := s.current()
 	if err != nil {
@@ -218,15 +309,24 @@ func (s *Session) ListTools(ctx context.Context, params *mcp.ListToolsParams) (*
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return res, err
 	}
-	cur, rerr := s.reconnect(ctx, cur)
-	if rerr != nil {
-		return nil, rerr
+	fresh, reconnectErr := s.reconnect(ctx, cur)
+	replay := shouldReplay(s.cfg.Replay.ListTools, params == nil || params.Cursor == "")
+	if !replay {
+		return nil, uncertainOutcomeError(s.cfg.Name, "list tools", err, reconnectErr)
 	}
-	return cur.ListTools(ctx, params)
+	if reconnectErr != nil {
+		return nil, reconnectErr
+	}
+	if fresh == nil {
+		return nil, ErrSessionClosed
+	}
+	return fresh.ListTools(ctx, params)
 }
 
-// CallTool calls the underlying session, reconnecting and retrying once on a
-// connection-level failure.
+// CallTool calls the underlying session and follows the configured replay
+// policy after a connection-level failure. ReplayNever conservatively returns
+// ErrorKindUncertainOutcome because the transport cannot prove whether the
+// server applied the request before the connection failed.
 func (s *Session) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	cur, err := s.current()
 	if err != nil {
@@ -236,15 +336,20 @@ func (s *Session) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mc
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return res, err
 	}
-	cur, rerr := s.reconnect(ctx, cur)
-	if rerr != nil {
-		return nil, rerr
+	fresh, reconnectErr := s.reconnect(ctx, cur)
+	if !shouldReplay(s.cfg.Replay.CallTool, false) {
+		return nil, uncertainOutcomeError(s.cfg.Name, "call tool", err, reconnectErr)
 	}
-	return cur.CallTool(ctx, params)
+	if reconnectErr != nil {
+		return nil, reconnectErr
+	}
+	if fresh == nil {
+		return nil, ErrSessionClosed
+	}
+	return fresh.CallTool(ctx, params)
 }
 
-// Ping pings the underlying session, reconnecting and retrying once on a
-// connection-level failure.
+// Ping follows the configured replay policy after a connection-level failure.
 func (s *Session) Ping(ctx context.Context, params *mcp.PingParams) error {
 	cur, err := s.current()
 	if err != nil {
@@ -254,14 +359,30 @@ func (s *Session) Ping(ctx context.Context, params *mcp.PingParams) error {
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return err
 	}
-	cur, rerr := s.reconnect(ctx, cur)
-	if rerr != nil {
-		return rerr
+	fresh, reconnectErr := s.reconnect(ctx, cur)
+	if !shouldReplay(s.cfg.Replay.Ping, true) {
+		return uncertainOutcomeError(s.cfg.Name, "ping", err, reconnectErr)
 	}
-	return cur.Ping(ctx, params)
+	if reconnectErr != nil {
+		return reconnectErr
+	}
+	if fresh == nil {
+		return ErrSessionClosed
+	}
+	return fresh.Ping(ctx, params)
 }
 
-func newTransport(cfg TransportConfig) (mcp.Transport, error) {
+func newTransport(ctx context.Context, cfg TransportConfig) (mcp.Transport, error) {
+	if cfg.Factory != nil {
+		transport, err := cfg.Factory(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if transport == nil {
+			return nil, errors.New("official mcp transport factory returned nil")
+		}
+		return transport, nil
+	}
 	switch cfg.Type {
 	case TransportSSE:
 		if err := validateAbsoluteURL(cfg.URL); err != nil {
@@ -288,6 +409,50 @@ func newTransport(cfg TransportConfig) (mcp.Transport, error) {
 			Kind: ErrorKindUnsupportedTransport,
 			Err:  fmt.Errorf("unsupported official mcp transport: %s", cfg.Type),
 		}
+	}
+}
+
+func validateReplayPolicies(policies ReplayPolicies) error {
+	for _, candidate := range []struct {
+		name   string
+		policy ReplayPolicy
+	}{
+		{name: "list tools", policy: policies.ListTools},
+		{name: "call tool", policy: policies.CallTool},
+		{name: "ping", policy: policies.Ping},
+	} {
+		name, policy := candidate.name, candidate.policy
+		switch policy {
+		case ReplayDefault, ReplayAlways, ReplayNever, ReplaySafe:
+		default:
+			return fmt.Errorf("invalid official mcp %s replay policy: %d", name, policy)
+		}
+	}
+	return nil
+}
+
+func shouldReplay(policy ReplayPolicy, operationSafe bool) bool {
+	switch policy {
+	case ReplayDefault, ReplayAlways:
+		return true
+	case ReplayNever:
+		return false
+	case ReplaySafe:
+		return operationSafe
+	default:
+		return false
+	}
+}
+
+func uncertainOutcomeError(serverName, operation string, operationErr, reconnectErr error) error {
+	cause := operationErr
+	if reconnectErr != nil {
+		cause = errors.Join(operationErr, reconnectErr)
+	}
+	return &officialmcp.Error{
+		Kind:       officialmcp.ErrorKindUncertainOutcome,
+		ServerName: serverName,
+		Err:        fmt.Errorf("official mcp %s outcome is uncertain: %w", operation, cause),
 	}
 }
 

--- a/components/tool/mcp/officialmcp/session/session.go
+++ b/components/tool/mcp/officialmcp/session/session.go
@@ -306,6 +306,10 @@ func (s *Session) ListTools(ctx context.Context, params *mcp.ListToolsParams) (*
 		return nil, err
 	}
 	res, err := cur.ListTools(ctx, params)
+	if officialmcp.IsSessionTerminal(err) {
+		_ = s.Close()
+		return nil, err
+	}
 	if officialmcp.IsConnectionInvalid(err) {
 		_, _ = s.reconnect(ctx, cur)
 		return nil, err
@@ -337,6 +341,10 @@ func (s *Session) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mc
 		return nil, err
 	}
 	res, err := cur.CallTool(ctx, params)
+	if officialmcp.IsSessionTerminal(err) {
+		_ = s.Close()
+		return nil, err
+	}
 	if officialmcp.IsConnectionInvalid(err) {
 		_, _ = s.reconnect(ctx, cur)
 		return nil, err
@@ -364,6 +372,10 @@ func (s *Session) Ping(ctx context.Context, params *mcp.PingParams) error {
 		return err
 	}
 	err = cur.Ping(ctx, params)
+	if officialmcp.IsSessionTerminal(err) {
+		_ = s.Close()
+		return err
+	}
 	if officialmcp.IsConnectionInvalid(err) {
 		_, _ = s.reconnect(ctx, cur)
 		return err

--- a/components/tool/mcp/officialmcp/session/session.go
+++ b/components/tool/mcp/officialmcp/session/session.go
@@ -312,7 +312,7 @@ func (s *Session) ListTools(ctx context.Context, params *mcp.ListToolsParams) (*
 	fresh, reconnectErr := s.reconnect(ctx, cur)
 	replay := shouldReplay(s.cfg.Replay.ListTools, params == nil || params.Cursor == "")
 	if !replay {
-		return nil, uncertainOutcomeError(s.cfg.Name, "list tools", err, reconnectErr)
+		return nil, connectionError(s.cfg.Name, "list tools", err, reconnectErr)
 	}
 	if reconnectErr != nil {
 		return nil, reconnectErr
@@ -453,6 +453,22 @@ func uncertainOutcomeError(serverName, operation string, operationErr, reconnect
 		Kind:       officialmcp.ErrorKindUncertainOutcome,
 		ServerName: serverName,
 		Err:        fmt.Errorf("official mcp %s outcome is uncertain: %w", operation, cause),
+	}
+}
+
+func connectionError(serverName, operation string, operationErr, reconnectErr error) error {
+	cause := operationErr
+	if reconnectErr != nil {
+		cause = errors.Join(operationErr, reconnectErr)
+	}
+	return &officialmcp.Error{
+		Kind:       officialmcp.ErrorKindConnection,
+		ServerName: serverName,
+		Err: fmt.Errorf(
+			"official mcp %s was not replayed after reconnect: %w",
+			operation,
+			cause,
+		),
 	}
 }
 

--- a/components/tool/mcp/officialmcp/session/session.go
+++ b/components/tool/mcp/officialmcp/session/session.go
@@ -306,6 +306,10 @@ func (s *Session) ListTools(ctx context.Context, params *mcp.ListToolsParams) (*
 		return nil, err
 	}
 	res, err := cur.ListTools(ctx, params)
+	if officialmcp.IsConnectionInvalid(err) {
+		_, _ = s.reconnect(ctx, cur)
+		return nil, err
+	}
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return res, err
 	}
@@ -333,6 +337,10 @@ func (s *Session) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mc
 		return nil, err
 	}
 	res, err := cur.CallTool(ctx, params)
+	if officialmcp.IsConnectionInvalid(err) {
+		_, _ = s.reconnect(ctx, cur)
+		return nil, err
+	}
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return res, err
 	}
@@ -356,6 +364,10 @@ func (s *Session) Ping(ctx context.Context, params *mcp.PingParams) error {
 		return err
 	}
 	err = cur.Ping(ctx, params)
+	if officialmcp.IsConnectionInvalid(err) {
+		_, _ = s.reconnect(ctx, cur)
+		return err
+	}
 	if err == nil || !officialmcp.IsConnectionError(err) {
 		return err
 	}

--- a/components/tool/mcp/officialmcp/session/session_test.go
+++ b/components/tool/mcp/officialmcp/session/session_test.go
@@ -138,7 +138,7 @@ func TestHTTPClientAndHeadersCompose(t *testing.T) {
 }
 
 func TestNewTransportStdioConfig(t *testing.T) {
-	transport, err := newTransport(TransportConfig{
+	transport, err := newTransport(context.Background(), TransportConfig{
 		Type:    TransportStdio,
 		Command: "echo",
 		Args:    []string{"hello"},
@@ -155,7 +155,7 @@ func TestNewTransportStdioConfig(t *testing.T) {
 }
 
 func TestNewTransportRejectsEmptyStdioCommand(t *testing.T) {
-	_, err := newTransport(TransportConfig{Type: TransportStdio})
+	_, err := newTransport(context.Background(), TransportConfig{Type: TransportStdio})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stdio command is empty")
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
