### PR TITLE
fix(agenticark): preserve raw reasoning content from Ark Responses API

### DIFF
--- a/components/model/agenticark/convertor.go
+++ b/components/model/agenticark/convertor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/schema"
+	openaischema "github.com/cloudwego/eino/schema/openai"
 	"github.com/eino-contrib/jsonschema"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 	"golang.org/x/sync/errgroup"
@@ -698,17 +699,38 @@ func reasoningToInputItem(block *schema.ContentBlock) (item *responses.InputItem
 
 	id, _ := getItemID(block)
 	status, _ := GetItemStatus(block)
+	reasoning := &responses.ItemReasoning{
+		Type:             responses.ItemType_reasoning,
+		Id:               ptrIfNonZero(id),
+		Status:           responses.ItemStatus_Enum(responses.ItemStatus_Enum_value[status]),
+		EncryptedContent: ptrIfNonZero(content.Signature),
+	}
+	if content.Text != "" {
+		reasoning.Summary = []*responses.ReasoningSummaryPart{
+			{Text: content.Text},
+		}
+	}
+
+	if content.OpenAIExtension != nil {
+		reasoning.Content = make([]*responses.OutputContentItem, 0, len(content.OpenAIExtension.Content))
+		for _, c := range content.OpenAIExtension.Content {
+			if c == nil {
+				continue
+			}
+			reasoning.Content = append(reasoning.Content, &responses.OutputContentItem{
+				Union: &responses.OutputContentItem_Text{
+					Text: &responses.OutputContentItemText{
+						Type: responses.ContentItemType_reasoning_text,
+						Text: c.Text,
+					},
+				},
+			})
+		}
+	}
 
 	item = &responses.InputItem{
 		Union: &responses.InputItem_Reasoning{
-			Reasoning: &responses.ItemReasoning{
-				Type:   responses.ItemType_reasoning,
-				Id:     ptrIfNonZero(id),
-				Status: responses.ItemStatus_Enum(responses.ItemStatus_Enum_value[status]),
-				Summary: []*responses.ReasoningSummaryPart{
-					{Text: content.Text},
-				},
-			},
+			Reasoning: reasoning,
 		},
 	}
 
@@ -1646,9 +1668,25 @@ func reasoningToContentBlocks(item *responses.OutputItem_Reasoning) (block *sche
 		text.WriteString(s.Text)
 	}
 
-	block = schema.NewContentBlock(&schema.Reasoning{
-		Text: text.String(),
-	})
+	content := &schema.Reasoning{
+		Text:      text.String(),
+		Signature: reasoning.GetEncryptedContent(),
+	}
+	if len(reasoning.Content) > 0 {
+		content.OpenAIExtension = &openaischema.ReasoningExtension{
+			Content: make([]*openaischema.ReasoningContent, 0, len(reasoning.Content)),
+		}
+		for _, c := range reasoning.Content {
+			if c == nil || c.GetText() == nil {
+				continue
+			}
+			content.OpenAIExtension.Content = append(content.OpenAIExtension.Content, &openaischema.ReasoningContent{
+				Text: c.GetText().Text,
+			})
+		}
+	}
+
+	block = schema.NewContentBlock(content)
 
 	if reasoning.Id != nil {
 		setItemID(block, *reasoning.Id)

--- a/components/model/agenticark/convertor_test.go
+++ b/components/model/agenticark/convertor_test.go
@@ -17,11 +17,13 @@
 package agenticark
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/bytedance/mockey"
 	"github.com/cloudwego/eino/schema"
+	openaischema "github.com/cloudwego/eino/schema/openai"
 	"github.com/eino-contrib/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
@@ -69,10 +71,10 @@ func TestToAssistantRoleInputItems(t *testing.T) {
 	setItemID(msg.ContentBlocks[1], "id-1")
 	setItemStatus(msg.ContentBlocks[1], responses.ItemStatus_completed.String())
 	msg.ResponseMeta = &schema.AgenticResponseMeta{
-			Extension: &ResponseMetaExtension{},
-		}
+		Extension: &ResponseMetaExtension{},
+	}
 
-		items, err := toAssistantRoleInputItems(msg)
+	items, err := toAssistantRoleInputItems(msg)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(items))
 	assert.Equal(t, responses.MessageRole_assistant, items[0].GetInputMessage().Role)
@@ -303,7 +305,13 @@ func TestFunctionToolCallToInputItem(t *testing.T) {
 
 func TestReasoningToInputItem(t *testing.T) {
 	block := schema.NewContentBlock(&schema.Reasoning{
-		Text: "r",
+		Text:      "summary",
+		Signature: "encrypted",
+		OpenAIExtension: &openaischema.ReasoningExtension{
+			Content: []*openaischema.ReasoningContent{
+				{Text: "raw reasoning"},
+			},
+		},
 	})
 
 	item, err := reasoningToInputItem(block)
@@ -311,7 +319,12 @@ func TestReasoningToInputItem(t *testing.T) {
 	reason := item.GetReasoning()
 	assert.NotNil(t, reason)
 	assert.Equal(t, 1, len(reason.Summary))
-	assert.Equal(t, "r", reason.Summary[0].Text)
+	assert.Equal(t, "summary", reason.Summary[0].Text)
+	assert.Equal(t, "encrypted", reason.GetEncryptedContent())
+	if assert.Len(t, reason.Content, 1) {
+		assert.Equal(t, responses.ContentItemType_reasoning_text, reason.Content[0].GetText().Type)
+		assert.Equal(t, "raw reasoning", reason.Content[0].GetText().Text)
+	}
 }
 
 func TestServerToolCallToInputItem(t *testing.T) {
@@ -840,15 +853,97 @@ func TestReasoningToContentBlocks(t *testing.T) {
 			Summary: []*responses.ReasoningSummaryPart{
 				{Text: "r"},
 			},
+			Content: []*responses.OutputContentItem{
+				{
+					Union: &responses.OutputContentItem_Text{
+						Text: &responses.OutputContentItemText{
+							Type: responses.ContentItemType_reasoning_text,
+							Text: "raw reasoning",
+						},
+					},
+				},
+			},
+			EncryptedContent: ptrOf("encrypted"),
 		},
 	}
 	block, err := reasoningToContentBlocks(item)
 	assert.NoError(t, err)
 	assert.NotNil(t, block.Reasoning)
 	assert.Equal(t, "r", block.Reasoning.Text)
+	assert.Equal(t, "encrypted", block.Reasoning.Signature)
+	if assert.NotNil(t, block.Reasoning.OpenAIExtension) &&
+		assert.Len(t, block.Reasoning.OpenAIExtension.Content, 1) {
+		assert.Equal(t, "raw reasoning", block.Reasoning.OpenAIExtension.Content[0].Text)
+	}
 
 	_, err = reasoningToContentBlocks(&responses.OutputItem_Reasoning{})
 	assert.Error(t, err)
+}
+
+func TestToOutputMessageWithRawReasoningResponse(t *testing.T) {
+	const rawReasoning = "\n用户现在问1+1等于几，首先正常的数学答案是2。"
+	const outputText = "在最基础的十进制数学算术里，1+1=2。"
+	responseJSON := `{
+		"created_at": 1788353431,
+		"id": "mock-response-id",
+		"model": "mock-model",
+		"object": "response",
+		"output": [
+			{
+				"id": "mock-reasoning-id",
+				"type": "reasoning",
+				"status": "completed",
+				"content": [
+					{
+						"type": "reasoning_text",
+						"text": "\n用户现在问1+1等于几，首先正常的数学答案是2。"
+					}
+				]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{
+						"type": "output_text",
+						"text": "在最基础的十进制数学算术里，1+1=2。"
+					}
+				],
+				"status": "completed",
+				"id": "mock-message-id"
+			}
+		],
+		"thinking": {"type": "enabled"},
+		"status": "completed"
+	}`
+
+	var resp responses.ResponseObject
+	err := json.Unmarshal([]byte(responseJSON), &resp)
+	assert.NoError(t, err)
+	if assert.Len(t, resp.Output, 2) {
+		assert.Len(t, resp.Output[0].GetReasoning().Content, 1,
+			"SDK must preserve reasoning.content from the API response")
+	}
+
+	msg, err := toOutputMessage(&resp)
+	assert.NoError(t, err)
+	if assert.Len(t, msg.ContentBlocks, 2) {
+		reasoning := msg.ContentBlocks[0].Reasoning
+		if assert.NotNil(t, reasoning) && assert.NotNil(t, reasoning.OpenAIExtension) &&
+			assert.Len(t, reasoning.OpenAIExtension.Content, 1) {
+			assert.Equal(t, rawReasoning, reasoning.OpenAIExtension.Content[0].Text)
+		}
+		assert.Equal(t, outputText, msg.ContentBlocks[1].AssistantGenText.Text)
+
+		inputItem, err := reasoningToInputItem(msg.ContentBlocks[0])
+		assert.NoError(t, err)
+		if assert.NotNil(t, inputItem.GetReasoning()) {
+			assert.Empty(t, inputItem.GetReasoning().Summary)
+			if assert.Len(t, inputItem.GetReasoning().Content, 1) {
+				assert.Equal(t, rawReasoning, inputItem.GetReasoning().Content[0].GetText().Text)
+			}
+		}
+	}
 }
 
 func TestMcpCallToContentBlocks(t *testing.T) {

--- a/components/model/agenticark/event_convertor.go
+++ b/components/model/agenticark/event_convertor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
+	openaischema "github.com/cloudwego/eino/schema/openai"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/utils"
 )
@@ -108,6 +109,10 @@ func receivedStreamResponse(streamReader *utils.ResponsesStreamReader,
 
 		case *responses.Event_ReasoningText:
 			block := receiver.reasoningSummaryTextDeltaEventToContentBlock(ev.ReasoningText)
+			sender.sendBlock(block, nil)
+
+		case *responses.Event_ReasoningRawTextDelta:
+			block := receiver.reasoningTextDeltaEventToContentBlock(ev.ReasoningRawTextDelta)
 			sender.sendBlock(block, nil)
 
 		case *responses.Event_FunctionCallArguments:
@@ -692,42 +697,61 @@ func (r *streamReceiver) itemDoneEventFunctionMCPApprovalRequestToContentBlock(o
 }
 
 func (r *streamReceiver) contentPartAddedEventToContentBlock(ev *responses.ContentPartEvent) (block *schema.ContentBlock, err error) {
-	key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
+	key := makeContentPartIndexKey(ev.OutputIndex, ev.ContentIndex, ev.Part)
 	blockIdx := r.getBlockIndex(key)
 
-	indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemId]
-	if !ok {
-		indices = map[int]bool{}
-		r.ProcessingAssistantGenTextBlockIndex[ev.ItemId] = indices
+	if !isReasoningContentPart(ev.Part) {
+		indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemId]
+		if !ok {
+			indices = map[int]bool{}
+			r.ProcessingAssistantGenTextBlockIndex[ev.ItemId] = indices
+		}
+		indices[blockIdx] = true
 	}
 
-	indices[blockIdx] = true
-
-	return r.eventContentPartToContentBlock(ev.ItemId, ev.Part, blockIdx, responses.ItemStatus_in_progress)
+	return r.eventContentPartToContentBlock(
+		ev.ItemId, ev.Part, ev.ContentIndex, blockIdx, responses.ItemStatus_in_progress)
 }
 
 func (r *streamReceiver) contentPartDoneEventToContentBlock(ev *responses.ContentPartDoneEvent) (block *schema.ContentBlock, err error) {
-	key := makeAssistantGenTextIndexKey(ev.OutputIndex, ev.ContentIndex)
+	key := makeContentPartIndexKey(ev.OutputIndex, ev.ContentIndex, ev.Part)
 	blockIdx := r.getBlockIndex(key)
+
+	if isReasoningContentPart(ev.Part) {
+		block = schema.NewContentBlockChunk(&schema.Reasoning{}, &schema.StreamingMeta{Index: blockIdx})
+		setItemStatus(block, responses.ItemStatus_completed.String())
+		setItemID(block, ev.ItemId)
+		return block, nil
+	}
 
 	indices, ok := r.ProcessingAssistantGenTextBlockIndex[ev.ItemId]
 	if !ok {
 		return nil, fmt.Errorf("item %q has no processing assistant gen text block index", ev.ItemId)
 	}
-
 	delete(indices, blockIdx)
 
-	return r.eventContentPartToContentBlock(ev.ItemId, ev.Part, blockIdx, responses.ItemStatus_completed)
+	return r.eventContentPartToContentBlock(
+		ev.ItemId, ev.Part, ev.ContentIndex, blockIdx, responses.ItemStatus_completed)
 }
 
 func (r *streamReceiver) eventContentPartToContentBlock(itemID string, content *responses.OutputContentItem,
-	blockIdx int, status responses.ItemStatus_Enum) (block *schema.ContentBlock, err error) {
+	contentIdx int64, blockIdx int, status responses.ItemStatus_Enum) (block *schema.ContentBlock, err error) {
 
 	meta := &schema.StreamingMeta{Index: blockIdx}
 
-	switch content.Union.(type) {
+	switch c := content.Union.(type) {
 	case *responses.OutputContentItem_Text:
-		block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+		if c.Text.GetType() == responses.ContentItemType_reasoning_text {
+			block = schema.NewContentBlockChunk(&schema.Reasoning{
+				OpenAIExtension: &openaischema.ReasoningExtension{
+					Content: []*openaischema.ReasoningContent{
+						{Index: ptrOf(int(contentIdx)), Text: c.Text.GetText()},
+					},
+				},
+			}, meta)
+		} else {
+			block = schema.NewContentBlockChunk(&schema.AssistantGenText{}, meta)
+		}
 	default:
 		// Unknown content part types are ignored rather than failing the stream.
 		return nil, nil
@@ -737,6 +761,18 @@ func (r *streamReceiver) eventContentPartToContentBlock(itemID string, content *
 	setItemID(block, itemID)
 
 	return block, nil
+}
+
+func isReasoningContentPart(content *responses.OutputContentItem) bool {
+	return content != nil && content.GetText() != nil &&
+		content.GetText().GetType() == responses.ContentItemType_reasoning_text
+}
+
+func makeContentPartIndexKey(outputIdx, contentIdx int64, content *responses.OutputContentItem) string {
+	if isReasoningContentPart(content) {
+		return makeReasoningIndexKey(outputIdx)
+	}
+	return makeAssistantGenTextIndexKey(outputIdx, contentIdx)
 }
 
 func (r *streamReceiver) outputTextDeltaEventToContentBlock(ev *responses.OutputTextEvent) *schema.ContentBlock {
@@ -785,6 +821,25 @@ func (r *streamReceiver) reasoningSummaryTextDeltaEventToContentBlock(ev *respon
 
 	reasoning := &schema.Reasoning{
 		Text: text,
+	}
+
+	meta := &schema.StreamingMeta{
+		Index: r.getBlockIndex(makeReasoningIndexKey(ev.OutputIndex)),
+	}
+	block := schema.NewContentBlockChunk(reasoning, meta)
+
+	setItemID(block, ev.ItemId)
+
+	return block
+}
+
+func (r *streamReceiver) reasoningTextDeltaEventToContentBlock(ev *responses.ReasoningTextDeltaEvent) *schema.ContentBlock {
+	reasoning := &schema.Reasoning{
+		OpenAIExtension: &openaischema.ReasoningExtension{
+			Content: []*openaischema.ReasoningContent{
+				{Index: ptrOf(int(ev.ContentIndex)), Text: ev.GetDelta()},
+			},
+		},
 	}
 
 	meta := &schema.StreamingMeta{

--- a/components/model/agenticark/event_convertor_test.go
+++ b/components/model/agenticark/event_convertor_test.go
@@ -18,12 +18,15 @@ package agenticark
 
 import (
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
+	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/utils"
 )
 
 func TestNewStreamReceiverInit(t *testing.T) {
@@ -295,6 +298,35 @@ func TestContentPartAddedEventToContentBlock(t *testing.T) {
 	assert.Equal(t, "mid", id)
 }
 
+func TestContentPartAddedEventToContentBlockWithRawReasoning(t *testing.T) {
+	r := newStreamReceiver()
+	ev := &responses.ContentPartEvent{
+		ItemId:       "rid",
+		OutputIndex:  1,
+		ContentIndex: 2,
+		Part: &responses.OutputContentItem{
+			Union: &responses.OutputContentItem_Text{
+				Text: &responses.OutputContentItemText{
+					Type: responses.ContentItemType_reasoning_text,
+					Text: "raw reasoning",
+				},
+			},
+		},
+	}
+
+	block, err := r.contentPartAddedEventToContentBlock(ev)
+	assert.NoError(t, err)
+	if assert.NotNil(t, block) && assert.NotNil(t, block.Reasoning) &&
+		assert.NotNil(t, block.Reasoning.OpenAIExtension) &&
+		assert.Len(t, block.Reasoning.OpenAIExtension.Content, 1) {
+		content := block.Reasoning.OpenAIExtension.Content[0]
+		assert.Equal(t, "raw reasoning", content.Text)
+		if assert.NotNil(t, content.Index) {
+			assert.Equal(t, 2, *content.Index)
+		}
+	}
+}
+
 func TestContentPartDoneEventToContentBlockNoIndex(t *testing.T) {
 	r := newStreamReceiver()
 	ev := &responses.ContentPartDoneEvent{
@@ -336,10 +368,70 @@ func TestContentPartDoneEventToContentBlockOK(t *testing.T) {
 	assert.Equal(t, responses.ItemStatus_completed.String(), status)
 }
 
+func TestRawReasoningContentPartLifecycle(t *testing.T) {
+	r := newStreamReceiver()
+	added, err := r.contentPartAddedEventToContentBlock(&responses.ContentPartEvent{
+		ItemId:       "rid",
+		OutputIndex:  1,
+		ContentIndex: 0,
+		Part: &responses.OutputContentItem{
+			Union: &responses.OutputContentItem_Text{
+				Text: &responses.OutputContentItemText{
+					Type: responses.ContentItemType_reasoning_text,
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	delta := r.reasoningTextDeltaEventToContentBlock(&responses.ReasoningTextDeltaEvent{
+		ItemId:       "rid",
+		OutputIndex:  1,
+		ContentIndex: 0,
+		Delta:        ptrOf("raw reasoning"),
+	})
+
+	done, err := r.contentPartDoneEventToContentBlock(&responses.ContentPartDoneEvent{
+		ItemId:       "rid",
+		OutputIndex:  1,
+		ContentIndex: 0,
+		Part: &responses.OutputContentItem{
+			Union: &responses.OutputContentItem_Text{
+				Text: &responses.OutputContentItemText{
+					Type: responses.ContentItemType_reasoning_text,
+					Text: "raw reasoning",
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, done.Reasoning)
+	assert.Nil(t, done.Reasoning.OpenAIExtension)
+
+	msg, err := schema.ConcatAgenticMessages([]*schema.AgenticMessage{
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{added}},
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{delta}},
+		{Role: schema.AgenticRoleTypeAssistant, ContentBlocks: []*schema.ContentBlock{done}},
+	})
+	assert.NoError(t, err)
+	if assert.Len(t, msg.ContentBlocks, 1) {
+		block := msg.ContentBlocks[0]
+		if assert.NotNil(t, block.Reasoning) &&
+			assert.NotNil(t, block.Reasoning.OpenAIExtension) &&
+			assert.Len(t, block.Reasoning.OpenAIExtension.Content, 1) {
+			assert.Equal(t, "raw reasoning", block.Reasoning.OpenAIExtension.Content[0].Text)
+		}
+		status, ok := GetItemStatus(block)
+		assert.True(t, ok)
+		assert.Equal(t, responses.ItemStatus_completed.String(), status)
+	}
+}
+
 func TestEventContentPartToContentBlockUnknown(t *testing.T) {
 	r := newStreamReceiver()
 	// Unknown content part types are ignored rather than failing the stream.
-	block, err := r.eventContentPartToContentBlock("id", &responses.OutputContentItem{}, 1, responses.ItemStatus_in_progress)
+	block, err := r.eventContentPartToContentBlock(
+		"id", &responses.OutputContentItem{}, 0, 1, responses.ItemStatus_in_progress)
 	assert.NoError(t, err)
 	assert.Nil(t, block)
 }
@@ -389,6 +481,41 @@ func TestReasoningSummaryTextDeltaEventToContentBlock(t *testing.T) {
 	})
 	assert.NotNil(t, block.Reasoning)
 	assert.Equal(t, "x", block.Reasoning.Text)
+}
+
+func TestReceivedStreamResponseWithRawReasoningDelta(t *testing.T) {
+	const eventStream = "event: response.reasoning_text.delta\n" +
+		"data: {\"type\":\"response.reasoning_text.delta\",\"content_index\":0," +
+		"\"delta\":\"raw reasoning\",\"item_id\":\"rid\",\"output_index\":0,\"sequence_number\":1}\n\n" +
+		"data: [DONE]\n\n"
+
+	body := io.NopCloser(strings.NewReader(eventStream))
+	streamReader := &utils.ResponsesStreamReader{
+		ChatCompletionStreamReader: utils.ChatCompletionStreamReader{
+			Unmarshaler: &utils.JSONUnmarshaler{},
+		},
+		Decoder: utils.NewEventStreamDecoder(body),
+	}
+	sr, sw := schema.Pipe[*model.AgenticCallbackOutput](1)
+	defer sr.Close()
+
+	receivedStreamResponse(streamReader, &model.AgenticConfig{}, sw)
+	sw.Close()
+
+	output, err := sr.Recv()
+	assert.NoError(t, err)
+	if assert.NotNil(t, output) && assert.NotNil(t, output.Message) &&
+		assert.Len(t, output.Message.ContentBlocks, 1) {
+		reasoning := output.Message.ContentBlocks[0].Reasoning
+		if assert.NotNil(t, reasoning) && assert.NotNil(t, reasoning.OpenAIExtension) &&
+			assert.Len(t, reasoning.OpenAIExtension.Content, 1) {
+			content := reasoning.OpenAIExtension.Content[0]
+			assert.Equal(t, "raw reasoning", content.Text)
+			if assert.NotNil(t, content.Index) {
+				assert.Equal(t, 0, *content.Index)
+			}
+		}
+	}
 }
 
 func TestFunctionCallArgumentsDeltaEventToContentBlock(t *testing.T) {

--- a/components/model/agenticark/go.mod
+++ b/components/model/agenticark/go.mod
@@ -5,11 +5,11 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.4.6
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.9.1
+	github.com/cloudwego/eino v0.9.5
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/stretchr/testify v1.10.0
-	github.com/volcengine/volcengine-go-sdk v1.2.34
+	github.com/volcengine/volcengine-go-sdk v1.2.46
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/sync v0.8.0
 	google.golang.org/protobuf v1.31.0
@@ -29,6 +29,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/components/model/agenticark/go.sum
+++ b/components/model/agenticark/go.sum
@@ -23,8 +23,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.9.1 h1:eSwgXfsaxmgTXsTgWi9OMBcm8hKvVhb1q0PPk58p6f8=
-github.com/cloudwego/eino v0.9.1/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
+github.com/cloudwego/eino v0.9.5 h1:0Nftjx9gPek/2S/hzm38LVxSjk5/6mqRr3I9VKrKvm4=
+github.com/cloudwego/eino v0.9.5/go.mod h1:OBD1mrkfkt/pJa4rkg1P0VnaMeOVl7l8IAdEqY//3IQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -78,6 +78,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -138,8 +140,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.34 h1:oty2YY90UvH05RDbDn6348Y6oS7A5Tr6kIteAjVqFlY=
-github.com/volcengine/volcengine-go-sdk v1.2.34/go.mod h1:oxoVo+A17kvkwPkIeIHPVLjSw7EQAm+l/Vau1YGHN+A=
+github.com/volcengine/volcengine-go-sdk v1.2.46 h1:HxtlSRcvMNhUUzu5GBhfa0lVoW/BoL4zZztA2PvHvlI=
+github.com/volcengine/volcengine-go-sdk v1.2.46/go.mod h1:5duonraYH9kPPB5/Ke2y63atELLRymBSgCo9ItIZqEM=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/ark/go.mod
+++ b/components/model/ark/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.11.1
-	github.com/volcengine/volcengine-go-sdk v1.2.45
+	github.com/volcengine/volcengine-go-sdk v1.2.46
 )
 
 require (

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -139,8 +139,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/volcengine/volc-sdk-golang v1.0.23 h1:anOslb2Qp6ywnsbyq9jqR0ljuO63kg9PY+4OehIk5R8=
 github.com/volcengine/volc-sdk-golang v1.0.23/go.mod h1:AfG/PZRUkHJ9inETvbjNifTDgut25Wbkm2QoYBTbvyU=
-github.com/volcengine/volcengine-go-sdk v1.2.45 h1:83UhHcCYIcN6IYKE15XyiEC73ulh9AEqxeAgHs7CmF4=
-github.com/volcengine/volcengine-go-sdk v1.2.45/go.mod h1:5duonraYH9kPPB5/Ke2y63atELLRymBSgCo9ItIZqEM=
+github.com/volcengine/volcengine-go-sdk v1.2.46 h1:HxtlSRcvMNhUUzu5GBhfa0lVoW/BoL4zZztA2PvHvlI=
+github.com/volcengine/volcengine-go-sdk v1.2.46/go.mod h1:5duonraYH9kPPB5/Ke2y63atELLRymBSgCo9ItIZqEM=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=

--- a/components/model/ark/message_extra.go
+++ b/components/model/ark/message_extra.go
@@ -24,6 +24,7 @@ import (
 const (
 	keyOfRequestID             = "ark-request-id"
 	keyOfReasoningContent      = "ark-reasoning-content"
+	keyOfRawReasoningContent   = "ark-raw-reasoning-content"
 	keyOfModelName             = "ark-model-name"
 	videoURLFPS                = "ark-model-video-url-fps"
 	keyOfContextID             = "ark-context-id"
@@ -118,6 +119,14 @@ func GetReasoningContent(msg *schema.Message) (string, bool) {
 
 func setReasoningContent(msg *schema.Message, reasoningContent string) {
 	setMsgExtra(msg, keyOfReasoningContent, reasoningContent)
+}
+
+func getRawReasoningContent(msg *schema.Message) (string, bool) {
+	return getMsgExtraValue[string](msg, keyOfRawReasoningContent)
+}
+
+func setRawReasoningContent(msg *schema.Message, reasoningContent string) {
+	setMsgExtra(msg, keyOfRawReasoningContent, reasoningContent)
 }
 
 func GetModelName(msg *schema.Message) (string, bool) {

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -139,7 +139,7 @@ type ResponsesAPIConfig struct {
 
 	// EnableReasoningContentPassback controls whether reasoning content
 	// from assistant messages is passed back to the model in multi-turn conversations.
-	// When enabled, reasoning content is included as reasoning summary items in the input,
+	// When enabled, reasoning summaries and raw reasoning content are passed back in their original form,
 	// allowing the model to be aware of its prior chain-of-thought.
 	// However, if a valid previous_response_id is set (via session cache), the passback is
 	// automatically skipped because previous_response_id already preserves the full conversation
@@ -648,12 +648,26 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 			itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_InputMessage{InputMessage: inputMessage}})
 		case schema.Assistant:
 			if enableReasoningPassback && responseReq.PreviousResponseId == nil && msg.ReasoningContent != "" {
-				itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_Reasoning{Reasoning: &responses.ItemReasoning{
-					Type: responses.ItemType_reasoning,
-					Summary: []*responses.ReasoningSummaryPart{
+				reasoning := &responses.ItemReasoning{Type: responses.ItemType_reasoning}
+				if rawReasoning, ok := getRawReasoningContent(msg); ok && rawReasoning == msg.ReasoningContent {
+					reasoning.Content = []*responses.OutputContentItem{
+						{
+							Union: &responses.OutputContentItem_Text{
+								Text: &responses.OutputContentItemText{
+									Type: responses.ContentItemType_reasoning_text,
+									Text: rawReasoning,
+								},
+							},
+						},
+					}
+				} else {
+					reasoning.Summary = []*responses.ReasoningSummaryPart{
 						{Text: msg.ReasoningContent},
-					},
-				}}})
+					}
+				}
+				itemList = append(itemList, &responses.InputItem{
+					Union: &responses.InputItem_Reasoning{Reasoning: reasoning},
+				})
 			}
 
 			inputMessage, err := cm.toArkAssistantRoleItemInputMessage(msg)
@@ -1033,6 +1047,9 @@ func (cm *ResponsesAPIChatModel) toOutputMessage(resp *responses.ResponseObject,
 		return nil, fmt.Errorf("received empty output from ARK")
 	}
 
+	var reasoningSummary strings.Builder
+	var rawReasoning strings.Builder
+
 	for _, item := range resp.Output {
 		switch asItem := item.GetUnion().(type) {
 		case *responses.OutputItem_OutputMessage:
@@ -1058,15 +1075,21 @@ func (cm *ResponsesAPIChatModel) toOutputMessage(resp *responses.ResponseObject,
 			if asItem.Reasoning == nil {
 				continue
 			}
+			for _, content := range asItem.Reasoning.GetContent() {
+				text := content.GetText()
+				if text == nil || text.GetType() != responses.ContentItemType_reasoning_text {
+					continue
+				}
+				rawReasoning.WriteString(text.GetText())
+			}
 			for _, s := range asItem.Reasoning.GetSummary() {
 				if s.Text == "" {
 					continue
 				}
-				if msg.ReasoningContent == "" {
-					msg.ReasoningContent = s.Text
-					continue
+				if reasoningSummary.Len() > 0 {
+					reasoningSummary.WriteString("\n\n")
 				}
-				msg.ReasoningContent = fmt.Sprintf("%s\n\n%s", msg.ReasoningContent, s.Text)
+				reasoningSummary.WriteString(s.Text)
 			}
 
 		case *responses.OutputItem_FunctionToolCall:
@@ -1082,6 +1105,14 @@ func (cm *ResponsesAPIChatModel) toOutputMessage(resp *responses.ResponseObject,
 				},
 			})
 		}
+	}
+
+	if rawReasoning.Len() > 0 {
+		msg.ReasoningContent = rawReasoning.String()
+		setReasoningContent(msg, msg.ReasoningContent)
+		setRawReasoningContent(msg, msg.ReasoningContent)
+	} else {
+		msg.ReasoningContent = reasoningSummary.String()
 	}
 
 	return msg, nil
@@ -1247,6 +1278,19 @@ func (cm *ResponsesAPIChatModel) receivedStreamResponse(streamReader *utils.Resp
 				ReasoningContent: delta,
 			}
 			setReasoningContent(msg, delta)
+			cm.sendCallbackOutput(sw, config, "", msg)
+
+		case *responses.Event_ReasoningRawTextDelta:
+			if ev.ReasoningRawTextDelta == nil || ev.ReasoningRawTextDelta.Delta == nil {
+				continue
+			}
+			delta := *ev.ReasoningRawTextDelta.Delta
+			msg := &schema.Message{
+				Role:             schema.Assistant,
+				ReasoningContent: delta,
+			}
+			setReasoningContent(msg, delta)
+			setRawReasoningContent(msg, delta)
 			cm.sendCallbackOutput(sw, config, "", msg)
 
 		case *responses.Event_Text:

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -18,7 +18,9 @@ package ark
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -392,6 +394,111 @@ func TestResponsesAPIChatModelPopulateInputReasoningPassback(t *testing.T) {
 		assert.Equal(t, 1, len(items))
 		assert.Nil(t, items[0].GetReasoning())
 	})
+}
+
+func TestResponsesAPIChatModelRawReasoningResponse(t *testing.T) {
+	const rawReasoning = "\n用户现在问1+1等于几，首先正常的数学答案是2。"
+	const outputText = "在最基础的十进制数学算术里，1+1=2。"
+	responseJSON := `{
+		"created_at": 1788353431,
+		"id": "mock-response-id",
+		"model": "mock-model",
+		"object": "response",
+		"output": [
+			{
+				"id": "mock-reasoning-id",
+				"type": "reasoning",
+				"status": "completed",
+				"content": [
+					{
+						"type": "reasoning_text",
+						"text": "\n用户现在问1+1等于几，首先正常的数学答案是2。"
+					}
+				]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{
+						"type": "output_text",
+						"text": "在最基础的十进制数学算术里，1+1=2。"
+					}
+				],
+				"status": "completed",
+				"id": "mock-message-id"
+			}
+		],
+		"thinking": {"type": "enabled"},
+		"status": "completed",
+		"usage": {
+			"input_tokens": 54,
+			"output_tokens": 305,
+			"total_tokens": 359,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 203}
+		}
+	}`
+
+	var resp responses.ResponseObject
+	err := json.Unmarshal([]byte(responseJSON), &resp)
+	assert.NoError(t, err)
+	if assert.Len(t, resp.Output, 2) {
+		assert.Len(t, resp.Output[0].GetReasoning().GetContent(), 1,
+			"SDK must preserve reasoning.content from the API response")
+	}
+
+	cm := &ResponsesAPIChatModel{}
+	msg, err := cm.toOutputMessage(&resp, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, rawReasoning, msg.ReasoningContent)
+	assert.Equal(t, outputText, msg.Content)
+	raw, ok := getRawReasoningContent(msg)
+	assert.True(t, ok)
+	assert.Equal(t, rawReasoning, raw)
+
+	req := &responses.ResponsesRequest{Model: "mock-model"}
+	err = cm.populateInput([]*schema.Message{msg}, req, true)
+	assert.NoError(t, err)
+	items := req.GetInput().GetListValue().GetListValue()
+	if assert.Len(t, items, 2) {
+		reasoning := items[0].GetReasoning()
+		if assert.NotNil(t, reasoning) {
+			assert.Empty(t, reasoning.GetSummary())
+			if assert.Len(t, reasoning.GetContent(), 1) {
+				assert.Equal(t, responses.ContentItemType_reasoning_text, reasoning.GetContent()[0].GetText().GetType())
+				assert.Equal(t, rawReasoning, reasoning.GetContent()[0].GetText().GetText())
+			}
+		}
+	}
+}
+
+func TestResponsesAPIChatModelReasoningSummaryResponse(t *testing.T) {
+	cm := &ResponsesAPIChatModel{}
+	msg, err := cm.toOutputMessage(&responses.ResponseObject{
+		Status: responses.ResponseStatus_completed,
+		Output: []*responses.OutputItem{
+			{
+				Union: &responses.OutputItem_Reasoning{
+					Reasoning: &responses.ItemReasoning{
+						Summary: []*responses.ReasoningSummaryPart{
+							{Text: "first summary"},
+							{Text: "second summary"},
+						},
+					},
+				},
+			},
+		},
+		Usage: &responses.Usage{
+			InputTokensDetails:  &responses.InputTokensDetails{},
+			OutputTokensDetails: &responses.OutputTokensDetails{},
+		},
+	}, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "first summary\n\nsecond summary", msg.ReasoningContent)
+	_, ok := getRawReasoningContent(msg)
+	assert.False(t, ok)
 }
 
 func TestResponsesAPIChatModelToOpenaiMultiModalContent(t *testing.T) {
@@ -783,6 +890,46 @@ func TestResponsesAPIChatModelReceivedStreamResponse_Default(t *testing.T) {
 		assert.Equal(t, 1, mocker.Times())
 
 	})
+}
+
+func TestResponsesAPIChatModelReceivedStreamResponse_RawReasoning(t *testing.T) {
+	const eventStream = "event: response.reasoning_text.delta\n" +
+		"data: {\"type\":\"response.reasoning_text.delta\",\"content_index\":0," +
+		"\"delta\":\"raw \",\"item_id\":\"mock-reasoning-id\",\"output_index\":0,\"sequence_number\":1}\n\n" +
+		"event: response.reasoning_text.delta\n" +
+		"data: {\"type\":\"response.reasoning_text.delta\",\"content_index\":0," +
+		"\"delta\":\"reasoning\",\"item_id\":\"mock-reasoning-id\",\"output_index\":0,\"sequence_number\":2}\n\n" +
+		"data: [DONE]\n\n"
+
+	body := io.NopCloser(strings.NewReader(eventStream))
+	streamReader := &utils.ResponsesStreamReader{
+		ChatCompletionStreamReader: utils.ChatCompletionStreamReader{
+			Unmarshaler: &utils.JSONUnmarshaler{},
+		},
+		Decoder: utils.NewEventStreamDecoder(body),
+	}
+	sr, sw := schema.Pipe[*model.CallbackOutput](2)
+	defer sr.Close()
+
+	cm := &ResponsesAPIChatModel{}
+	cm.receivedStreamResponse(streamReader, &model.Config{}, nil, sw)
+	sw.Close()
+
+	chunks := make([]*schema.Message, 0, 2)
+	for i := 0; i < 2; i++ {
+		output, err := sr.Recv()
+		assert.NoError(t, err)
+		if assert.NotNil(t, output) && assert.NotNil(t, output.Message) {
+			chunks = append(chunks, output.Message)
+		}
+	}
+
+	msg, err := schema.ConcatMessages(chunks)
+	assert.NoError(t, err)
+	assert.Equal(t, "raw reasoning", msg.ReasoningContent)
+	raw, ok := getRawReasoningContent(msg)
+	assert.True(t, ok)
+	assert.Equal(t, "raw reasoning", raw)
 }
 
 func TestResponsesAPIChatModelReceivedStreamResponse_ToolCallMetaMsg(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] No user documentation update is required because this fixes existing response conversion behavior without introducing a new public API.

#### (Optional) Translate the PR title into Chinese.

fix(agenticark): 保留 Ark Responses API 返回的原始思维链内容

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

Ark Responses API can return raw reasoning content in `reasoning.content` when thinking summary compression is disabled. Previously, agenticark only converted `reasoning.summary`, causing the raw reasoning content to be dropped.

This PR:

- upgrades the Volcengine Go SDK to support `reasoning.content` and raw reasoning stream events;
- preserves raw reasoning content in `schema.Reasoning.OpenAIExtension.Content`;
- preserves encrypted reasoning content and supports passing raw reasoning back in subsequent requests;
- handles raw reasoning content in both streaming and non-streaming responses;
- adds regression tests based on the reported `skip-thinking-summary` response.

zh(optional):

当关闭思维链摘要压缩时，Ark Responses API 会通过 `reasoning.content` 返回原始思维链。此前 agenticark 仅转换 `reasoning.summary`，导致原始思维链内容丢失。

本 PR：

- 升级 Volcengine Go SDK，以支持 `reasoning.content` 和原始思维链流式事件；
- 将原始思维链保留至 `schema.Reasoning.OpenAIExtension.Content`；
- 保留加密思维链内容，并支持在后续请求中回传原始思维链；
- 同时兼容流式和非流式响应；
- 基于用户反馈的 `skip-thinking-summary` 响应补充回归测试。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A