### PR TITLE
docs(openai): fix AzureModelMapperFunc doc comment to match actual behavior

### DIFF
--- a/components/model/openai/README.md
+++ b/components/model/openai/README.md
@@ -106,7 +106,7 @@ ByAzure bool `json:"by_azure"`
 
 // AzureModelMapperFunc is used to map the model name to the deployment name for Azure OpenAI Service.
 // This is useful when the model name is different from the deployment name.
-// Optional for Azure, remove [,:] from the model name by default.
+// Optional for Azure, remove [.:] from the model name by default.
 AzureModelMapperFunc func(model string) string
 
 // BaseURL is the Azure OpenAI endpoint URL

--- a/components/model/openai/chatmodel.go
+++ b/components/model/openai/chatmodel.go
@@ -105,7 +105,7 @@ type ChatModelConfig struct {
 
 	// AzureModelMapperFunc is used to map the model name to the deployment name for Azure OpenAI Service.
 	// This is useful when the model name is different from the deployment name.
-	// Optional for Azure, remove [,:] from the model name by default.
+	// Optional for Azure, remove [.:] from the model name by default.
 	AzureModelMapperFunc func(model string) string
 
 	// BaseURL is the Azure OpenAI endpoint URL

--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -90,7 +90,7 @@ type Config struct {
 
 	// AzureModelMapperFunc is used to map the model name to the deployment name for Azure OpenAI Service.
 	// This is useful when the model name is different from the deployment name.
-	// Optional for Azure, remove [,:] from the model name by default.
+	// Optional for Azure, remove [.:] from the model name by default.
 	AzureModelMapperFunc func(model string) string
 
 	// BaseURL is the Azure OpenAI endpoint URL


### PR DESCRIPTION
### References

References #939

### Why

`AzureModelMapperFunc`'s doc comment claims the default mapper strips `[,:]` (comma/colon) from the deployment name, but the actual default implementation in the underlying `go-openai` client strips `[.:]` (dot/colon). A caller passing a real Foundry deployment name containing a dot (e.g. `gpt-5.6-luna`) gets it silently rewritten, resulting in a 404 with no hint that the client transformed the name.

### What changed

Fixed the doc comment in three places to say `[.:]` instead of `[,:]`, matching what the code actually does:
- `libs/acl/openai/chat_model.go`
- `components/model/openai/chatmodel.go`
- `components/model/openai/README.md`

This is a comment/doc-only change (option 2 from the issue's three suggestions) — the least controversial fix since it doesn't change runtime behavior, unlike options 1 (stop transforming by default) or 3 (add debug logging), which the maintainer hasn't weighed in on yet.

### Surface area

- [x] Docs / tests / CI only

### Validation

`gofmt -l` on the two changed `.go` files reports no issues. `go build` in the affected modules currently fails in this environment due to a pre-existing `bytedance/sonic` / Go 1.26 incompatibility unrelated to this change (comment-only edit, no code logic touched).

### AI assistance

- **Tool(s) used:** Claude Code
- **How you used it:** AI helped locate all doc-comment occurrences of the mismatched regex description across the repo and drafted the fix.
- **Human verification:** Read and understood every line of this change; confirmed via `grep` that all three occurrences of the stale `[,:]` comment were found and fixed consistently; confirmed the change is comment-only with no behavioral impact; take responsibility for this change.
- [x] I've read and understand every line of this change and take responsibility for it.
