### PR TITLE
fix(mcp): handle empty tool arguments (#923)

### DIFF
--- a/components/tool/mcp/mcp.go
+++ b/components/tool/mcp/mcp.go
@@ -129,6 +129,11 @@ func (m *toolHelper) InvokableRun(ctx context.Context, argumentsInJSON string, o
 		}
 	}
 
+	args := argumentsInJSON
+	if args == "" {
+		args = "{}"
+	}
+
 	result, err := m.cli.CallTool(ctx, mcp.CallToolRequest{
 		Request: mcp.Request{
 			Method: "tools/call",
@@ -136,7 +141,7 @@ func (m *toolHelper) InvokableRun(ctx context.Context, argumentsInJSON string, o
 		Header: headers,
 		Params: mcp.CallToolParams{
 			Name:      m.info.Name,
-			Arguments: json.RawMessage(argumentsInJSON),
+			Arguments: json.RawMessage(args),
 			Meta:      specOptions.meta,
 		},
 	})

--- a/components/tool/mcp/mcp_test.go
+++ b/components/tool/mcp/mcp_test.go
@@ -18,6 +18,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudwego/eino/components/tool"
@@ -41,9 +42,15 @@ func TestTool(t *testing.T) {
 		WithCustomHeaders(map[string]string{"key": "value"}),
 	}
 
-	result, err := tools[0].(tool.InvokableTool).InvokableRun(ctx, "{\"input\": \"123\"}", options...)
+	result, err := tools[0].(tool.InvokableTool).InvokableRun(ctx, "", options...)
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}", result)
+	assert.Equal(t, json.RawMessage("{}"), cli.callToolRequest.Params.Arguments)
+
+	result, err = tools[0].(tool.InvokableTool).InvokableRun(ctx, "{\"input\": \"123\"}", options...)
+	assert.NoError(t, err)
+	assert.Equal(t, "{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}", result)
+	assert.Equal(t, json.RawMessage("{\"input\": \"123\"}"), cli.callToolRequest.Params.Arguments)
 
 	tools, err = GetTools(ctx, &Config{
 		Cli:           cli,
@@ -56,7 +63,9 @@ func TestTool(t *testing.T) {
 	assert.Equal(t, map[string]string{"key": "value"}, helper.customHeaders)
 }
 
-type mockMCPClient struct{}
+type mockMCPClient struct {
+	callToolRequest mcp.CallToolRequest
+}
 
 func (m *mockMCPClient) ListResourcesByPage(ctx context.Context, request mcp.ListResourcesRequest) (*mcp.ListResourcesResult, error) {
 	//TODO implement me
@@ -137,6 +146,12 @@ func (m *mockMCPClient) ListTools(ctx context.Context, request mcp.ListToolsRequ
 }
 
 func (m *mockMCPClient) CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	m.callToolRequest = request
+	_, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			mcp.TextContent{


### PR DESCRIPTION
## Summary

- Normalize empty MCP tool-call arguments to `{}` before serialization.
- Preserve non-empty arguments as-is.
- Add regression coverage for empty and non-empty arguments.

## Test plan

- [x] `GOTOOLCHAIN=go1.24.6 go test ./...` in `components/tool/mcp`
- [x] `git diff --check`

Fixes #923