### PR TITLE
fix(mcp): normalize empty arguments to "{}" before calling tool

### DIFF
--- a/components/tool/mcp/mcp.go
+++ b/components/tool/mcp/mcp.go
@@ -129,6 +129,10 @@ func (m *toolHelper) InvokableRun(ctx context.Context, argumentsInJSON string, o
 		}
 	}
 
+	if argumentsInJSON == "" {
+		argumentsInJSON = "{}"
+	}
+
 	result, err := m.cli.CallTool(ctx, mcp.CallToolRequest{
 		Request: mcp.Request{
 			Method: "tools/call",

--- a/components/tool/mcp/mcp_test.go
+++ b/components/tool/mcp/mcp_test.go
@@ -18,6 +18,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudwego/eino/components/tool"
@@ -45,6 +46,14 @@ func TestTool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}", result)
 
+	// calling a tool with no arguments must not send an empty (unmarshalable) Arguments payload
+	_, err = tools[0].(tool.InvokableTool).InvokableRun(ctx, "", options...)
+	assert.NoError(t, err)
+	assert.Equal(t, json.RawMessage("{}"), cli.lastRequest.Params.Arguments)
+	if _, err := cli.lastRequest.Params.Arguments.(json.RawMessage).MarshalJSON(); err != nil {
+		t.Fatalf("Arguments must marshal without error, got: %v", err)
+	}
+
 	tools, err = GetTools(ctx, &Config{
 		Cli:           cli,
 		ToolNameList:  []string{"name"},
@@ -56,7 +65,9 @@ func TestTool(t *testing.T) {
 	assert.Equal(t, map[string]string{"key": "value"}, helper.customHeaders)
 }
 
-type mockMCPClient struct{}
+type mockMCPClient struct {
+	lastRequest mcp.CallToolRequest
+}
 
 func (m *mockMCPClient) ListResourcesByPage(ctx context.Context, request mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
 	//TODO implement me
@@ -137,6 +148,7 @@ func (m *mockMCPClient) ListTools(ctx context.Context, request mcp.ListToolsRequ
 }
 
 func (m *mockMCPClient) CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	m.lastRequest = request
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{


### PR DESCRIPTION
### References

Closes #923

### Why

Calling a parameterless MCP tool (e.g. a tool with no input schema) makes the model produce a tool_call with no `arguments` field. eino invokes `InvokableRun` with an empty string, which `components/tool/mcp`'s `InvokableRun` converted straight into a zero-length `json.RawMessage`. Its `MarshalJSON()` returns `unexpected end of JSON input` for empty input, so the mcp-go client's request serialization fails and the whole tool call errors out, breaking any ReAct-style agent that calls a no-arg MCP tool.

### What changed

`InvokableRun` in `components/tool/mcp/mcp.go` now normalizes an empty `argumentsInJSON` to `"{}"` before building the `CallToolRequest`, mirroring the same fallback already applied to tool_call arguments in `components/model/claude` (see #895 / #482) for the identical root cause.

### Bug fix verification

Added a case to `TestTool` in `components/tool/mcp/mcp_test.go` that calls `InvokableRun` with an empty arguments string and asserts the captured request's `Params.Arguments` is `json.RawMessage("{}")` and marshals without error.

- On `main` (fix reverted): test fails — `Arguments` is `json.RawMessage{}` instead of `{}`.
- On this branch: test passes.

### Surface area

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Ran (with `GOTOOLCHAIN=go1.23.0+auto` to match `components/tool/mcp/go.mod`'s `go 1.23.0`, since this environment's default Go 1.26 toolchain hits an unrelated `bytedance/sonic` build incompatibility):

```
cd components/tool/mcp
GOTOOLCHAIN=go1.23.0+auto go test ./... -run TestTool -v   # PASS
GOTOOLCHAIN=go1.23.0+auto go vet ./...                     # clean
gofmt -l mcp.go mcp_test.go                                # no output
```

### AI assistance

- **Tool(s) used:** Claude Code
- **How you used it:** AI helped locate the root cause in `InvokableRun`, found the existing analogous fix in `components/model/claude` (#895/#482) to follow the same convention, implemented the fallback, and drafted the regression test.
- **Human verification:** Read and understood every line of this change; ran the test suite myself and confirmed it fails on unfixed `main` and passes with the fix (temporarily reverted the fix via `git stash` to verify the red/green cycle firsthand); confirmed `go vet`/`gofmt` are clean; confirmed the change is scoped to this one bug (no unrelated refactors); take responsibility for this change.
- [x] I've read and understand every line of this change and take responsibility for it.
