### PR TITLE
feat(langfuse): expose OTLP retry config

### DIFF
--- a/callbacks/langfuse/v2/README.md
+++ b/callbacks/langfuse/v2/README.md
@@ -98,6 +98,20 @@ The batch processor does not add a shorter export deadline. For the built-in
 OTLP exporter, `Config.Timeout` limits each HTTP request and the OpenTelemetry
 exporter's retry policy controls the total retry window. Explicit `ForceFlush`
 operations pass the caller's context to the exporter and remain cancellable.
+Set `Config.RetryConfig` to override that policy. A nil value preserves the
+OpenTelemetry defaults: retries enabled with a 5-second initial interval,
+30-second maximum interval, and 1-minute total retry window. For example:
+
+```go
+RetryConfig: &langfuse.RetryConfig{
+    Enabled:         true,
+    InitialInterval: 5 * time.Second,
+    MaxInterval:     30 * time.Second,
+    MaxElapsedTime:  5 * time.Minute,
+},
+```
+
+A zero `MaxElapsedTime` retries indefinitely and should be used carefully.
 
 These processor-level diagnostics apply when the callback creates its own OTel
 tracer provider. With a caller-owned `TracerProvider`, queueing and exporting are

--- a/callbacks/langfuse/v2/README_zh.md
+++ b/callbacks/langfuse/v2/README_zh.md
@@ -98,6 +98,19 @@ langfuse callback discarded telemetry since previous report (interval 1m0s): que
 
 batch processor 不会额外设置更短的导出 deadline。使用内置 OTLP exporter 时，`Config.Timeout` 限制单次 HTTP 请求，OpenTelemetry exporter 的重试策略控制整个重试窗口。显式 `ForceFlush` 会将调用方 context 传给 exporter，因此仍可取消。
 
+使用 `Config.RetryConfig` 可以覆盖该策略。值为 nil 时保留 OpenTelemetry 默认值：启用重试，首次间隔 5 秒、最大间隔 30 秒、总重试窗口 1 分钟。例如：
+
+```go
+RetryConfig: &langfuse.RetryConfig{
+    Enabled:         true,
+    InitialInterval: 5 * time.Second,
+    MaxInterval:     30 * time.Second,
+    MaxElapsedTime:  5 * time.Minute,
+},
+```
+
+`MaxElapsedTime` 为零时会无限重试，应谨慎使用。
+
 当 callback 使用调用方传入的 `TracerProvider` 时，队列和导出由该 provider 管理，应通过其 span processor/exporter 诊断；callback 自身的截断和序列化诊断仍然有效。
 
 ## 大小限制和脱敏

--- a/callbacks/langfuse/v2/config.go
+++ b/callbacks/langfuse/v2/config.go
@@ -42,6 +42,10 @@ const (
 	instrumentationVersion         = "v2.0.0"
 )
 
+// RetryConfig configures exponential backoff for transient OTLP export
+// failures. It is an alias of the OpenTelemetry OTLP/HTTP retry config.
+type RetryConfig = otlptracehttp.RetryConfig
+
 // Config configures the Langfuse OTLP/HTTP callback.
 type Config struct {
 	// Host accepts a Langfuse base URL, an OTLP base URL ending in
@@ -58,6 +62,10 @@ type Config struct {
 	Tags        []string
 	Timeout     time.Duration
 	SampleRate  float64
+	// RetryConfig overrides the OpenTelemetry OTLP/HTTP retry policy. Nil uses
+	// the OpenTelemetry default policy. MaxElapsedTime limits the total retry
+	// window for one batch; zero retries indefinitely.
+	RetryConfig *RetryConfig
 
 	// Name, UserID, and SessionID configure default root trace attributes.
 	// Prefer the corresponding StartTrace options for each trace.
@@ -244,6 +252,9 @@ func newHTTPExporter(ctx context.Context, cfg *Config) (sdktrace.SpanExporter, e
 		}),
 		otlptracehttp.WithTimeout(timeout),
 		otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+	}
+	if cfg.RetryConfig != nil {
+		exporterOptions = append(exporterOptions, otlptracehttp.WithRetry(*cfg.RetryConfig))
 	}
 	if cfg.ExportDiagnostics {
 		exporterOptions = append(exporterOptions, otlptracehttp.WithHTTPClient(newDiagnosticHTTPClient(cfg.HTTPClient, timeout)))

--- a/callbacks/langfuse/v2/config_test.go
+++ b/callbacks/langfuse/v2/config_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package langfuse
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestHTTPExporterUsesRetryConfig(t *testing.T) {
+	var attempts atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		response.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	exporter, err := newHTTPExporter(context.Background(), &Config{
+		Host:      server.URL,
+		PublicKey: "public",
+		SecretKey: "secret",
+		Timeout:   time.Second,
+		RetryConfig: &RetryConfig{
+			Enabled:         true,
+			InitialInterval: time.Millisecond,
+			MaxInterval:     time.Millisecond,
+			MaxElapsedTime:  20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	_, span := provider.Tracer("retry-config-test").Start(context.Background(), "test")
+	span.End()
+	if err := exporter.ExportSpans(context.Background(), recorder.Ended()); err == nil {
+		t.Fatal("export unexpectedly succeeded")
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("export attempts = %d, want at least 2", got)
+	}
+
+	shutdownContext, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := exporter.Shutdown(shutdownContext); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- expose the OTLP/HTTP retry policy as `langfuse.Config.RetryConfig`
- preserve OpenTelemetry defaults when the field is nil
- document bounded and indefinite retry semantics in the English and Chinese READMEs

## Motivation

`Config.Timeout` controls each HTTP attempt, but callers currently cannot tune the total retry window for transient export failures. Large or cross-region trace uploads may need a longer bounded retry window without supplying a fully custom `SpanExporter`.

## Compatibility

The field is optional. A nil value does not add `otlptracehttp.WithRetry`, so existing users retain OpenTelemetry's default retry behavior.

## Testing

- `go test .` in `callbacks/langfuse/v2` with Go 1.24.1
- integration test verifies that a custom retry policy causes multiple attempts on HTTP 503
- validated for one day in a downstream service with a five-minute bounded retry window
