### PR TITLE
fix(a2a): avoid nil task ID in unlock error logs

### DIFF
--- a/a2a/server/server.go
+++ b/a2a/server/server.go
@@ -324,7 +324,7 @@ func (s *A2AServer) sendMessage(ctx context.Context, input *models.MessageSendPa
 		defer func() {
 			unLockErr := s.taskLocker.Unlock(detachedCtx, t.ID)
 			if unLockErr != nil {
-				s.logger(ctx, "failed to release lock for task[%s]: %s", *input.Message.TaskID, unLockErr.Error())
+				s.logger(ctx, "failed to release lock for task[%s]: %s", t.ID, unLockErr.Error())
 			}
 		}()
 		frame, err := s.executeHandler(ctx, detachedCtx, t, input)
@@ -345,7 +345,7 @@ func (s *A2AServer) sendMessage(ctx context.Context, input *models.MessageSendPa
 			}
 			unLockErr := s.taskLocker.Unlock(detachedCtx, t.ID)
 			if unLockErr != nil {
-				s.logger(detachedCtx, "failed to release lock for task[%s]: %s", *input.Message.TaskID, unLockErr.Error())
+				s.logger(detachedCtx, "failed to release lock for task[%s]: %s", t.ID, unLockErr.Error())
 			}
 		}()
 		_, err = s.executeHandler(ctx, detachedCtx, t, input)

--- a/a2a/server/server_test.go
+++ b/a2a/server/server_test.go
@@ -18,12 +18,80 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/eino-ext/a2a/models"
 )
+
+type failingUnlockTaskLocker struct{}
+
+func (failingUnlockTaskLocker) Lock(context.Context, string) error {
+	return nil
+}
+
+func (failingUnlockTaskLocker) Unlock(context.Context, string) error {
+	return errors.New("unlock failed")
+}
+
+type capturedLog struct {
+	format string
+	args   []any
+}
+
+func TestSendMessageUnlockErrorUsesGeneratedTaskID(t *testing.T) {
+	const generatedTaskID = "generated-task-id"
+
+	for _, tc := range []struct {
+		name     string
+		blocking bool
+	}{
+		{name: "blocking", blocking: true},
+		{name: "non-blocking", blocking: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r := &mockHandlerRegistrar{}
+			logs := make(chan capturedLog, 1)
+			require.NoError(t, RegisterHandlers(ctx, r, &Config{
+				MessageHandler: func(context.Context, *InputParams) (*models.TaskContent, error) {
+					return &models.TaskContent{Status: models.TaskStatus{State: models.TaskStateCompleted}}, nil
+				},
+				TaskIDGenerator: func(context.Context) (string, error) {
+					return generatedTaskID, nil
+				},
+				TaskLocker: failingUnlockTaskLocker{},
+				Logger: func(_ context.Context, format string, args ...any) {
+					logs <- capturedLog{format: format, args: args}
+				},
+			}))
+
+			result, err := r.h.SendMessage(ctx, &models.MessageSendParams{
+				Message: models.Message{Role: models.RoleUser},
+				Configuration: &models.MessageSendConfiguration{
+					Blocking: &tc.blocking,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result.Task)
+			assert.Equal(t, generatedTaskID, result.Task.ID)
+
+			select {
+			case entry := <-logs:
+				assert.Equal(t, "failed to release lock for task[%s]: %s", entry.format)
+				require.Len(t, entry.args, 2)
+				assert.Equal(t, generatedTaskID, entry.args[0])
+				assert.Equal(t, "unlock failed", entry.args[1])
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for unlock error log")
+			}
+		})
+	}
+}
 
 func TestMessageHandler(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- use the server-generated `t.ID` in task unlock error logs
- cover both blocking and non-blocking `message/send` paths with a regression test

## Problem

For a new task, `input.Message.TaskID` is nil because the task ID is generated by the server. If `TaskLocker.Unlock` returns an error, the unlock error log dereferences `input.Message.TaskID`, causing a nil pointer panic. In the non-blocking path, that panic escapes the background goroutine and can terminate the process.

The unlock operation already uses `t.ID`, so the error log should use the same generated task ID.

## Test

- `go test -race ./server -run '^TestSendMessageUnlockErrorUsesGeneratedTaskID$' -count=10`
- `go test ./... -count=1`
