### PR TITLE
fix(acl/openai): assign new block index for text interleaved between tool calls

### DIFF
--- a/libs/acl/openai/agentic_convert.go
+++ b/libs/acl/openai/agentic_convert.go
@@ -107,6 +107,18 @@ func (c *chunkConverter) advanceContent(blockType schema.ContentBlockType, sourc
 		c.lastContentPartIndex = sourceIndex
 		return
 	}
+	if c.inToolCalls {
+		// A content part arriving after tool calls started (e.g. providers that
+		// interleave text chunks between parallel tool-call chunks) begins a new
+		// block. Reusing the previous content index would group it with the
+		// tool-call block and break ConcatAgenticMessages with a block type
+		// mismatch.
+		c.curIndex++
+		c.inToolCalls = false
+		c.lastContentType = blockType
+		c.lastContentPartIndex = sourceIndex
+		return
+	}
 	if blockType != c.lastContentType || sourceIndex != c.lastContentPartIndex {
 		c.curIndex++
 		c.lastContentType = blockType

--- a/libs/acl/openai/agentic_convert_test.go
+++ b/libs/acl/openai/agentic_convert_test.go
@@ -583,6 +583,74 @@ func TestChunkConverter(t *testing.T) {
 		assert.Equal(t, 2, out4.ContentBlocks[0].StreamingMeta.Index)
 	})
 
+	t.Run("text interleaved between tool calls", func(t *testing.T) {
+		conv := newChunkConverter()
+
+		// Chunk 1: text
+		chunk1 := &schema.Message{
+			Role:    schema.Assistant,
+			Content: "\n\n",
+		}
+		out1, err := conv.convert(chunk1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, out1.ContentBlocks[0].StreamingMeta.Index)
+
+		// Chunk 2: tool call 0 starts (new block)
+		chunk2 := &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{
+				{Index: intPtr(0), ID: "call_1", Function: schema.FunctionCall{Name: "exec", Arguments: `{"command"`}},
+			},
+		}
+		out2, err := conv.convert(chunk2)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, out2.ContentBlocks[0].StreamingMeta.Index)
+
+		// Chunk 3: tool call 0 continues (same block)
+		chunk3 := &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{
+				{Index: intPtr(0), Function: schema.FunctionCall{Arguments: `: "whoami"}`}},
+			},
+		}
+		out3, err := conv.convert(chunk3)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, out3.ContentBlocks[0].StreamingMeta.Index)
+
+		// Chunk 4: text interleaved between tool calls. Some providers emit
+		// whitespace content chunks between parallel tool calls; this must start
+		// a new block instead of reusing the text block's index, otherwise
+		// ConcatAgenticMessages groups it with the tool-call block and fails
+		// with a block type mismatch.
+		chunk4 := &schema.Message{
+			Role:    schema.Assistant,
+			Content: "\n",
+		}
+		out4, err := conv.convert(chunk4)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, out4.ContentBlocks[0].StreamingMeta.Index)
+
+		// Chunk 5: tool call 1 starts (new block)
+		chunk5 := &schema.Message{
+			Role: schema.Assistant,
+			ToolCalls: []schema.ToolCall{
+				{Index: intPtr(1), ID: "call_2", Function: schema.FunctionCall{Name: "exec", Arguments: `{"command": "id"}`}},
+			},
+		}
+		out5, err := conv.convert(chunk5)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, out5.ContentBlocks[0].StreamingMeta.Index)
+
+		// The full frame sequence must concatenate without a block type mismatch.
+		frames := make([]*schema.AgenticMessage, 0, 5)
+		for _, out := range []*schema.AgenticMessage{out1, out2, out3, out4, out5} {
+			frames = append(frames, out)
+		}
+		msg, err := schema.ConcatAgenticMessages(frames)
+		assert.NoError(t, err)
+		assert.NotNil(t, msg)
+	})
+
 	t.Run("multiContent with source index changes", func(t *testing.T) {
 		conv := newChunkConverter()
 


### PR DESCRIPTION
Fixes #975

## Problem

Some providers (observed on Cloudflare Workers AI gateways) emit content chunks **between parallel tool-call chunks** in one stream:

```
data: {"choices":[{"delta":{"tool_calls":[{"id":"call_a","index":0,"type":"function",...}]}}]}
data: {"choices":[{"delta":{"content":"\n"}}]}            <-- interleaved text
data: {"choices":[{"delta":{"tool_calls":[{"id":"call_b","index":1,"type":"function",...}]}}]}
```

`chunkConverter.advanceContent` only compares block type and source index, ignoring `c.inToolCalls`. Once tool calls have started, an interleaved text chunk still matches the previous text block's type, so it inherits the tool-call group's `StreamingMeta.Index`. `schema.ConcatAgenticMessages` then groups mismatched block types under one index and fails with:

```
content block type mismatch: expected 'function_tool_call', but got 'assistant_gen_text'
```

## Fix

When `inToolCalls` is set, `advanceContent` now always advances to a new block index and resets `inToolCalls`, so:

- the interleaved text gets its own index (no collision with the tool-call group)
- a following tool call also gets a fresh index

Change is confined to `(*chunkConverter).advanceContent`; streams without interleaved text are unaffected.

## Test

Added `TestChunkConverter/text_interleaved_between_tool_calls` covering the exact frame sequence (text → tool call 0 → interleaved text → tool call 1), asserting each block gets a distinct index and the full sequence passes `ConcatAgenticMessages`.

```
go test -gcflags="all=-N -l" ./libs/acl/openai/...   # ok
```
