### PR TITLE
fix(agenticclaude): preserve complete tool JSON schemas

### DIFF
--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/schema"
 	"github.com/cloudwego/eino/schema/claude"
 	"github.com/eino-contrib/jsonschema"
@@ -549,12 +550,12 @@ func toToolInputSchema(s *jsonschema.Schema) (anthropic.ToolInputSchemaParam, er
 		return anthropic.ToolInputSchemaParam{}, nil
 	}
 
-	raw, err := json.Marshal(s)
+	raw, err := sonic.Marshal(s)
 	if err != nil {
 		return anthropic.ToolInputSchemaParam{}, fmt.Errorf("marshal full JSON schema: %w", err)
 	}
 	extraFields := make(map[string]any)
-	if err := json.Unmarshal(raw, &extraFields); err != nil {
+	if err := sonic.Unmarshal(raw, &extraFields); err != nil {
 		return anthropic.ToolInputSchemaParam{}, fmt.Errorf("decode full JSON schema: %w", err)
 	}
 	delete(extraFields, "type")

--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/cloudwego/eino/schema"
 	"github.com/cloudwego/eino/schema/claude"
+	"github.com/eino-contrib/jsonschema"
 )
 
 func toAnthropicMessages(input []*schema.AgenticMessage) (sysInstruction []anthropic.TextBlockParam, msgParams []anthropic.MessageParam, err error) {
@@ -525,12 +526,9 @@ func toFunctionTools(functionTools []*schema.ToolInfo) ([]anthropic.ToolUnionPar
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert tool %q parameters to JSON schema: %w", tool.Name, err)
 		}
-		var inputSchema anthropic.ToolInputSchemaParam
-		if s != nil {
-			inputSchema = anthropic.ToolInputSchemaParam{
-				Properties: s.Properties,
-				Required:   s.Required,
-			}
+		inputSchema, err := toToolInputSchema(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to preserve tool %q full JSON schema: %w", tool.Name, err)
 		}
 		toolParam := &anthropic.ToolParam{
 			Type:        anthropic.ToolTypeCustom,
@@ -544,6 +542,33 @@ func toFunctionTools(functionTools []*schema.ToolInfo) ([]anthropic.ToolUnionPar
 		tools = append(tools, anthropic.ToolUnionParam{OfTool: toolParam})
 	}
 	return tools, nil
+}
+
+func toToolInputSchema(s *jsonschema.Schema) (anthropic.ToolInputSchemaParam, error) {
+	if s == nil {
+		return anthropic.ToolInputSchemaParam{}, nil
+	}
+
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return anthropic.ToolInputSchemaParam{}, fmt.Errorf("marshal full JSON schema: %w", err)
+	}
+	extraFields := make(map[string]any)
+	if err := json.Unmarshal(raw, &extraFields); err != nil {
+		return anthropic.ToolInputSchemaParam{}, fmt.Errorf("decode full JSON schema: %w", err)
+	}
+	delete(extraFields, "type")
+	delete(extraFields, "properties")
+	delete(extraFields, "required")
+	if len(extraFields) == 0 {
+		extraFields = nil
+	}
+
+	return anthropic.ToolInputSchemaParam{
+		Properties:  s.Properties,
+		Required:    s.Required,
+		ExtraFields: extraFields,
+	}, nil
 }
 
 func toDeferredFunctionTools(functionTools []*schema.ToolInfo) ([]anthropic.ToolUnionParam, error) {

--- a/components/model/agenticclaude/convertor_test.go
+++ b/components/model/agenticclaude/convertor_test.go
@@ -24,7 +24,58 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/cloudwego/eino/schema"
 	claudeschema "github.com/cloudwego/eino/schema/claude"
+	"github.com/eino-contrib/jsonschema"
 )
+
+func TestToFunctionToolsPreservesFullJSONSchema(t *testing.T) {
+	properties := jsonschema.NewProperties()
+	properties.Set("action", &jsonschema.Schema{Type: "string"})
+
+	tools, err := toFunctionTools([]*schema.ToolInfo{{
+		Name: "manage_resource",
+		ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&jsonschema.Schema{
+			Type:                 "object",
+			Properties:           properties,
+			Required:             []string{"action"},
+			AdditionalProperties: jsonschema.FalseSchema,
+			OneOf: []*jsonschema.Schema{{
+				Type:     "object",
+				Required: []string{"action", "name"},
+			}},
+		}),
+	}})
+	if err != nil {
+		t.Fatalf("toFunctionTools() error = %v", err)
+	}
+
+	raw, err := json.Marshal(tools[0].OfTool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal input schema: %v", err)
+	}
+	var inputSchema map[string]any
+	if err := json.Unmarshal(raw, &inputSchema); err != nil {
+		t.Fatalf("unmarshal input schema: %v", err)
+	}
+	if _, ok := inputSchema["oneOf"]; !ok {
+		t.Fatalf("input schema = %s, want oneOf", raw)
+	}
+	if additionalProperties, ok := inputSchema["additionalProperties"].(bool); !ok || additionalProperties {
+		t.Fatalf("input schema = %s, want additionalProperties=false", raw)
+	}
+}
+
+func TestToFunctionToolsRejectsUnserializableFullJSONSchema(t *testing.T) {
+	_, err := toFunctionTools([]*schema.ToolInfo{{
+		Name: "invalid_schema",
+		ParamsOneOf: schema.NewParamsOneOfByJSONSchema(&jsonschema.Schema{
+			Type:   "object",
+			Extras: map[string]any{"x-invalid": make(chan struct{})},
+		}),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "marshal full JSON schema") {
+		t.Fatalf("toFunctionTools() error = %v, want full schema marshal error", err)
+	}
+}
 
 func TestToolSearchResultToBlockParam(t *testing.T) {
 	blockParam, err := toolSearchResultToBlockParam(&schema.ToolSearchFunctionToolResult{


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: <type>(optional scope): <description>
- [x] The description is user-oriented and clear enough for others to understand.
- [x] User documentation is not required because this restores the documented JSON Schema behavior without changing the public API.

#### (Optional) Translate the PR title into Chinese.

fix(agenticclaude): 保留工具的完整 JSON Schema

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

AgenticClaude currently copies only properties and required from schema.ToolInfo into the Anthropic tool input schema. Keywords such as oneOf, anyOf, additionalProperties, const, and definitions are silently dropped from the wire request, which changes validation semantics for discriminated tool inputs.

This change serializes the complete Eino JSON Schema and forwards keywords not modeled by anthropic.ToolInputSchemaParam through its ExtraFields support. It keeps the existing nil-schema behavior and returns a contextual error when a schema cannot be serialized.

Regression tests verify both the final SDK JSON representation and the serialization error path.

Validation:

- go test ./... -count=1

zh(optional):

AgenticClaude 之前只复制 properties 和 required，导致 oneOf、additionalProperties、const 等 JSON Schema 关键字在 Claude 请求中丢失。本变更通过 SDK 的 ExtraFields 保留完整 schema，并补充最终 JSON wire 与异常路径回归测试。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A