### PR TITLE
fix(claude): agenticclaude panic when ToJSONSchema returns nil, nil

### DIFF
--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -525,14 +525,18 @@ func toFunctionTools(functionTools []*schema.ToolInfo) ([]anthropic.ToolUnionPar
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert tool %q parameters to JSON schema: %w", tool.Name, err)
 		}
+		var inputSchema anthropic.ToolInputSchemaParam
+		if s != nil {
+			inputSchema = anthropic.ToolInputSchemaParam{
+				Properties: s.Properties,
+				Required:   s.Required,
+			}
+		}
 		toolParam := &anthropic.ToolParam{
 			Type:        anthropic.ToolTypeCustom,
 			Name:        tool.Name,
 			Description: newClaudeStrOpt(tool.Desc),
-			InputSchema: anthropic.ToolInputSchemaParam{
-				Properties: s.Properties,
-				Required:   s.Required,
-			},
+			InputSchema: inputSchema,
 		}
 		if hasCacheControlOnToolInfo(tool) {
 			toolParam.CacheControl = *getToolInfoCacheControl(tool)

--- a/components/model/agenticclaude/model_test.go
+++ b/components/model/agenticclaude/model_test.go
@@ -834,6 +834,25 @@ func TestSetToolInfoCacheControl(t *testing.T) {
 			t.Fatalf("tool param should not have cache_control, got type=%q", tools[0].OfTool.CacheControl.Type)
 		}
 	})
+
+	t.Run("tool without params one of keeps empty input schema", func(t *testing.T) {
+		tools, err := toFunctionTools([]*schema.ToolInfo{{
+			Name: "fn",
+			Desc: "desc",
+		}})
+		if err != nil {
+			t.Fatalf("toFunctionTools() error = %v", err)
+		}
+		if len(tools) != 1 || tools[0].OfTool == nil {
+			t.Fatalf("toFunctionTools() = %#v", tools)
+		}
+		if tools[0].OfTool.InputSchema.Properties != nil {
+			t.Fatalf("input schema properties = %#v, want nil", tools[0].OfTool.InputSchema.Properties)
+		}
+		if len(tools[0].OfTool.InputSchema.Required) != 0 {
+			t.Fatalf("input schema required = %#v, want empty", tools[0].OfTool.InputSchema.Required)
+		}
+	})
 }
 
 func TestManualCacheControlInConvertors(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
