### PR TITLE
fix(devops): enforce graph count limit

### DIFF
--- a/devops/internal/service/container.go
+++ b/devops/internal/service/container.go
@@ -65,7 +65,7 @@ func (s *containerServiceImpl) AddGraphInfo(rootGN string, rootGI *compose.Graph
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.totalGraphNum > maxGraphNum {
+	if s.totalGraphNum >= maxGraphNum {
 		return "", fmt.Errorf("too many graph, max=%d", maxGraphNum)
 	}
 

--- a/devops/internal/service/container_test.go
+++ b/devops/internal/service/container_test.go
@@ -67,6 +67,26 @@ func Test_containerServiceImpl_AddGraphInfo(t *testing.T) {
 		assert.Equal(t, s.graphNameCounter[mockGraphName], 10)
 	})
 
+	t.Run("reject graph beyond limit", func(t *testing.T) {
+		mockGraphName := "mock_graph"
+		s := &containerServiceImpl{
+			container:        map[string]*model.GraphContainer{},
+			graphNameCounter: map[string]int{},
+		}
+
+		for i := 0; i < maxGraphNum; i++ {
+			_, err := s.AddGraphInfo(mockGraphName, &compose.GraphInfo{})
+			if !assert.NoError(t, err) {
+				return
+			}
+		}
+
+		_, err := s.AddGraphInfo(mockGraphName, &compose.GraphInfo{})
+		assert.EqualError(t, err, fmt.Sprintf("too many graph, max=%d", maxGraphNum))
+		assert.Equal(t, maxGraphNum, s.totalGraphNum)
+		assert.Len(t, s.container, maxGraphNum)
+	})
+
 	t.Run("add graph info with subGraph, once", func(t *testing.T) {
 		mockGraphName := "mock_graph"
 		s := &containerServiceImpl{


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear.
- [x] No user documentation update is required; this restores the existing advertised limit.

#### (Optional) Translate the PR title into Chinese.

`fix(devops): 强制执行图数量上限`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`AddGraphInfo` checked the pre-increment root graph counter with `>`, so it accepted 101 graphs when `maxGraphNum` is 100 and rejected only the 102nd call. This changes the boundary check to `>=` and adds a regression test verifying that the 101st graph is rejected without mutating the counter or container.

Validation:

- `go test -gcflags='all=-N -l' ./internal/service -run '^Test_containerServiceImpl_AddGraphInfo$' -count=1` (Windows, Go 1.26.3)
- `go test -race -gcflags='all=-N -l' ./internal/service -run '^Test_containerServiceImpl_AddGraphInfo$' -count=1` (Linux, Go 1.25.6)
- `go vet ./internal/service`
- `git diff --check`

#### (Optional) Which issue(s) this PR fixes:

Fixes #960

#### (optional) The PR that updates user documentation:

Not required.