### PR TITLE
fix(ark): support EnhancedTool text results in Responses API

### DIFF
--- a/components/model/ark/go.mod
+++ b/components/model/ark/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/bytedance/mockey v1.2.14
 	github.com/bytedance/sonic v1.15.0
-	github.com/cloudwego/eino v0.7.13
+	github.com/cloudwego/eino v0.7.37
 	github.com/eino-contrib/jsonschema v1.0.3
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/stretchr/testify v1.11.1

--- a/components/model/ark/go.sum
+++ b/components/model/ark/go.sum
@@ -23,8 +23,8 @@ github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEex
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
-github.com/cloudwego/eino v0.7.13 h1:Ku7hY+83gGJJjf4On3UgqjC57UcA+DXe0tqAZiNDDew=
-github.com/cloudwego/eino v0.7.13/go.mod h1:nA8Vacmuqv3pqKBQbTWENBLQ8MmGmPt/WqiyLeB8ohQ=
+github.com/cloudwego/eino v0.7.37 h1:T73Y/8X7ERW4h3jP+brB/I4+N5ATDyGLx5bs2H4ev8I=
+github.com/cloudwego/eino v0.7.37/go.mod h1:nA8Vacmuqv3pqKBQbTWENBLQ8MmGmPt/WqiyLeB8ohQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/model/ark/responses_api.go
+++ b/components/model/ark/responses_api.go
@@ -682,14 +682,15 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 
 			itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_InputMessage{InputMessage: inputMessage}})
 		case schema.Tool:
-			if len(msg.UserInputMultiContent) > 0 {
-				return fmt.Errorf("ark response api doesn't support multi modal tool result")
+			output, err := convToolResultToString(msg)
+			if err != nil {
+				return err
 			}
 			itemList = append(itemList, &responses.InputItem{Union: &responses.InputItem_FunctionToolCallOutput{
 				FunctionToolCallOutput: &responses.ItemFunctionToolCallOutput{
 					Type:   responses.ItemType_function_call_output,
 					CallId: msg.ToolCallID,
-					Output: msg.Content,
+					Output: output,
 				},
 			}})
 
@@ -705,6 +706,21 @@ func (cm *ResponsesAPIChatModel) populateInput(in []*schema.Message, responseReq
 		},
 	}
 	return nil
+}
+
+func convToolResultToString(msg *schema.Message) (string, error) {
+	if len(msg.UserInputMultiContent) == 0 {
+		return msg.Content, nil
+	}
+
+	var output strings.Builder
+	for i, part := range msg.UserInputMultiContent {
+		if part.Type != schema.ChatMessagePartTypeText {
+			return "", fmt.Errorf("volcengine go sdk currently only supports text tool result, got type %s at index %d", part.Type, i)
+		}
+		output.WriteString(part.Text)
+	}
+	return output.String(), nil
 }
 
 func (cm *ResponsesAPIChatModel) populateTools(responseReq *responses.ResponsesRequest, options *model.Options, enableToolWebSearch *ToolWebSearch, maxToolCalls *int64) error {

--- a/components/model/ark/responses_api_test.go
+++ b/components/model/ark/responses_api_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/bytedance/mockey"
 	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components/model"
+	toolcomponent "github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
 	"github.com/cloudwego/eino/schema"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,23 @@ import (
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/model/responses"
 	"github.com/volcengine/volcengine-go-sdk/service/arkruntime/utils"
 )
+
+type textEnhancedTool struct{}
+
+func (t *textEnhancedTool) Info(context.Context) (*schema.ToolInfo, error) {
+	return &schema.ToolInfo{
+		Name: "text_enhanced_tool",
+		Desc: "returns a text-only enhanced tool result",
+	}, nil
+}
+
+func (t *textEnhancedTool) InvokableRun(context.Context, *schema.ToolArgument, ...toolcomponent.Option) (*schema.ToolResult, error) {
+	return &schema.ToolResult{
+		Parts: []schema.ToolOutputPart{
+			{Type: schema.ToolPartTypeText, Text: "enhanced tool output"},
+		},
+	}, nil
+}
 
 func TestResponsesAPIChatModelGenerate(t *testing.T) {
 	PatchConvey("test Generate", t, func() {
@@ -214,6 +233,54 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 		assert.Equal(t, "tool output", item.Output)
 	})
 
+	PatchConvey("tool call with text-only multi content", t, func() {
+		req := &responses.ResponsesRequest{
+			Model: "test-model",
+		}
+		in := []*schema.Message{
+			{
+				Role:       schema.Tool,
+				ToolCallID: "call_123",
+				UserInputMultiContent: []schema.MessageInputPart{
+					{Type: schema.ChatMessagePartTypeText, Text: "tool "},
+					{Type: schema.ChatMessagePartTypeText, Text: "output"},
+				},
+			},
+		}
+
+		err := cm.populateInput(in, req, false)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(req.GetInput().GetListValue().GetListValue()))
+
+		item := req.GetInput().GetListValue().GetListValue()[0].GetFunctionToolCallOutput()
+		assert.Equal(t, "call_123", item.CallId)
+		assert.Equal(t, "tool output", item.Output)
+	})
+
+	PatchConvey("tool call with non-text multi content", t, func() {
+		req := &responses.ResponsesRequest{
+			Model: "test-model",
+		}
+		imageURL := "https://example.com/tool-output.png"
+		in := []*schema.Message{
+			{
+				Role:       schema.Tool,
+				ToolCallID: "call_123",
+				UserInputMultiContent: []schema.MessageInputPart{
+					{
+						Type: schema.ChatMessagePartTypeImageURL,
+						Image: &schema.MessageInputImage{
+							MessagePartCommon: schema.MessagePartCommon{URL: &imageURL},
+						},
+					},
+				},
+			},
+		}
+
+		err := cm.populateInput(in, req, false)
+		assert.ErrorContains(t, err, "only supports text tool result")
+	})
+
 	PatchConvey("unknown role", t, func() {
 		req := &responses.ResponsesRequest{
 			Model: "test-model",
@@ -227,6 +294,45 @@ func TestResponsesAPIChatModelInjectInput(t *testing.T) {
 		err := cm.populateInput(in, req, false)
 		assert.NotNil(t, err)
 	})
+}
+
+func TestResponsesAPIChatModelPopulateInputFromEnhancedTool(t *testing.T) {
+	ctx := context.Background()
+	toolNode, err := compose.NewToolNode(ctx, &compose.ToolsNodeConfig{
+		Tools: []toolcomponent.BaseTool{&textEnhancedTool{}},
+	})
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	toolMessages, err := toolNode.Invoke(ctx, schema.AssistantMessage("", []schema.ToolCall{
+		{
+			ID: "call_enhanced",
+			Function: schema.FunctionCall{
+				Name:      "text_enhanced_tool",
+				Arguments: `{}`,
+			},
+		},
+	}))
+	assert.NoError(t, err)
+	assert.Len(t, toolMessages, 1)
+	if err != nil || len(toolMessages) != 1 {
+		return
+	}
+	assert.Empty(t, toolMessages[0].Content)
+	assert.Len(t, toolMessages[0].UserInputMultiContent, 1)
+
+	req := &responses.ResponsesRequest{Model: "test-model"}
+	err = (&ResponsesAPIChatModel{}).populateInput(toolMessages, req, false)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	item := req.GetInput().GetListValue().GetListValue()[0].GetFunctionToolCallOutput()
+	assert.Equal(t, "call_enhanced", item.CallId)
+	assert.Equal(t, "enhanced tool output", item.Output)
 }
 
 func TestResponsesAPIChatModelPopulateInputReasoningPassback(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

fix(ark): 支持 Responses API 处理 EnhancedTool 的文本结果

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

EnhancedTool stores structured results in `Message.UserInputMultiContent`, including text-only results. The Ark Responses API adapter previously rejected any non-empty `UserInputMultiContent` as a multimodal tool result, causing text-only EnhancedTool calls to fail.

This PR:
- Converts text-only tool result parts into `function_call_output.output`.
- Concatenates multiple text parts in their original order.
- Preserves the existing string-based tool result behavior.
- Returns a precise error for non-text results that the current Volcengine Go SDK cannot represent.
- Adds a regression test covering the complete `EnhancedTool -> ToolsNode.Invoke -> Responses API input conversion` path.
- Upgrades Eino to v0.7.37 to exercise EnhancedTool in the integration-style unit test.

zh(optional):

EnhancedTool 会将结构化结果写入 `Message.UserInputMultiContent`，即使结果只包含文本。此前 Ark Responses API 适配器会将所有非空的 `UserInputMultiContent` 判定为多模态工具结果，导致纯文本 EnhancedTool 调用失败。

本 PR：
- 将纯文本工具结果转换为 `function_call_output.output`。
- 按原始顺序拼接多个文本 part。
- 保持原有字符串工具结果行为不变。
- 对当前 Volcengine Go SDK 无法表达的非文本结果返回准确错误。
- 增加完整覆盖 `EnhancedTool -> ToolsNode.Invoke -> Responses API 输入转换` 链路的回归测试。
- 将 Eino 升级至 v0.7.37，以支持 EnhancedTool 测试。

#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation:

N/A