### PR TITLE
docs: correct contribution repository details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We use [git-flow](https://nvie.com/posts/a-successful-git-branching-model/) as o
 
 ## Bugs
 ### 1. How to Find Known Issues
-We are using [Github Issues](https://github.com/cloudwego/{project_name}/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
+We are using [Github Issues](https://github.com/cloudwego/eino-ext/issues) for our public bugs. We keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
 
 ### 2. Reporting New Issues
 Providing a reduced test code is a recommended way for reporting issues. Then can place in:
@@ -23,12 +23,12 @@ Please do not report the safe disclosure of bugs to public issues. Contact us by
 
 ## Submit a Pull Request
 Before you submit your Pull Request (PR) consider the following guidelines:
-1. Search [GitHub](https://github.com/cloudwego/{project_name}/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
+1. Search [GitHub](https://github.com/cloudwego/eino-ext/pulls) for an open or closed PR that relates to your submission. You don't want to duplicate existing efforts.
 2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add. Discussing the design upfront helps to ensure that we're ready to accept your work.
-3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the cloudwego {project_name} repo.
+3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the cloudwego/eino-ext repo.
 4. In your forked repository, make your changes in a new git branch:
     ```
-    git checkout -b my-fix-branch develop
+    git checkout -b my-fix-branch main
     ```
 5. Create your patch, including appropriate test cases.
 6. Follow our [Style Guides](#code-style-guides).
@@ -38,7 +38,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     ```
     git push origin my-fix-branch
     ```
-9. In GitHub, send a pull request to `{project_name}:develop`
+9. In GitHub, send a pull request to `cloudwego/eino-ext:main`
 
 ## Contribution Prerequisites
 - Our development environment keeps up with [Go Official](https://golang.org/project/).


### PR DESCRIPTION
#### What type of PR is this?

docs

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear.
- [x] This PR is itself the required documentation update.

#### (Optional) Translate the PR title into Chinese.

`docs: 更正贡献指南中的仓库信息`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

The contribution guide retained `{project_name}` placeholders in its issue, pull-request, fork, and target instructions. It also told contributors to branch from and target `develop`, but this repository uses `main` as its default branch and has no upstream `develop` branch.

This change replaces the placeholders with `cloudwego/eino-ext` and updates the branch instructions to `main`.

Validation:

- confirmed the repository default branch is `main`
- confirmed no upstream `develop` branch exists
- repository-wide Markdown scan reports 0 remaining placeholder links in this branch
- `git diff --check`

#### (Optional) Which issue(s) this PR fixes:

Fixes #966

#### (optional) The PR that updates user documentation:

This PR.