### PR TITLE
fix(local): populate IsDir, Size and ModifiedAt in LsInfo results

### DIFF
--- a/adk/backend/local/local.go
+++ b/adk/backend/local/local.go
@@ -298,8 +298,15 @@ func (s *Local) LsInfo(ctx context.Context, req *filesystem.LsInfoRequest) ([]fi
 
 	var files []filesystem.FileInfo
 	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get info of %s: %w", entry.Name(), err)
+		}
 		files = append(files, filesystem.FileInfo{
-			Path: entry.Name(),
+			Path:       entry.Name(),
+			IsDir:      entry.IsDir(),
+			Size:       info.Size(),
+			ModifiedAt: info.ModTime().Format(time.RFC3339Nano),
 		})
 	}
 

--- a/adk/backend/local/local_test.go
+++ b/adk/backend/local/local_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +52,7 @@ func TestLsInfo(t *testing.T) {
 		defer os.RemoveAll(dir)
 
 		// Create test files and directories
-		assert.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte(""), 0644))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello"), 0644))
 		assert.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0755))
 
 		req := &filesystem.LsInfoRequest{Path: dir}
@@ -59,7 +60,36 @@ func TestLsInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, files, 2)
 		assert.Equal(t, "file1.txt", files[0].Path)
+		assert.False(t, files[0].IsDir)
+		assert.Equal(t, int64(len("hello")), files[0].Size)
+		_, err = time.Parse(time.RFC3339Nano, files[0].ModifiedAt)
+		assert.NoError(t, err)
 		assert.Equal(t, "subdir", files[1].Path)
+		assert.True(t, files[1].IsDir)
+		_, err = time.Parse(time.RFC3339Nano, files[1].ModifiedAt)
+		assert.NoError(t, err)
+	})
+
+	t.Run("symlink entries report the link itself", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("creating symlinks on windows requires privileges")
+		}
+
+		dir := setupTestDir(t)
+		defer os.RemoveAll(dir)
+
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "target.txt"), []byte("hello"), 0644))
+		assert.NoError(t, os.Symlink("target.txt", filepath.Join(dir, "link.txt")))
+
+		req := &filesystem.LsInfoRequest{Path: dir}
+		files, err := s.LsInfo(ctx, req)
+		assert.NoError(t, err)
+		assert.Len(t, files, 2)
+		assert.Equal(t, "link.txt", files[0].Path)
+		assert.False(t, files[0].IsDir)
+		assert.Equal(t, int64(len("target.txt")), files[0].Size)
+		assert.Equal(t, "target.txt", files[1].Path)
+		assert.False(t, files[1].IsDir)
 	})
 
 	t.Run("list non-existent directory", func(t *testing.T) {


### PR DESCRIPTION
## What is the purpose of the change

Fixes cloudwego/eino#1100.

`Local.LsInfo` filled only `FileInfo.Path`, so models using the ls tool could not tell files from directories and kept descending into files, and had no size information to avoid reading large/binary files. The in-memory backend already returns `IsDir`/`Size`/`ModifiedAt`; the local backend now fills the same fields.

## Brief changelog

- `adk/backend/local`: use `os.DirEntry.Info()` to fill `IsDir`, `Size` and `ModifiedAt` (RFC3339Nano, same format as the in-memory backend) per entry.
- `local_test.go`: extend `TestLsInfo` with field assertions and a symlink subtest; symlink entries report the link itself (lstat semantics, consistent with `os.ReadDir`), skipped on Windows.

Notes for reviewers:
- The new `entry.Info()` error path returns an error, matching the existing behavior of `Read` when `file.Stat()` fails.
- The agentkit backend already returns `is_dir`; adding `size`/`mtime` there could be a follow-up.

## Verifying this change

- The new assertions fail on the previous code (`Size` 0 vs expected 5, `IsDir` false for a directory) and pass after the change.
- `go test ./...` in `adk/backend/local`: all 25 tests PASS.
- `go vet ./...` and `gofmt -l`: clean.