### PR TITLE
fix: use identity mapper as default for AzureModelMapperFunc

### DIFF
--- a/libs/acl/openai/chat_model.go
+++ b/libs/acl/openai/chat_model.go
@@ -90,7 +90,9 @@ type Config struct {
 
 	// AzureModelMapperFunc is used to map the model name to the deployment name for Azure OpenAI Service.
 	// This is useful when the model name is different from the deployment name.
-	// Optional for Azure, remove [,:] from the model name by default.
+	// Optional for Azure. Defaults to an identity function (no transformation).
+	// The upstream SDK historically stripped [.:] from names; set this field to
+	// restore that behaviour if your deployment names rely on it.
 	AzureModelMapperFunc func(model string) string
 
 	// BaseURL is the Azure OpenAI endpoint URL
@@ -238,6 +240,12 @@ func NewClient(ctx context.Context, config *Config) (*Client, error) {
 		}
 		if config.AzureModelMapperFunc != nil {
 			clientConf.AzureModelMapperFunc = config.AzureModelMapperFunc
+		} else {
+			// Use identity mapper by default: deployment names are user-provided
+			// identifiers that should be passed through unchanged. The upstream
+			// SDK strips dots from model names by default (legacy Azure convention),
+			// which breaks modern Foundry deployments whose names contain dots.
+			clientConf.AzureModelMapperFunc = func(model string) string { return model }
 		}
 	} else {
 		clientConf = openai.DefaultConfig(config.APIKey)


### PR DESCRIPTION
## Description

Use an identity function as the default for `AzureModelMapperFunc` instead of the upstream SDK's dot/colon stripping behavior.

### Problem

With `ByAzure: true` and a deployment name containing a dot (e.g. `gpt-5.6-luna`), the request silently targets a non-existent deployment because the upstream SDK's default mapper strips dots from the name. The 404 error gives no hint that the name was rewritten.

The doc comment says it removes `[,:]` but the SDK implementation removes `[.:]` — either way, silently transforming user-provided deployment names is surprising behavior for modern Azure Foundry deployments.

### Fix

1. Set a default identity mapper (`func(model string) string { return model }`) when `AzureModelMapperFunc` is nil, so deployment names pass through unchanged.
2. Update the doc comment to reflect the actual default and explain the historical context.

Users who rely on the legacy `gpt-3.5-turbo` → `gpt-35-turbo` convention can explicitly set the mapper.

### Changes

- `libs/acl/openai/chat_model.go`: Default to identity mapper + updated doc comment

### Testing

- `go build ./...` pass
- `go vet ./...` pass (pre-existing test compat issue with Go 1.24 `t.Context()` unrelated to this change)

### Related

- Fixes #939
