### PR TITLE
fix(devops): synchronize canvas cache updates

### DIFF
--- a/devops/internal/service/container.go
+++ b/devops/internal/service/container.go
@@ -220,7 +220,9 @@ func (s *containerServiceImpl) CreateCanvas(graphID string) (canvasInfo devmodel
 		Version:     devmodel.Version,
 		GraphSchema: graphSchema,
 	}
+	s.mu.Lock()
 	c.CanvasInfo = &canvasInfo
+	s.mu.Unlock()
 
 	return canvasInfo, nil
 }

--- a/devops/internal/service/container_test.go
+++ b/devops/internal/service/container_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -248,6 +249,52 @@ func Test_containerServiceImpl_CreateCanvas(t *testing.T) {
 		c, ok := s.GetCanvas(id)
 		assert.True(t, ok)
 		assert.Equal(t, "graph", c.Name)
+	})
+
+	t.Run("create and get canvas concurrently", func(t *testing.T) {
+		s := newContainerService()
+		g := &compose.GraphInfo{
+			Name:       "graph",
+			InputType:  reflect.TypeOf(map[string]any{}),
+			OutputType: reflect.TypeOf(map[string]any{}),
+		}
+		id, err := s.AddGraphInfo("graph", g)
+		if !assert.NoError(t, err) {
+			return
+		}
+		_, err = s.CreateCanvas(id)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		errCh := make(chan error, 1600)
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					_, err := s.CreateCanvas(id)
+					if err != nil {
+						errCh <- err
+					}
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					_, ok := s.GetCanvas(id)
+					if !ok {
+						errCh <- fmt.Errorf("canvas not found")
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(t, err)
+		}
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear.
- [x] No user documentation update is required; this only synchronizes internal cache access.

#### (Optional) Translate the PR title into Chinese.

`fix(devops): 同步 canvas 缓存更新`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`CreateCanvas` assigned `GraphContainer.CanvasInfo` after releasing the container service mutex, while `GetCanvas` read the pointer under the corresponding read lock. Concurrent canvas creation and lookup therefore produced read/write and write/write race reports.

This change protects the cache assignment with the service mutex and adds a concurrent regression test. The test reproduces the race before this change and passes under the race detector afterward.

Validation:

- `go test -gcflags='all=-N -l' ./internal/service -run '^Test_containerServiceImpl_CreateCanvas$' -count=10` (Windows, Go 1.26.3)
- `go test -race -gcflags='all=-N -l' ./internal/service -run '^Test_containerServiceImpl_CreateCanvas$' -count=10` (Linux, Go 1.25.6)
- `go vet ./internal/service`
- `git diff --check`

#### (Optional) Which issue(s) this PR fixes:

Fixes #961

#### (optional) The PR that updates user documentation:

Not required.