### PR TITLE
feat(agenticclaude): expose cache_creation_input_tokens in message.Extra

### DIFF
--- a/components/model/agenticclaude/consts.go
+++ b/components/model/agenticclaude/consts.go
@@ -88,8 +88,4 @@ const (
 
 const implType = "AgenticClaude"
 
-// KeyOfCacheCreationInputTokens is the Extra map key for Anthropic
-// cache_creation_input_tokens. It uses the same key as the legacy claude
-// adapter so downstream consumers (e.g. Langfuse cost tracking) do not need
-// to distinguish between the two adapters.
-const KeyOfCacheCreationInputTokens = "_eino_claude_cache_creation_input_tokens"
+const keyOfCacheCreationInputTokens = "_eino_claude_cache_creation_input_tokens"

--- a/components/model/agenticclaude/consts.go
+++ b/components/model/agenticclaude/consts.go
@@ -87,3 +87,9 @@ const (
 )
 
 const implType = "AgenticClaude"
+
+// KeyOfCacheCreationInputTokens is the Extra map key for Anthropic
+// cache_creation_input_tokens. It uses the same key as the legacy claude
+// adapter so downstream consumers (e.g. Langfuse cost tracking) do not need
+// to distinguish between the two adapters.
+const KeyOfCacheCreationInputTokens = "_eino_claude_cache_creation_input_tokens"

--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -600,11 +600,17 @@ func toAgenticMessage(resp *anthropic.Message) (*schema.AgenticMessage, error) {
 		blocks = append(blocks, contentBlock)
 	}
 
-	return &schema.AgenticMessage{
+	msg := &schema.AgenticMessage{
 		Role:          schema.AgenticRoleTypeAssistant,
 		ContentBlocks: blocks,
 		ResponseMeta:  toAgenticResponseMeta(resp),
-	}, nil
+	}
+	if resp.Usage.CacheCreationInputTokens > 0 {
+		msg.Extra = map[string]any{
+			KeyOfCacheCreationInputTokens: int(resp.Usage.CacheCreationInputTokens),
+		}
+	}
+	return msg, nil
 }
 
 func toAgenticContentBlock(block any) (*schema.ContentBlock, error) {

--- a/components/model/agenticclaude/convertor.go
+++ b/components/model/agenticclaude/convertor.go
@@ -607,7 +607,7 @@ func toAgenticMessage(resp *anthropic.Message) (*schema.AgenticMessage, error) {
 	}
 	if resp.Usage.CacheCreationInputTokens > 0 {
 		msg.Extra = map[string]any{
-			KeyOfCacheCreationInputTokens: int(resp.Usage.CacheCreationInputTokens),
+			keyOfCacheCreationInputTokens: int(resp.Usage.CacheCreationInputTokens),
 		}
 	}
 	return msg, nil

--- a/components/model/agenticclaude/event_convertor.go
+++ b/components/model/agenticclaude/event_convertor.go
@@ -48,7 +48,7 @@ func (c *streamConverter) toMessageStreamingChunk(event anthropic.MessageStreamE
 		}
 		if e.Usage.CacheCreationInputTokens > 0 {
 			msg.Extra = map[string]any{
-				KeyOfCacheCreationInputTokens: int(e.Usage.CacheCreationInputTokens),
+				keyOfCacheCreationInputTokens: int(e.Usage.CacheCreationInputTokens),
 			}
 		}
 		return msg, nil

--- a/components/model/agenticclaude/event_convertor.go
+++ b/components/model/agenticclaude/event_convertor.go
@@ -42,10 +42,16 @@ func (c *streamConverter) toMessageStreamingChunk(event anthropic.MessageStreamE
 	case anthropic.MessageStartEvent:
 		return toAgenticMessage(&e.Message)
 	case anthropic.MessageDeltaEvent:
-		return &schema.AgenticMessage{
+		msg := &schema.AgenticMessage{
 			Role:         schema.AgenticRoleTypeAssistant,
 			ResponseMeta: toDeltaResponseMeta(e),
-		}, nil
+		}
+		if e.Usage.CacheCreationInputTokens > 0 {
+			msg.Extra = map[string]any{
+				KeyOfCacheCreationInputTokens: int(e.Usage.CacheCreationInputTokens),
+			}
+		}
+		return msg, nil
 	case anthropic.ContentBlockStartEvent:
 		contentBlock, err := c.toStreamingStartBlock(e.Index, e.ContentBlock.AsAny())
 		if err != nil {

--- a/components/model/agenticclaude/go.sum
+++ b/components/model/agenticclaude/go.sum
@@ -7,8 +7,6 @@ cloud.google.com/go/compute/metadata v0.5.0 h1:Zr0eK8JbFv6+Wi4ilXAR8FJ3wyNdpxHKJ
 cloud.google.com/go/compute/metadata v0.5.0/go.mod h1:aHnloV2TPI38yx4s9+wAZhHykWvVCfu7hQbF+9CWoiY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
-github.com/anthropics/anthropic-sdk-go v1.42.0 h1:Zv882/dnrE4OHnwhMAsi9lwVVXRF8GtR3ofiBResYUw=
-github.com/anthropics/anthropic-sdk-go v1.42.0/go.mod h1:r4eaLX9tBolUrXLOrLj7eU8tmeBtoobCkM0kBsivBaY=
 github.com/anthropics/anthropic-sdk-go v1.56.0 h1:idVU14wOZ06D0GBNEvuhn927xXmBVEquo0469iDwLsc=
 github.com/anthropics/anthropic-sdk-go v1.56.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
@@ -125,8 +123,6 @@ github.com/goph/emperror v0.17.2/go.mod h1:+ZbQ+fUNO/6FNiUo0ujtMjhgad9Xa6fQL9KhH
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -181,8 +177,6 @@ github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGB
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
-github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829 h1:zGlGD0Zfk2HaIo4EnUVBRhnXQ+cnGQz5X2PdBcplOyw=
-github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260508151727-1282bb917829/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 h1:uOfcYT+3QungH6tIGSVCR/Y3KJmgJiHcojJbMTPDZAI=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.1/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -197,9 +191,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/components/model/agenticclaude/message_extra.go
+++ b/components/model/agenticclaude/message_extra.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agenticclaude
+
+import "github.com/cloudwego/eino/schema"
+
+// GetCacheCreationInputTokens returns the Anthropic cache_creation_input_tokens
+// count from the message. This is the number of input tokens written into a new
+// prompt cache entry, billed at ~125% of the base input token rate.
+//
+// The cache-read side is available through the standard token usage path:
+//
+//	msg.ResponseMeta.TokenUsage.PromptTokenDetails.CachedTokens
+//
+// When streaming, Anthropic reports this once per request (on message_start or
+// message_delta). schema.ConcatAgenticMessages merges Extra maps with a
+// last-value-wins policy for int, so the final concatenated message carries
+// the correct count without accumulation.
+func GetCacheCreationInputTokens(msg *schema.AgenticMessage) (int, bool) {
+	if msg == nil || msg.Extra == nil {
+		return 0, false
+	}
+	v, ok := msg.Extra[KeyOfCacheCreationInputTokens].(int)
+	return v, ok
+}

--- a/components/model/agenticclaude/message_extra.go
+++ b/components/model/agenticclaude/message_extra.go
@@ -34,6 +34,6 @@ func GetCacheCreationInputTokens(msg *schema.AgenticMessage) (int, bool) {
 	if msg == nil || msg.Extra == nil {
 		return 0, false
 	}
-	v, ok := msg.Extra[KeyOfCacheCreationInputTokens].(int)
+	v, ok := msg.Extra[keyOfCacheCreationInputTokens].(int)
 	return v, ok
 }

--- a/components/model/agenticclaude/message_extra_test.go
+++ b/components/model/agenticclaude/message_extra_test.go
@@ -50,7 +50,7 @@ func TestGetCacheCreationInputTokens(t *testing.T) {
 
 	t.Run("key present with value", func(t *testing.T) {
 		msg := &schema.AgenticMessage{Extra: map[string]any{
-			KeyOfCacheCreationInputTokens: 1234,
+			keyOfCacheCreationInputTokens: 1234,
 		}}
 		tokens, ok := GetCacheCreationInputTokens(msg)
 		if !ok || tokens != 1234 {
@@ -135,6 +135,29 @@ func TestCacheCreationInputTokens_SetInStreamDelta(t *testing.T) {
 			t.Fatalf("expected (300, true), got (%d, %v)", tokens, ok)
 		}
 	})
+}
+
+func TestCacheCreationInputTokens_PreservedAfterConcat(t *testing.T) {
+	sc := newStreamConverter()
+	event := mustUnmarshalStreamEvent(t, `{
+		"type": "message_delta",
+		"delta": {"stop_reason": "end_turn"},
+		"usage": {"output_tokens": 42, "cache_creation_input_tokens": 300}
+	}`)
+	usageChunk, err := sc.toMessageStreamingChunk(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	textChunk := newAssistantStreamingChunk(schema.NewContentBlock(&schema.AssistantGenText{Text: "hello"}))
+
+	msg, err := schema.ConcatAgenticMessages([]*schema.AgenticMessage{usageChunk, textChunk})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokens, ok := GetCacheCreationInputTokens(msg)
+	if !ok || tokens != 300 {
+		t.Fatalf("expected (300, true), got (%d, %v)", tokens, ok)
+	}
 }
 
 func mustUnmarshalStreamEvent(t *testing.T, raw string) anthropic.MessageStreamEventUnion {

--- a/components/model/agenticclaude/message_extra_test.go
+++ b/components/model/agenticclaude/message_extra_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agenticclaude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestGetCacheCreationInputTokens(t *testing.T) {
+	t.Run("nil message", func(t *testing.T) {
+		tokens, ok := GetCacheCreationInputTokens(nil)
+		if ok || tokens != 0 {
+			t.Fatalf("expected (0, false), got (%d, %v)", tokens, ok)
+		}
+	})
+
+	t.Run("nil Extra", func(t *testing.T) {
+		msg := &schema.AgenticMessage{}
+		tokens, ok := GetCacheCreationInputTokens(msg)
+		if ok || tokens != 0 {
+			t.Fatalf("expected (0, false), got (%d, %v)", tokens, ok)
+		}
+	})
+
+	t.Run("key not present", func(t *testing.T) {
+		msg := &schema.AgenticMessage{Extra: map[string]any{"other": 42}}
+		tokens, ok := GetCacheCreationInputTokens(msg)
+		if ok || tokens != 0 {
+			t.Fatalf("expected (0, false), got (%d, %v)", tokens, ok)
+		}
+	})
+
+	t.Run("key present with value", func(t *testing.T) {
+		msg := &schema.AgenticMessage{Extra: map[string]any{
+			KeyOfCacheCreationInputTokens: 1234,
+		}}
+		tokens, ok := GetCacheCreationInputTokens(msg)
+		if !ok || tokens != 1234 {
+			t.Fatalf("expected (1234, true), got (%d, %v)", tokens, ok)
+		}
+	})
+}
+
+func TestCacheCreationInputTokens_SetInConvOutputMessage(t *testing.T) {
+	t.Run("zero cache creation does not set Extra", func(t *testing.T) {
+		var resp anthropic.Message
+		if err := json.Unmarshal([]byte(`{
+			"id": "msg_1",
+			"type": "message",
+			"role": "assistant",
+			"content": [],
+			"usage": {"input_tokens": 100, "output_tokens": 50, "cache_creation_input_tokens": 0}
+		}`), &resp); err != nil {
+			t.Fatal(err)
+		}
+		msg, err := toAgenticMessage(&resp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.Extra != nil {
+			t.Fatalf("expected nil Extra when cache_creation_input_tokens=0, got %v", msg.Extra)
+		}
+	})
+
+	t.Run("nonzero cache creation sets Extra", func(t *testing.T) {
+		var resp anthropic.Message
+		if err := json.Unmarshal([]byte(`{
+			"id": "msg_1",
+			"type": "message",
+			"role": "assistant",
+			"content": [],
+			"usage": {"input_tokens": 100, "output_tokens": 50, "cache_creation_input_tokens": 500}
+		}`), &resp); err != nil {
+			t.Fatal(err)
+		}
+		msg, err := toAgenticMessage(&resp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tokens, ok := GetCacheCreationInputTokens(msg)
+		if !ok || tokens != 500 {
+			t.Fatalf("expected (500, true), got (%d, %v)", tokens, ok)
+		}
+	})
+}
+
+func TestCacheCreationInputTokens_SetInStreamDelta(t *testing.T) {
+	sc := newStreamConverter()
+
+	t.Run("delta with zero cache creation", func(t *testing.T) {
+		event := mustUnmarshalStreamEvent(t, `{
+			"type": "message_delta",
+			"delta": {"stop_reason": "end_turn"},
+			"usage": {"output_tokens": 42, "cache_creation_input_tokens": 0}
+		}`)
+		msg, err := sc.toMessageStreamingChunk(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msg.Extra != nil {
+			t.Fatalf("expected nil Extra for zero cache_creation, got %v", msg.Extra)
+		}
+	})
+
+	t.Run("delta with nonzero cache creation", func(t *testing.T) {
+		event := mustUnmarshalStreamEvent(t, `{
+			"type": "message_delta",
+			"delta": {"stop_reason": "end_turn"},
+			"usage": {"output_tokens": 42, "cache_creation_input_tokens": 300}
+		}`)
+		msg, err := sc.toMessageStreamingChunk(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tokens, ok := GetCacheCreationInputTokens(msg)
+		if !ok || tokens != 300 {
+			t.Fatalf("expected (300, true), got (%d, %v)", tokens, ok)
+		}
+	})
+}
+
+func mustUnmarshalStreamEvent(t *testing.T, raw string) anthropic.MessageStreamEventUnion {
+	t.Helper()
+	var event anthropic.MessageStreamEventUnion
+	if err := json.Unmarshal([]byte(raw), &event); err != nil {
+		t.Fatalf("json.Unmarshal(event) error = %v", err)
+	}
+	return event
+}


### PR DESCRIPTION
## Summary

Port `cache_creation_input_tokens` from the legacy claude adapter to agenticclaude, following the pattern established in #929.

Anthropic bills prompt cache reads (~10% of base rate) and writes (~125% of base rate) at very different prices. The read side is already exposed through the standard `PromptTokenDetails.CachedTokens` path. The creation side (`cache_creation_input_tokens`) has no standard schema equivalent, so it is surfaced in `message.Extra`:

- **Key**: `_eino_claude_cache_creation_input_tokens` (same key as the legacy claude adapter)
- **Set in**: `toAgenticMessage` (Generate) and `toMessageStreamingChunk` (message_delta)
- **Read via**: `agenticclaude.GetCacheCreationInputTokens(msg *schema.AgenticMessage) (int, bool)`
- **Streaming**: Anthropic reports once per request on message_start or message_delta. `int` has built-in `useLast` concat, so `ConcatAgenticMessages` correctly preserves the value without accumulation.
- **Zero activity**: When `CacheCreationInputTokens == 0`, no Extra entry is written.

### Design decisions

- **Same Extra key as legacy adapter** — Downstream consumers (e.g. Langfuse cost tracking) do not need to distinguish between legacy and agentic adapters.
- **Only `cache_creation` in Extra** — `cache_read` is NOT duplicated because it's already in the standard `PromptTokenDetails.CachedTokens` path.
- **`int` type, not a struct** — Simpler than a typed struct; no need to register concat func since `int` has built-in support.

## Changes

| File | Change |
|------|--------|
| `consts.go` | Add exported `KeyOfCacheCreationInputTokens` constant |
| `convertor.go` | Set cache_creation in `toAgenticMessage` (Generate path) |
| `event_convertor.go` | Set cache_creation in `toMessageStreamingChunk` (message_delta) |
| `message_extra.go` | New: `GetCacheCreationInputTokens()` getter |
| `message_extra_test.go` | New: tests for getter, Generate path, streaming delta path |

## Test plan

- [x] `TestGetCacheCreationInputTokens` — nil message, nil Extra, key missing, key present
- [x] `TestCacheCreationInputTokens_SetInConvOutputMessage` — zero and nonzero paths
- [x] `TestCacheCreationInputTokens_SetInStreamDelta` — zero and nonzero paths
- [x] All existing tests pass (`go test ./...`)

## Related

- #929 — Same feature for the legacy claude adapter (already merged)