### PR TITLE
docs: fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For more details about component implementations, please refer to the [Eino ecos
 
 If you discover a potential security issue in this project, or think you may
 have discovered a security issue, we ask that you notify Bytedance Security via
-our [security center](https://security.bytedance.com/src) or [vulnerability reporting email](sec@bytedance.com).
+our [security center](https://security.bytedance.com/src) or [vulnerability reporting email](mailto:sec@bytedance.com).
 
 Please do **not** create a public GitHub issue.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -30,7 +30,7 @@ EinoExt 项目为 [Eino](https://github.com/cloudwego/eino) 框架提供了各�
 
 ## 安全
 
-如果你在该项目中发现潜在的安全问题，或你认为可能发现了安全问题，请通过我们的[安全中心](https://security.bytedance.com/src)或[漏洞报告邮箱](sec@bytedance.com)通知字节跳动安全团队。
+如果你在该项目中发现潜在的安全问题，或你认为可能发现了安全问题，请通过我们的[安全中心](https://security.bytedance.com/src)或[漏洞报告邮箱](mailto:sec@bytedance.com)通知字节跳动安全团队。
 
 请**不要**创建公开的 GitHub Issue。
 

--- a/adk/backend/agentkit/README.md
+++ b/adk/backend/agentkit/README.md
@@ -201,4 +201,4 @@ A: Default is 30 minutes (1800 seconds). Configure with `SessionTTL` (range: 60-
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See the [LICENSE](../../LICENSE) file for details.
+Licensed under the Apache License, Version 2.0. See the [LICENSE](../../../LICENSE) file for details.

--- a/adk/backend/agentkit/README_zh.md
+++ b/adk/backend/agentkit/README_zh.md
@@ -189,4 +189,4 @@ export VOLC_TOOL_ID="your_tool_id"
 
 ## 许可证
 
-根据 Apache License 2.0 许可。有关详细信息，请参阅 [LICENSE](../../LICENSE) 文件。
+根据 Apache License 2.0 许可。有关详细信息，请参阅 [LICENSE](../../../LICENSE) 文件。

--- a/adk/backend/local/README.md
+++ b/adk/backend/local/README.md
@@ -181,4 +181,4 @@ A: Yes, but ensure proper input validation, command validation, and appropriate 
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See the [LICENSE](../../LICENSE) file for details.
+Licensed under the Apache License, Version 2.0. See the [LICENSE](../../../LICENSE) file for details.

--- a/adk/backend/local/README_zh.md
+++ b/adk/backend/local/README_zh.md
@@ -177,4 +177,4 @@ backend, _ := local.NewBackend(ctx, &local.Config{
 
 ## 许可证
 
-根据 Apache License 2.0 许可。有关详细信息，请参阅 [LICENSE](../../LICENSE) 文件。
+根据 Apache License 2.0 许可。有关详细信息，请参阅 [LICENSE](../../../LICENSE) 文件。

--- a/components/model/openai/README.md
+++ b/components/model/openai/README.md
@@ -204,7 +204,6 @@ See the following examples for more usage:
 - [Intent & Tool Calling](./examples/intent_tool/)
 - [Streaming Response](./examples/stream/)
 - [Structured Output](./examples/structured/)
-- [Timeout Handling](./examples/timeout/)
 
 
 

--- a/components/model/openai/README_zh.md
+++ b/components/model/openai/README_zh.md
@@ -204,7 +204,6 @@ Audio *Audio `json:"audio,omitempty"`
 - [意图识别与工具调用](./examples/intent_tool/)
 - [流式响应](./examples/stream/)
 - [结构化输出](./examples/structured/)
-- [超时处理](./examples/timeout/)
 
 
 

--- a/components/retriever/opensearch2/README.md
+++ b/components/retriever/opensearch2/README.md
@@ -138,7 +138,6 @@ type RetrieverConfig struct {
 
 - [Approximate Search Example](./examples/approximate)
 - [Dense Vector Similarity Example](./examples/dense_vector_similarity)
-- [KNN Search Example](./examples/knn)
 - [Neural Sparse Search Example](./examples/neural_sparse)
 
 ## For More Details

--- a/components/retriever/opensearch2/README_zh.md
+++ b/components/retriever/opensearch2/README_zh.md
@@ -138,7 +138,6 @@ type RetrieverConfig struct {
 
 - [近似搜索示例](./examples/approximate)
 - [稠密向量相似度示例](./examples/dense_vector_similarity)
-- [KNN 搜索示例](./examples/knn)
 - [Neural Sparse 搜索示例](./examples/neural_sparse)
 
 ## 更多详情

--- a/devops/README.md
+++ b/devops/README.md
@@ -10,7 +10,7 @@ EinoExt/Devops project provides visual debugging capabilities for [Eino](https:/
 
 If you discover a potential security issue in this project, or think you may
 have discovered a security issue, we ask that you notify Bytedance Security via
-our [security center](https://security.bytedance.com/src) or [vulnerability reporting email](sec@bytedance.com).
+our [security center](https://security.bytedance.com/src) or [vulnerability reporting email](mailto:sec@bytedance.com).
 
 Please do **not** create a public GitHub issue.
 

--- a/devops/README.zh_CN.md
+++ b/devops/README.zh_CN.md
@@ -7,7 +7,7 @@ EinoExt/Devops 项目为 [Eino](https://github.com/cloudwego/eino) 提供可视�
 
 ## 安全
 
-如果你在该项目中发现潜在的安全问题，或你认为可能发现了安全问题，请通过我们的[安全中心](https://security.bytedance.com/src)或[漏洞报告邮箱](sec@bytedance.com)通知字节跳动安全团队。
+如果你在该项目中发现潜在的安全问题，或你认为可能发现了安全问题，请通过我们的[安全中心](https://security.bytedance.com/src)或[漏洞报告邮箱](mailto:sec@bytedance.com)通知字节跳动安全团队。
 
 请**不要**创建公开的 GitHub Issue。
 

--- a/libs/acl/langfuse/README.md
+++ b/libs/acl/langfuse/README.md
@@ -6,7 +6,7 @@ English | [简体中文](README_zh.md)
 
 This is a low-level Langfuse API client library for Go. It provides direct access to the Langfuse API for creating traces, spans, generations, and events. This library is used internally by the higher-level `callbacks/langfuse` package.
 
-**Note**: For most use cases with Eino, you should use the [callbacks/langfuse](../../callbacks/langfuse) package instead, which provides a simpler interface integrated with Eino's callback system.
+**Note**: For most use cases with Eino, you should use the [callbacks/langfuse](../../../callbacks/langfuse) package instead, which provides a simpler interface integrated with Eino's callback system.
 
 ## Features
 
@@ -245,7 +245,7 @@ This library is typically used:
 2. **Direct Integration**: When you need fine-grained control over Langfuse API calls
 3. **Custom Solutions**: When building custom observability solutions
 
-For most Eino integrations, use [callbacks/langfuse](../../callbacks/langfuse) instead.
+For most Eino integrations, use [callbacks/langfuse](../../../callbacks/langfuse) instead.
 
 ## License
 

--- a/libs/acl/langfuse/README_zh.md
+++ b/libs/acl/langfuse/README_zh.md
@@ -6,7 +6,7 @@
 
 这是一个用于 Go 的低级 Langfuse API 客户端库。它提供对 Langfuse API 的直接访问，用于创建跟踪、跨度、生成和事件。此库由更高级别的 `callbacks/langfuse` 包内部使用。
 
-**注意**：对于大多数 Eino 用例，您应该使用 [callbacks/langfuse](../../callbacks/langfuse) 包，它提供了与 Eino 回调系统集成的更简单接口。
+**注意**：对于大多数 Eino 用例，您应该使用 [callbacks/langfuse](../../../callbacks/langfuse) 包，它提供了与 Eino 回调系统集成的更简单接口。
 
 ## 特性
 
@@ -245,7 +245,7 @@ client.Flush()
 2. **直接集成**：当您需要对 Langfuse API 调用进行细粒度控制时
 3. **自定义解决方案**：构建自定义可观测性解决方案时
 
-对于大多数 Eino 集成，请改用 [callbacks/langfuse](../../callbacks/langfuse)。
+对于大多数 Eino 集成，请改用 [callbacks/langfuse](../../../callbacks/langfuse)。
 
 ## 许可证
 

--- a/libs/acl/openai/README.md
+++ b/libs/acl/openai/README.md
@@ -278,8 +278,8 @@ This library is typically used:
 3. **Custom Solutions**: When building custom LLM integrations
 
 For most Eino integrations, use the higher-level component packages instead:
-- [components/model/openai](../../components/model/openai) for chat models
-- [components/embedding/openai](../../components/embedding/openai) for embeddings
+- [components/model/openai](../../../components/model/openai) for chat models
+- [components/embedding/openai](../../../components/embedding/openai) for embeddings
 
 ## License
 

--- a/libs/acl/openai/README_zh.md
+++ b/libs/acl/openai/README_zh.md
@@ -278,8 +278,8 @@ openai.WithStreamOptions(&openai.StreamOptions{
 3. **自定义解决方案**：构建自定义 LLM 集成时
 
 对于大多数 Eino 集成，请改用更高级别的组件包：
-- [components/model/openai](../../components/model/openai) 用于聊天模型
-- [components/embedding/openai](../../components/embedding/openai) 用于嵌入
+- [components/model/openai](../../../components/model/openai) 用于聊天模型
+- [components/embedding/openai](../../../components/embedding/openai) 用于嵌入
 
 ## 许可证
 


### PR DESCRIPTION
#### What type of PR is this?

docs

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear.
- [x] This PR is itself the required documentation update.

#### (Optional) Translate the PR title into Chinese.

`docs: 修复 README 中的失效链接`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

A full tracked-Markdown link check found 20 broken prose-link occurrences across 16 English and Chinese README files. This change:

- adds `mailto:` to four security email links
- corrects four ADK root-license links
- removes stale links to two example directories that do not exist
- corrects eight ACL links that were one directory level short

The English and Chinese README copies are updated together. The copied Markdown fixture under recursive splitter testdata is intentionally unchanged.

Validation:

- decoded all 245 tracked Markdown files as UTF-8 (0 decoding failures)
- checked 542 remaining local prose links
- 0 maintained-document failures; the only two remaining failures are inside the intentionally copied test fixture
- `git diff --check`

#### (Optional) Which issue(s) this PR fixes:

Fixes #964

#### (optional) The PR that updates user documentation:

This PR.