### PR TITLE
fix(langfuse): preserve agent outcomes through retries and callback panics

### DIFF
--- a/callbacks/langfuse/v2/README.md
+++ b/callbacks/langfuse/v2/README.md
@@ -124,6 +124,11 @@ User-initiated `context.Canceled` callbacks are exported with the default Langfu
 
 Inside an ADK agent, failed model, tool, and nested-agent observations retain their own errors. They do not mark the application root as failed: the outermost agent determines whether the failure is terminal. `adk.WillRetryError` events and message-stream errors are recovery notifications and do not fail the agent observation. Retry exhaustion and other terminal agent errors still fail both the agent and the root, even if partial output was produced. This behavior is independent of `CollapseAgentInternalSpans`. Calls outside an agent retain their existing root-error propagation.
 
+Agent metadata retains retry notifications in `eino_retry_events` (operation, the SDK's attempt value, error, and rejection reason), including responses rejected by `ShouldRetry` after a successful provider call. `eino_retry_event_count` counts observed notifications, not completed retries; exhaustion can also emit a notification, and attempt numbering is preserved from Eino. Error-valued reasons are stored as text; structured reasons remain JSON, with a text fallback for values that cannot be serialized. These diagnostics respect attribute limits and do not change the Agent's error level.
+
+Root output prefers a nonempty explicit `EndTrace` result, then context termination output (cancellation, interruption, or timeout), then the outermost Agent result. Nested calls cannot overwrite that Agent result, including an empty result, regardless of callback completion order. Calls without an Agent retain the last child output as a fallback.
+
+
 Resumable Eino tool, graph, subgraph, and ADK business interrupts are exported
 with the default Langfuse level and an `interrupted` status instead of `ERROR`.
 The interrupt cause remains available in structured observation output and

--- a/callbacks/langfuse/v2/README.md
+++ b/callbacks/langfuse/v2/README.md
@@ -128,6 +128,9 @@ Agent metadata retains retry notifications in `eino_retry_events` (operation, th
 
 Root output prefers a nonempty explicit `EndTrace` result, then context termination output (cancellation, interruption, or timeout), then the outermost Agent result. Nested calls cannot overwrite that Agent result, including an empty result, regardless of callback completion order. Calls without an Agent retain the last child output as a fallback.
 
+Callback-owned goroutines recover and log panics with stack traces. A terminal collector panic records `eino_callback_panic` diagnostics and ends its observation, releasing the root's child count; already recorded output is preserved. An input collector panic records the diagnostic before unblocking input completion, allowing the normal end/error callback to capture the final result and finish the span. Callback panics mark the affected observation as an internal telemetry error but do not independently fail the application root. Root metadata retains the diagnostic, and existing business failures remain errors.
+
+
 
 Resumable Eino tool, graph, subgraph, and ADK business interrupts are exported
 with the default Langfuse level and an `interrupted` status instead of `ERROR`.

--- a/callbacks/langfuse/v2/README.md
+++ b/callbacks/langfuse/v2/README.md
@@ -122,6 +122,8 @@ Call `EndTrace` when the root operation completes. It records the final output a
 
 User-initiated `context.Canceled` callbacks are exported with the default Langfuse level, a `cancelled` status message, and cancellation metadata instead of being counted as errors. `context.DeadlineExceeded` and other callback failures remain errors.
 
+Inside an ADK agent, failed model, tool, and nested-agent observations retain their own errors. They do not mark the application root as failed: the outermost agent determines whether the failure is terminal. `adk.WillRetryError` events and message-stream errors are recovery notifications and do not fail the agent observation. Retry exhaustion and other terminal agent errors still fail both the agent and the root, even if partial output was produced. This behavior is independent of `CollapseAgentInternalSpans`. Calls outside an agent retain their existing root-error propagation.
+
 Resumable Eino tool, graph, subgraph, and ADK business interrupts are exported
 with the default Langfuse level and an `interrupted` status instead of `ERROR`.
 The interrupt cause remains available in structured observation output and

--- a/callbacks/langfuse/v2/README_zh.md
+++ b/callbacks/langfuse/v2/README_zh.md
@@ -80,6 +80,11 @@ func main() {
 
 ADK Agent 内的模型、工具和子 Agent 调用失败时，各自 observation 保留错误；是否让应用 root 失败，由最外层 Agent 的终止错误决定。事件或消息流中的 `adk.WillRetryError` 表示恢复过程，不会标记 Agent 失败。重试耗尽、预算或迭代限制等终止错误仍会让 Agent 和 root 显示错误，即使之前已经产生部分输出。这一行为不依赖 `CollapseAgentInternalSpans`；没有 Agent 包裹的调用仍沿用原有的 root 错误传播方式。
 
+Agent metadata 中的 `eino_retry_events` 保留重试通知的 operation、SDK 原始 attempt 值、错误和拒绝原因，也涵盖供应商正常返回后被 `ShouldRetry` 拒绝的情况。`eino_retry_event_count` 统计收到的通知数，不等于实际执行的重试次数；耗尽时也可能产生通知，attempt 编号沿用 Eino。error 类型的拒绝原因保存为文本，结构化原因保留 JSON，无法序列化时回退到文本。这些诊断信息遵循属性大小限制，不改变 Agent 的错误级别。
+
+根节点输出依次优先采用：非空的显式 `EndTrace` 结果、上下文终止结果（取消、中断或超时）、最外层 Agent 结果。无论回调结束顺序如何，嵌套调用都不能覆盖 Agent 结果，包括空结果。没有 Agent 的调用仍使用最后一个子调用输出兜底。
+
+
 ## Trace 精简
 
 设置 `Config.CollapseAgentInternalSpans` 可折叠 Eino Agent 下同名的内部 Chain、内部 `ReAct` Graph、`Init` Lambda，以及匿名或默认命名的 Lambda 包装层。默认关闭，以保留完整的框架 trace。Generation、Tool 和 Sub-Agent 会通过标准 OTel context 继续挂在最近的保留父节点下。

--- a/callbacks/langfuse/v2/README_zh.md
+++ b/callbacks/langfuse/v2/README_zh.md
@@ -78,6 +78,8 @@ func main() {
 
 用户主动触发的 `context.Canceled` 会记录为 `cancelled`，可恢复的 Eino Tool、Graph、SubGraph 和 ADK interrupt 会记录为 `interrupted`，两者都不会统一标记成 `ERROR`。真正的超时和 callback 失败仍会标记为错误。
 
+ADK Agent 内的模型、工具和子 Agent 调用失败时，各自 observation 保留错误；是否让应用 root 失败，由最外层 Agent 的终止错误决定。事件或消息流中的 `adk.WillRetryError` 表示恢复过程，不会标记 Agent 失败。重试耗尽、预算或迭代限制等终止错误仍会让 Agent 和 root 显示错误，即使之前已经产生部分输出。这一行为不依赖 `CollapseAgentInternalSpans`；没有 Agent 包裹的调用仍沿用原有的 root 错误传播方式。
+
 ## Trace 精简
 
 设置 `Config.CollapseAgentInternalSpans` 可折叠 Eino Agent 下同名的内部 Chain、内部 `ReAct` Graph、`Init` Lambda，以及匿名或默认命名的 Lambda 包装层。默认关闭，以保留完整的框架 trace。Generation、Tool 和 Sub-Agent 会通过标准 OTel context 继续挂在最近的保留父节点下。

--- a/callbacks/langfuse/v2/README_zh.md
+++ b/callbacks/langfuse/v2/README_zh.md
@@ -84,6 +84,9 @@ Agent metadata 中的 `eino_retry_events` 保留重试通知的 operation、SDK 
 
 根节点输出依次优先采用：非空的显式 `EndTrace` 结果、上下文终止结果（取消、中断或超时）、最外层 Agent 结果。无论回调结束顺序如何，嵌套调用都不能覆盖 Agent 结果，包括空结果。没有 Agent 的调用仍使用最后一个子调用输出兜底。
 
+回调自身的 goroutine 会恢复 panic 并记录堆栈。结束阶段的采集回调发生 panic 时，会记录 `eino_callback_panic` 诊断并结束 observation，释放根节点的子调用计数，同时保留已记录的输出。输入采集 panic 会先记录诊断再解除输入等待，由正常的结束或错误回调保存最终结果并收尾。回调 panic 将受影响的 observation 标记为遥测内部错误，不单独将应用根节点判为业务失败；根节点 metadata 保留诊断，已有业务错误继续保留。
+
+
 
 ## Trace 精简
 

--- a/callbacks/langfuse/v2/agent_error_scope_test.go
+++ b/callbacks/langfuse/v2/agent_error_scope_test.go
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package langfuse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// scopeModel emits the same model callbacks as a streaming provider. The ADK
+// retry/failover wrappers and agent callbacks are real, including both the raw
+// failed generation and the WillRetryError received by the agent collector.
+type scopeModel struct {
+	name     string
+	failures int32
+	calls    atomic.Int32
+}
+
+func (m *scopeModel) IsCallbacksEnabled() bool                                         { return true }
+func (m *scopeModel) WithTools([]*schema.ToolInfo) (model.ToolCallingChatModel, error) { return m, nil }
+func (m *scopeModel) Generate(context.Context, []*schema.Message, ...model.Option) (*schema.Message, error) {
+	return nil, errors.New("test requires streaming")
+}
+func (m *scopeModel) Stream(ctx context.Context, input []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	ctx = callbacks.EnsureRunInfo(ctx, m.name, components.ComponentOfChatModel)
+	ctx = callbacks.OnStart(ctx, &model.CallbackInput{Messages: input})
+	r, w := schema.Pipe[*model.CallbackOutput](2)
+	w.Send(&model.CallbackOutput{Message: schema.AssistantMessage("partial", nil)}, nil)
+	if m.calls.Add(1) <= m.failures {
+		w.Send(nil, errors.New("provider stream failed"))
+	} else {
+		w.Send(&model.CallbackOutput{Message: &schema.Message{Role: schema.Assistant, Content: " done", ResponseMeta: &schema.ResponseMeta{FinishReason: "stop"}}}, nil)
+	}
+	w.Close()
+	_, r = callbacks.OnEndWithStreamOutput(ctx, r)
+	return schema.StreamReaderWithConvert(r, func(out *model.CallbackOutput) (*schema.Message, error) {
+		// ADK assigns message IDs to its stream. Keep the provider's callback
+		// snapshot separate so the test does not share mutable message structs.
+		msg := *out.Message
+		return &msg, nil
+	}), nil
+}
+
+func TestAgentErrorScopeADKRecovery(t *testing.T) {
+	for _, collapse := range []bool{false, true} {
+		for _, mode := range []string{"retry", "failover", "exhausted"} {
+			t.Run(fmt.Sprintf("%s/collapse=%v", mode, collapse), func(t *testing.T) {
+				h, exporter := newScopeHandler(t, collapse)
+				ctx := h.StartTrace(context.Background(), WithName("root"))
+				primary := &scopeModel{name: "primary", failures: 1}
+				backup := &scopeModel{name: "backup"}
+				cfg := &adk.ChatModelAgentConfig{Name: "writer", Model: primary, ModelRetryConfig: &adk.ModelRetryConfig{
+					MaxRetries:  1,
+					BackoffFunc: func(context.Context, int) time.Duration { return time.Nanosecond },
+					ShouldRetry: func(_ context.Context, r *adk.RetryContext) *adk.RetryDecision {
+						return &adk.RetryDecision{Retry: r.Err != nil}
+					},
+				}}
+				if mode == "exhausted" {
+					primary.failures = 2
+				}
+				if mode == "failover" {
+					cfg.ModelRetryConfig.MaxRetries = 0
+					cfg.ModelFailoverConfig = &adk.ModelFailoverConfig[*schema.Message]{
+						MaxRetries:     1,
+						ShouldFailover: func(_ context.Context, _ *schema.Message, err error) bool { return err != nil },
+						GetFailoverModel: func(context.Context, *adk.FailoverContext[*schema.Message]) (model.BaseChatModel, []*schema.Message, error) {
+							return backup, nil, nil
+						},
+					}
+				}
+				agent, err := adk.NewChatModelAgent(ctx, cfg)
+				if err != nil {
+					t.Fatal(err)
+				}
+				iter := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, EnableStreaming: true}).Run(ctx, []*schema.Message{schema.UserMessage("write")}, adk.WithCallbacks(h))
+				var terminal error
+				var final string
+				for {
+					event, ok := iter.Next()
+					if !ok {
+						break
+					}
+					if event.Err != nil {
+						terminal = event.Err
+					}
+					if event.Output != nil && event.Output.MessageOutput != nil {
+						msg, err := event.Output.MessageOutput.GetMessage()
+						if err == nil && msg != nil {
+							final = msg.Content
+						}
+					}
+				}
+				h.EndTrace(ctx, "")
+				flushScope(t, h)
+				wantFailure := mode == "exhausted"
+				if (terminal != nil) != wantFailure {
+					t.Fatalf("terminal=%v, want failure=%v", terminal, wantFailure)
+				}
+				if !wantFailure && final != "partial done" {
+					t.Fatalf("final=%q", final)
+				}
+				assertScopeError(t, exporter, "root", wantFailure)
+				assertScopeError(t, exporter, "writer", wantFailure)
+				failedGenerations := 0
+				for _, span := range exporter.GetSpans() {
+					attrs := attributesByKey(span.Attributes)
+					if attrs["langfuse.observation.type"].Value.AsString() == "generation" && span.Status.Code == codes.Error {
+						failedGenerations++
+					}
+				}
+				wantFailedGenerations := 1
+				if wantFailure {
+					wantFailedGenerations = 2
+				}
+				if failedGenerations != wantFailedGenerations {
+					t.Fatalf("failed generations=%d, want %d", failedGenerations, wantFailedGenerations)
+				}
+				if primary.calls.Load()+backup.calls.Load() != 2 {
+					t.Fatal("expected two real model attempts")
+				}
+			})
+		}
+	}
+}
+
+func TestAgentErrorScopeEventForms(t *testing.T) {
+	for _, typed := range []bool{false, true} {
+		for _, terminal := range []error{nil, errors.New("budget limit"), adk.ErrExceedMaxIterations} {
+			t.Run(fmt.Sprintf("typed=%v/terminal=%v", typed, terminal), func(t *testing.T) {
+				h, exporter := newScopeHandler(t, false)
+				ctx := h.StartTrace(context.Background(), WithName("root"))
+				component := adk.ComponentOfAgent
+				if typed {
+					component = adk.ComponentOfAgenticAgent
+				}
+				info := &callbacks.RunInfo{Name: "agent", Component: component}
+				aCtx := h.OnStart(ctx, info, nil)
+				retryErr := fmt.Errorf("wrapped: %w", &adk.WillRetryError{ErrStr: "retry", RetryAttempt: 1})
+				if typed {
+					events, sender := adk.NewAsyncIteratorPair[*adk.TypedAgentEvent[*schema.AgenticMessage]]()
+					h.OnEnd(aCtx, info, &adk.TypedAgentCallbackOutput[*schema.AgenticMessage]{Events: events})
+					sender.Send(&adk.TypedAgentEvent[*schema.AgenticMessage]{Err: retryErr})
+					r, w := schema.Pipe[*schema.AgenticMessage](1)
+					w.Send(nil, retryErr)
+					w.Close()
+					sender.Send(&adk.TypedAgentEvent[*schema.AgenticMessage]{Output: &adk.TypedAgentOutput[*schema.AgenticMessage]{MessageOutput: &adk.TypedMessageVariant[*schema.AgenticMessage]{IsStreaming: true, MessageStream: r}}})
+					if terminal != nil {
+						sender.Send(&adk.TypedAgentEvent[*schema.AgenticMessage]{Err: terminal})
+					}
+					sender.Close()
+				} else {
+					events, sender := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+					h.OnEnd(aCtx, info, &adk.AgentCallbackOutput{Events: events})
+					sender.Send(&adk.AgentEvent{Err: retryErr})
+					r, w := schema.Pipe[*schema.Message](1)
+					w.Send(nil, retryErr)
+					w.Close()
+					sender.Send(&adk.AgentEvent{Output: &adk.AgentOutput{MessageOutput: &adk.MessageVariant{IsStreaming: true, MessageStream: r}}})
+					if terminal != nil {
+						sender.Send(&adk.AgentEvent{Err: terminal})
+					}
+					sender.Close()
+				}
+				h.EndTrace(ctx, "")
+				flushScope(t, h)
+				assertScopeError(t, exporter, "root", terminal != nil)
+				assertScopeError(t, exporter, "agent", terminal != nil)
+			})
+		}
+	}
+}
+
+func TestAgentErrorScopeNestedAndStandalone(t *testing.T) {
+	for _, collapse := range []bool{false, true} {
+		t.Run(fmt.Sprint(collapse), func(t *testing.T) {
+			h, exporter := newScopeHandler(t, collapse)
+			ctx := h.StartTrace(context.Background(), WithName("root"))
+			outer := &callbacks.RunInfo{Name: "outer", Component: adk.ComponentOfAgent}
+			aCtx := h.OnStart(ctx, outer, nil)
+			child := &callbacks.RunInfo{Name: "child", Component: adk.ComponentOfAgent}
+			childCtx := h.OnStart(aCtx, child, nil)
+			h.OnError(childCtx, child, errors.New("child failed, handled by outer"))
+			tool := &callbacks.RunInfo{Name: "tool", Component: components.ComponentOfTool}
+			toolCtx := h.OnStart(aCtx, tool, nil)
+			h.OnError(toolCtx, tool, errors.New("tool failed, handled by outer"))
+			// A new root nested in an agent context is independent of that agent.
+			independent := h.StartTrace(aCtx, WithName("independent-root"))
+			modelInfo := &callbacks.RunInfo{Name: "standalone-model", Component: components.ComponentOfChatModel}
+			modelCtx := h.OnStart(independent, modelInfo, &model.CallbackInput{})
+			h.OnError(modelCtx, modelInfo, errors.New("standalone failure"))
+			h.EndTrace(independent, "")
+			h.OnEnd(aCtx, outer, "recovered")
+			h.EndTrace(ctx, "recovered")
+			flushScope(t, h)
+			for _, name := range []string{"root", "outer"} {
+				assertScopeError(t, exporter, name, false)
+			}
+			for _, name := range []string{"child", "tool", "independent-root", "standalone-model"} {
+				assertScopeError(t, exporter, name, true)
+			}
+		})
+	}
+}
+
+func TestAgentErrorScopeLateChildAndCancellation(t *testing.T) {
+	for _, terminal := range []bool{false, true} {
+		t.Run(fmt.Sprint(terminal), func(t *testing.T) {
+			h, exporter := newScopeHandler(t, false)
+			base, cancel := context.WithCancelCause(context.Background())
+			defer cancel(nil)
+			ctx := h.StartTrace(base, WithName("root"))
+			info := &callbacks.RunInfo{Name: "agent", Component: adk.ComponentOfAgent}
+			aCtx := h.OnStart(ctx, info, nil)
+			modelInfo := &callbacks.RunInfo{Name: "late-model", Component: components.ComponentOfChatModel}
+			modelCtx := h.OnStart(aCtx, modelInfo, &model.CallbackInput{})
+			r, w := schema.Pipe[callbacks.CallbackOutput](1)
+			h.OnEndWithStreamOutput(modelCtx, modelInfo, r)
+			if terminal {
+				h.OnError(aCtx, info, errors.New("terminal failure"))
+			} else {
+				h.OnEnd(aCtx, info, "done")
+			}
+			// Complete the agent collector before cancellation, while the model
+			// collector remains blocked. A late child must never change its result.
+			state := spanStateFromContext(aCtx)
+			deadline := time.After(time.Second)
+			for state.span.IsRecording() {
+				select {
+				case <-deadline:
+					t.Fatal("agent callback did not finish")
+				case <-time.After(time.Millisecond):
+				}
+			}
+			cancel(errors.New("generation stopped by user"))
+			h.EndTrace(ctx, "done")
+			w.Send(nil, errors.New("late stream error"))
+			w.Close()
+			flushScope(t, h)
+			assertScopeError(t, exporter, "root", terminal)
+			assertScopeError(t, exporter, "late-model", true)
+		})
+	}
+}
+
+func TestAgentErrorScopeInterruptedToolKeepsRootStatus(t *testing.T) {
+	h, exporter := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	info := &callbacks.RunInfo{Name: "agent", Component: adk.ComponentOfAgent}
+	aCtx := h.OnStart(ctx, info, nil)
+	tool := &callbacks.RunInfo{Name: "chapter", Component: components.ComponentOfTool}
+	toolCtx := h.OnStart(aCtx, tool, nil)
+	h.OnError(toolCtx, tool, compose.Interrupt(toolCtx, "awaiting confirmation"))
+	h.OnEnd(aCtx, info, nil)
+	h.EndTrace(ctx, "")
+	flushScope(t, h)
+	assertScopeError(t, exporter, "root", false)
+	attrs := attributesByKey(spanByName(t, exporter.GetSpans(), "root").Attributes)
+	assertStringAttribute(t, attrs, "langfuse.observation.metadata.eino_callback_interrupted", "true")
+}
+
+func newScopeHandler(t *testing.T, collapse bool) (*CallbackHandler, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	h, err := NewHandler(context.Background(), &Config{TracerProvider: provider, CollapseAgentInternalSpans: collapse})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { h.Shutdown(context.Background()); provider.Shutdown(context.Background()) })
+	return h, exporter
+}
+
+func flushScope(t *testing.T, h *CallbackHandler) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := h.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertScopeError(t *testing.T, exporter *tracetest.InMemoryExporter, name string, want bool) {
+	t.Helper()
+	span := spanByName(t, exporter.GetSpans(), name)
+	attrs := attributesByKey(span.Attributes)
+	if got := span.Status.Code == codes.Error; got != want {
+		t.Fatalf("%s OTel status=%v, want error=%v", name, span.Status, want)
+	}
+	if got := attrs["langfuse.observation.level"].Value.AsString() == "ERROR"; got != want {
+		t.Fatalf("%s Langfuse level=%v, want error=%v", name, attrs["langfuse.observation.level"], want)
+	}
+}

--- a/callbacks/langfuse/v2/agent_error_scope_test.go
+++ b/callbacks/langfuse/v2/agent_error_scope_test.go
@@ -18,6 +18,7 @@ package langfuse
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -152,6 +153,82 @@ func TestAgentErrorScopeADKRecovery(t *testing.T) {
 	}
 }
 
+func TestAgentRetryDiagnosticsForRejectedResponses(t *testing.T) {
+	for _, exhausted := range []bool{false, true} {
+		for _, reason := range []any{"empty content", errors.New("invalid finish reason"), map[string]any{"code": "invalid_output"}, make(chan int)} {
+			t.Run(fmt.Sprintf("exhausted=%v/reason=%T", exhausted, reason), func(t *testing.T) {
+				h, exporter := newScopeHandler(t, true)
+				ctx := h.StartTrace(context.Background(), WithName("root"))
+				m := &scopeModel{name: "provider"}
+				agent, err := adk.NewChatModelAgent(ctx, &adk.ChatModelAgentConfig{Name: "writer", Model: m, ModelRetryConfig: &adk.ModelRetryConfig{
+					MaxRetries: 1, BackoffFunc: func(context.Context, int) time.Duration { return time.Nanosecond },
+					ShouldRetry: func(_ context.Context, r *adk.RetryContext) *adk.RetryDecision {
+						if exhausted || m.calls.Load() == 1 {
+							return &adk.RetryDecision{Retry: true, RejectReason: reason}
+						}
+						return nil
+					},
+				}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				it := adk.NewRunner(ctx, adk.RunnerConfig{Agent: agent, EnableStreaming: true}).Run(ctx, []*schema.Message{schema.UserMessage("test")}, adk.WithCallbacks(h))
+				var terminal error
+				for {
+					event, ok := it.Next()
+					if !ok {
+						break
+					}
+					if event.Err != nil {
+						terminal = event.Err
+					}
+					if event.Output != nil && event.Output.MessageOutput != nil {
+						_, _ = event.Output.MessageOutput.GetMessage()
+					}
+				}
+				h.EndTrace(ctx, "")
+				flushScope(t, h)
+				if (terminal != nil) != exhausted || m.calls.Load() != 2 {
+					t.Fatalf("terminal=%v calls=%d", terminal, m.calls.Load())
+				}
+				assertScopeError(t, exporter, "writer", exhausted)
+				assertScopeError(t, exporter, "root", exhausted)
+				attrs := attributesByKey(spanByName(t, exporter.GetSpans(), "writer").Attributes)
+				var events []agentRetryEvent
+				if err := json.Unmarshal([]byte(attrs["langfuse.observation.metadata.eino_retry_events"].Value.AsString()), &events); err != nil {
+					t.Fatal(err)
+				}
+				wantCount := 1
+				if exhausted {
+					wantCount = 2
+				}
+				if len(events) != wantCount || attrs["langfuse.observation.metadata.eino_retry_event_count"].Value.AsInt64() != int64(wantCount) {
+					t.Fatalf("retry events=%+v", events)
+				}
+				wantReason := reason
+				if cause, ok := reason.(error); ok {
+					wantReason = cause.Error()
+				}
+				encodedReason, err := json.Marshal(wantReason)
+				if err != nil {
+					encodedReason, _ = json.Marshal(fmt.Sprint(wantReason))
+				}
+				for index, event := range events {
+					gotReason, _ := json.Marshal(event.RejectReason)
+					if string(gotReason) != string(encodedReason) || event.Error == "" || event.Operation != "agent message" || event.Attempt != index {
+						t.Fatalf("event=%+v reason=%s want=%s", event, gotReason, encodedReason)
+					}
+				}
+				for _, span := range exporter.GetSpans() {
+					if attributesByKey(span.Attributes)["langfuse.observation.type"].Value.AsString() == "generation" && span.Status.Code == codes.Error {
+						t.Fatal("provider succeeded; rejection belongs to the retry policy")
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestAgentErrorScopeEventForms(t *testing.T) {
 	for _, typed := range []bool{false, true} {
 		for _, terminal := range []error{nil, errors.New("budget limit"), adk.ErrExceedMaxIterations} {
@@ -194,6 +271,14 @@ func TestAgentErrorScopeEventForms(t *testing.T) {
 				flushScope(t, h)
 				assertScopeError(t, exporter, "root", terminal != nil)
 				assertScopeError(t, exporter, "agent", terminal != nil)
+				attrs := attributesByKey(spanByName(t, exporter.GetSpans(), "agent").Attributes)
+				var retries []agentRetryEvent
+				if err := json.Unmarshal([]byte(attrs["langfuse.observation.metadata.eino_retry_events"].Value.AsString()), &retries); err != nil {
+					t.Fatal(err)
+				}
+				if len(retries) != 2 || retries[0].Operation != "agent output" || retries[1].Operation != "agent message" || retries[0].Attempt != 1 || retries[1].Attempt != 1 {
+					t.Fatalf("retry events=%+v", retries)
+				}
 			})
 		}
 	}

--- a/callbacks/langfuse/v2/agent_root_output_test.go
+++ b/callbacks/langfuse/v2/agent_root_output_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package langfuse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/components"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+func TestAgentRootOutputPriority(t *testing.T) {
+	for _, component := range []components.Component{adk.ComponentOfAgent, adk.ComponentOfAgenticAgent} {
+		for _, tc := range []struct {
+			name, agentOutput, explicit, want string
+			childFirst, cancel, noAgent       bool
+		}{
+			{name: "late child", agentOutput: "done", want: `"done"`},
+			{name: "early child", agentOutput: "done", childFirst: true, want: `"done"`},
+			{name: "explicit", agentOutput: "done", explicit: "application result", want: "application result"},
+			{name: "explicit survives cancellation", agentOutput: "done", explicit: "application result", cancel: true, want: "application result"},
+			{name: "context end", agentOutput: "done", cancel: true, want: `"done"`},
+			{name: "empty agent output"},
+			{name: "standalone fallback", noAgent: true, want: `{"role":"assistant","content":"failed partial"}`},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", component, tc.name), func(t *testing.T) {
+				h, exporter := newScopeHandler(t, true)
+				base, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				ctx := h.StartTrace(base, WithName("root"))
+				info := &callbacks.RunInfo{Name: "agent", Component: component}
+				agentCtx := ctx
+				if !tc.noAgent {
+					agentCtx = h.OnStart(ctx, info, nil)
+				}
+				mi := &callbacks.RunInfo{Name: "provider", Component: components.ComponentOfChatModel}
+				mc := h.OnStart(agentCtx, mi, &model.CallbackInput{})
+				finishChild := func() {
+					r, w := schema.Pipe[callbacks.CallbackOutput](2)
+					w.Send(&model.CallbackOutput{Message: schema.AssistantMessage("failed partial", nil)}, nil)
+					w.Send(nil, errors.New("attempt failed"))
+					w.Close()
+					h.OnEndWithStreamOutput(mc, mi, r)
+					flushScope(t, h)
+				}
+				if tc.childFirst {
+					finishChild()
+				}
+				if !tc.noAgent {
+					if tc.agentOutput == "" {
+						events, sender := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+						sender.Close()
+						// Exercise a genuinely empty agent result, not a JSON empty string.
+						if component == adk.ComponentOfAgent {
+							h.OnEnd(agentCtx, info, &adk.AgentCallbackOutput{Events: events})
+						} else {
+							typedEvents, typedSender := adk.NewAsyncIteratorPair[*adk.TypedAgentEvent[*schema.AgenticMessage]]()
+							typedSender.Close()
+							h.OnEnd(agentCtx, info, &adk.TypedAgentCallbackOutput[*schema.AgenticMessage]{Events: typedEvents})
+						}
+					} else {
+						h.OnEnd(agentCtx, info, tc.agentOutput)
+					}
+					flushScope(t, h)
+				}
+				if !tc.cancel || tc.explicit != "" {
+					h.EndTrace(ctx, tc.explicit)
+				}
+				if tc.cancel {
+					cancel()
+					// Deterministically run the same completion path as the context watcher.
+					ctx.Value(traceRunKey{}).(*traceRun).contextEnded(ctx)
+				}
+				if !tc.childFirst {
+					finishChild()
+				}
+				flushScope(t, h)
+				root := spanByName(t, exporter.GetSpans(), "root")
+				got := attributesByKey(root.Attributes)["langfuse.observation.output"].Value.AsString()
+				if got != tc.want {
+					t.Fatalf("root output=%q, want=%q", got, tc.want)
+				}
+				assertScopeError(t, exporter, "root", tc.noAgent)
+				assertScopeError(t, exporter, "provider", true)
+			})
+		}
+	}
+}
+
+func TestAgentRootOutputIgnoresNestedAgent(t *testing.T) {
+	h, exporter := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	outer := &callbacks.RunInfo{Name: "outer", Component: adk.ComponentOfAgent}
+	outerCtx := h.OnStart(ctx, outer, nil)
+	inner := &callbacks.RunInfo{Name: "inner", Component: adk.ComponentOfAgent}
+	innerCtx := h.OnStart(outerCtx, inner, nil)
+	h.OnEnd(outerCtx, outer, "done")
+	h.EndTrace(ctx, "")
+	h.OnError(innerCtx, inner, errors.New("handled child failure"))
+	flushScope(t, h)
+	root := spanByName(t, exporter.GetSpans(), "root")
+	assertStringAttribute(t, attributesByKey(root.Attributes), "langfuse.observation.output", `"done"`)
+	assertScopeError(t, exporter, "root", false)
+	assertScopeError(t, exporter, "inner", true)
+}

--- a/callbacks/langfuse/v2/callback_panic_test.go
+++ b/callbacks/langfuse/v2/callback_panic_test.go
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package langfuse
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/callbacks"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/schema"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type panicJSONOutput struct{}
+
+func (panicJSONOutput) MarshalJSON() ([]byte, error) { panic("test serialization panic") }
+
+type panicEndSpan struct{ trace.Span }
+
+func (panicEndSpan) End(...trace.SpanEndOption) { panic("test span end panic") }
+
+func TestCallbackPanicFinalizesTerminalCollectors(t *testing.T) {
+	for _, kind := range []string{"stream", "agent", "agentic", "error", "diagnostic"} {
+		t.Run(kind, func(t *testing.T) {
+			h, exporter := newScopeHandler(t, true)
+			ctx := h.StartTrace(context.Background(), WithName("root"))
+			info := &callbacks.RunInfo{Name: "child", Component: compose.ComponentOfChain}
+			if kind == "agent" {
+				info.Component = adk.ComponentOfAgent
+			}
+			if kind == "agentic" {
+				info.Component = adk.ComponentOfAgenticAgent
+			}
+			childCtx := h.OnStart(ctx, info, nil)
+			state := spanStateFromContext(childCtx)
+			switch kind {
+			case "agent":
+				events, sender := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+				sender.Send(&adk.AgentEvent{Output: &adk.AgentOutput{CustomizedOutput: panicJSONOutput{}}})
+				sender.Close()
+				h.OnEnd(childCtx, info, &adk.AgentCallbackOutput{Events: events})
+			case "agentic":
+				events, sender := adk.NewAsyncIteratorPair[*adk.TypedAgentEvent[*schema.AgenticMessage]]()
+				sender.Send(&adk.TypedAgentEvent[*schema.AgenticMessage]{Output: &adk.TypedAgentOutput[*schema.AgenticMessage]{CustomizedOutput: panicJSONOutput{}}})
+				sender.Close()
+				h.OnEnd(childCtx, info, &adk.TypedAgentCallbackOutput[*schema.AgenticMessage]{Events: events})
+			case "error":
+				original := state.attributes.prepare
+				state.attributes.prepare = func(value string) string {
+					if strings.HasPrefix(value, "{") {
+						panic("test error output panic")
+					}
+					return original(value)
+				}
+				h.OnError(childCtx, info, errors.New("business failure"))
+			default:
+				if kind == "diagnostic" {
+					state.attributes.prepare = func(string) string { panic("test diagnostic panic") }
+				}
+				r, w := schema.Pipe[callbacks.CallbackOutput](1)
+				w.Send(panicJSONOutput{}, nil)
+				w.Close()
+				h.OnEndWithStreamOutput(childCtx, info, r)
+			}
+			h.EndTrace(ctx, "application result")
+			flushScope(t, h)
+			assertPanicRootEnded(t, ctx)
+			if len(exporter.GetSpans()) != 2 {
+				t.Fatalf("exported spans=%d", len(exporter.GetSpans()))
+			}
+			if kind == "diagnostic" {
+				if spanByName(t, exporter.GetSpans(), "child").Status.Code != codes.Error {
+					t.Fatal("missing OTel error status")
+				}
+			} else {
+				assertScopeError(t, exporter, "child", true)
+			}
+			assertScopeError(t, exporter, "root", kind == "error")
+			root := spanByName(t, exporter.GetSpans(), "root")
+			rootAttrs := attributesByKey(root.Attributes)
+			assertStringAttribute(t, rootAttrs, "langfuse.observation.output", "application result")
+			if rootAttrs["langfuse.observation.metadata.eino_callback_panic"].Value.AsString() == "" {
+				t.Fatal("missing root panic diagnostic")
+			}
+			child := spanByName(t, exporter.GetSpans(), "child")
+			if kind != "diagnostic" && attributesByKey(child.Attributes)["langfuse.observation.metadata.eino_callback_panic"].Value.AsString() == "" {
+				t.Fatal("missing child diagnostic")
+			}
+			if len(child.Events) == 0 {
+				t.Fatal("missing panic exception")
+			}
+			state.end("must not replace final output")
+			if len(exporter.GetSpans()) != 2 {
+				t.Fatal("span ended more than once")
+			}
+		})
+	}
+}
+
+func TestCallbackPanicInputWaitsForFinalOutput(t *testing.T) {
+	h, exporter := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	info := &callbacks.RunInfo{Name: "child", Component: compose.ComponentOfChain}
+	input, w := schema.Pipe[callbacks.CallbackInput](1)
+	w.Send(panicJSONOutput{}, nil)
+	w.Close()
+	childCtx := h.OnStartWithStreamInput(ctx, info, input)
+	state := spanStateFromContext(childCtx)
+	select {
+	case <-state.inputDone:
+	case <-time.After(time.Second):
+		t.Fatal("input completion blocked")
+	}
+	if !state.span.IsRecording() {
+		t.Fatal("input failure prematurely ended the span")
+	}
+	if len(exporter.GetSpans()) != 0 {
+		t.Fatal("input failure exported incomplete output")
+	}
+	h.OnEnd(childCtx, info, "done")
+	h.EndTrace(ctx, "")
+	flushScope(t, h)
+	assertPanicRootEnded(t, ctx)
+	assertScopeError(t, exporter, "child", true)
+	assertScopeError(t, exporter, "root", false)
+	for _, name := range []string{"child", "root"} {
+		span := spanByName(t, exporter.GetSpans(), name)
+		assertStringAttribute(t, attributesByKey(span.Attributes), "langfuse.observation.output", `"done"`)
+	}
+}
+
+func TestCallbackPanicPreservesAlreadyRecordedOutput(t *testing.T) {
+	h, exporter := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	info := &callbacks.RunInfo{Name: "agent", Component: adk.ComponentOfAgent}
+	childCtx := h.OnStart(ctx, info, nil)
+	state := spanStateFromContext(childCtx)
+	original := state.attributes.prepare
+	state.attributes.prepare = func(value string) string {
+		if strings.HasPrefix(value, "[") {
+			panic("test retry metadata panic")
+		}
+		return original(value)
+	}
+	events, sender := adk.NewAsyncIteratorPair[*adk.AgentEvent]()
+	sender.Send(&adk.AgentEvent{Err: &adk.WillRetryError{ErrStr: "retry", RetryAttempt: 1}})
+	sender.Send(&adk.AgentEvent{Output: &adk.AgentOutput{MessageOutput: &adk.MessageVariant{Message: schema.AssistantMessage("done", nil)}}})
+	sender.Close()
+	h.OnEnd(childCtx, info, &adk.AgentCallbackOutput{Events: events})
+	h.EndTrace(ctx, "")
+	flushScope(t, h)
+	assertPanicRootEnded(t, ctx)
+	assertScopeError(t, exporter, "agent", true)
+	assertScopeError(t, exporter, "root", false)
+	for _, name := range []string{"agent", "root"} {
+		span := spanByName(t, exporter.GetSpans(), name)
+		assertStringAttribute(t, attributesByKey(span.Attributes), "langfuse.observation.output", `{"messages":{"role":"assistant","content":"done"}}`)
+	}
+}
+
+func TestCallbackPanicSpanEndStillReleasesRoot(t *testing.T) {
+	h, exporter := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	info := &callbacks.RunInfo{Name: "child", Component: compose.ComponentOfChain}
+	childCtx := h.OnStart(ctx, info, nil)
+	state := spanStateFromContext(childCtx)
+	actualSpan := state.span
+	state.span = panicEndSpan{Span: actualSpan}
+	r, w := schema.Pipe[callbacks.CallbackOutput](1)
+	w.Send("done", nil)
+	w.Close()
+	h.OnEndWithStreamOutput(childCtx, info, r)
+	h.EndTrace(ctx, "result")
+	flushScope(t, h)
+	assertPanicRootEnded(t, ctx)
+	spanByName(t, exporter.GetSpans(), "root")
+	actualSpan.End()
+}
+
+func TestCallbackPanicClosesOwnedStream(t *testing.T) {
+	h, _ := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	info := &callbacks.RunInfo{Name: "child", Component: compose.ComponentOfChain}
+	childCtx := h.OnStart(ctx, info, nil)
+	r, w := schema.Pipe[callbacks.CallbackOutput](1)
+	defer w.Close()
+	w.Send("first", nil)
+	converted := schema.StreamReaderWithConvert(r, func(v callbacks.CallbackOutput) (callbacks.CallbackOutput, error) { panic("stream conversion panic") })
+	h.OnEndWithStreamOutput(childCtx, info, converted)
+	h.EndTrace(ctx, "")
+	flushScope(t, h)
+	if !w.Send("after panic", nil) {
+		t.Fatal("callback-owned stream was not closed")
+	}
+	assertPanicRootEnded(t, ctx)
+}
+
+func TestCallbackPanicRootEndReleasesWaitersAndRegistry(t *testing.T) {
+	h, _ := newScopeHandler(t, true)
+	ctx := h.StartTrace(context.Background(), WithName("root"))
+	run := ctx.Value(traceRunKey{}).(*traceRun)
+	actualSpan := run.span
+	run.span = panicEndSpan{Span: actualSpan}
+	info := &callbacks.RunInfo{Name: "child", Component: compose.ComponentOfChain}
+	childCtx := h.OnStart(ctx, info, nil)
+	r, w := schema.Pipe[callbacks.CallbackOutput](1)
+	w.Send("done", nil)
+	w.Close()
+	h.EndTrace(ctx, "result")
+	h.OnEndWithStreamOutput(childCtx, info, r)
+	flushScope(t, h)
+	assertPanicRootEnded(t, ctx)
+	if _, ok := h.activeTraceRun.runs.Load(run); ok {
+		t.Fatal("root remains in the registry")
+	}
+	actualSpan.End()
+}
+
+func assertPanicRootEnded(t *testing.T, ctx context.Context) {
+	t.Helper()
+	run := ctx.Value(traceRunKey{}).(*traceRun)
+	run.mu.Lock()
+	active, ended := run.active, run.ended
+	run.mu.Unlock()
+	if active != 0 || !ended {
+		t.Fatalf("active=%d ended=%v", active, ended)
+	}
+	select {
+	case <-run.done:
+	default:
+		t.Fatal("root completion channel not closed")
+	}
+}

--- a/callbacks/langfuse/v2/handler.go
+++ b/callbacks/langfuse/v2/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"reflect"
@@ -56,11 +57,21 @@ type spanState struct {
 	// enclosingAgent owns recovery of failures from this callback. Only an
 	// outermost agent (or a call outside an agent) can fail the root trace.
 	enclosingAgent *spanState
+	outermostAgent bool
 	ctx            context.Context
 	inputDone      chan struct{}
 	endOnce        sync.Once
 	outcomeMu      sync.Mutex
 	failed         bool
+	// retryEvents is owned by the agent event collector.
+	retryEvents []agentRetryEvent
+}
+
+type agentRetryEvent struct {
+	Operation    string `json:"operation"`
+	Attempt      int    `json:"attempt"`
+	Error        string `json:"error"`
+	RejectReason any    `json:"reject_reason,omitempty"`
 }
 
 type asyncGroup struct {
@@ -263,6 +274,7 @@ func (c *CallbackHandler) startSpan(ctx context.Context, info *callbacks.RunInfo
 		attributes:     newSpanAttributeWriter(span, c.prepare, remaining, c.losses),
 		run:            run,
 		enclosingAgent: enclosingAgent,
+		outermostAgent: enclosingAgent == nil && (info.Component == adk.ComponentOfAgent || info.Component == adk.ComponentOfAgenticAgent),
 		ctx:            ctx,
 		inputDone:      make(chan struct{}),
 	}
@@ -410,17 +422,39 @@ func (c *CallbackHandler) setAgentOutput(state *spanState, messages, customized 
 	if values := nonEmptySlice(customized); values != nil {
 		output["customized"] = values
 	}
-	if len(output) == 0 {
-		return ""
+	var serialized string
+	if len(output) > 0 {
+		serialized = c.setJSONAttribute(state, "langfuse.observation.output", output)
 	}
-	return c.setJSONAttribute(state, "langfuse.observation.output", output)
+	// Preserve the final output before spending any remaining attribute budget
+	// on diagnostics. The event count counts notifications, not executed retries.
+	if len(state.retryEvents) > 0 {
+		state.attributes.setInt("langfuse.observation.metadata.eino_retry_event_count", len(state.retryEvents))
+		c.setJSONAttribute(state, "langfuse.observation.metadata.eino_retry_events", state.retryEvents)
+	}
+	return serialized
 }
 
 func (s *spanState) recordAgentError(operation string, err error) {
 	var retryErr *adk.WillRetryError
 	if errors.As(err, &retryErr) {
-		// The failed attempt is recorded on the model observation. This event
-		// tells consumers to continue; exhaustion arrives as a separate error.
+		// A successful provider response can still be rejected by ShouldRetry.
+		// Keep its diagnostic even when the model observation has no error.
+		reason := retryErr.RejectReason()
+		if cause, ok := reason.(error); ok {
+			reason = cause.Error()
+		}
+		if reason != nil {
+			encoded, marshalErr := json.Marshal(reason)
+			if marshalErr != nil {
+				s.attributes.losses.Add(lossMetadataSerialization, 1)
+				reason = fmt.Sprint(reason)
+			} else {
+				reason = json.RawMessage(encoded)
+			}
+		}
+		stateEvent := agentRetryEvent{Operation: operation, Attempt: retryErr.RetryAttempt, Error: retryErr.Error(), RejectReason: reason}
+		s.retryEvents = append(s.retryEvents, stateEvent)
 		return
 	}
 	s.recordError(operation, err)
@@ -483,7 +517,7 @@ func (s *spanState) end(output string) {
 	s.endOnce.Do(func() {
 		s.span.End()
 		if s.run != nil {
-			s.run.childEnded(output)
+			s.run.childEnded(output, s.outermostAgent)
 		}
 	})
 }

--- a/callbacks/langfuse/v2/handler.go
+++ b/callbacks/langfuse/v2/handler.go
@@ -45,6 +45,7 @@ const (
 
 type (
 	activeAgentNameKey struct{}
+	agentScopeKey      struct{}
 	spanStateKey       struct{}
 )
 
@@ -52,11 +53,14 @@ type spanState struct {
 	span       trace.Span
 	attributes *spanAttributeWriter
 	run        *traceRun
-	ctx        context.Context
-	inputDone  chan struct{}
-	endOnce    sync.Once
-	outcomeMu  sync.Mutex
-	failed     bool
+	// enclosingAgent owns recovery of failures from this callback. Only an
+	// outermost agent (or a call outside an agent) can fail the root trace.
+	enclosingAgent *spanState
+	ctx            context.Context
+	inputDone      chan struct{}
+	endOnce        sync.Once
+	outcomeMu      sync.Mutex
+	failed         bool
 }
 
 type asyncGroup struct {
@@ -223,15 +227,14 @@ func (c *CallbackHandler) Shutdown(ctx context.Context) error {
 }
 
 func (c *CallbackHandler) markActiveAgent(ctx context.Context, info *callbacks.RunInfo) context.Context {
-	if !c.collapseAgentInternalSpans || info.Name == "" {
-		return ctx
-	}
 	switch info.Component {
 	case adk.ComponentOfAgent, adk.ComponentOfAgenticAgent:
-		return context.WithValue(ctx, activeAgentNameKey{}, info.Name)
-	default:
-		return ctx
+		ctx = context.WithValue(ctx, agentScopeKey{}, spanStateFromContext(ctx))
+		if c.collapseAgentInternalSpans && info.Name != "" {
+			ctx = context.WithValue(ctx, activeAgentNameKey{}, info.Name)
+		}
 	}
+	return ctx
 }
 
 func (c *CallbackHandler) startSpan(ctx context.Context, info *callbacks.RunInfo) (context.Context, *spanState) {
@@ -248,13 +251,20 @@ func (c *CallbackHandler) startSpan(ctx context.Context, info *callbacks.RunInfo
 		attribute.String("langfuse.observation.metadata.eino_type", info.Type),
 	)
 	attrs, remaining := fitAttributes(attrs, c.maxSpanAttributeBytes, c.losses)
+	enclosingAgent, _ := ctx.Value(agentScopeKey{}).(*spanState)
+	if enclosingAgent != nil && enclosingAgent.run != run {
+		// StartTrace may introduce a new root inside an existing agent context.
+		// Recovery in the previous trace must not suppress this trace's errors.
+		enclosingAgent = nil
+	}
 	ctx, span := c.tracer.Start(ctx, callbackName(info), trace.WithAttributes(attrs...))
 	return ctx, &spanState{
-		span:       span,
-		attributes: newSpanAttributeWriter(span, c.prepare, remaining, c.losses),
-		run:        run,
-		ctx:        ctx,
-		inputDone:  make(chan struct{}),
+		span:           span,
+		attributes:     newSpanAttributeWriter(span, c.prepare, remaining, c.losses),
+		run:            run,
+		enclosingAgent: enclosingAgent,
+		ctx:            ctx,
+		inputDone:      make(chan struct{}),
 	}
 }
 
@@ -340,7 +350,7 @@ func (c *CallbackHandler) collectAgentMessages(state *spanState, events *adk.Asy
 			continue
 		}
 		if event.Err != nil {
-			state.recordError("agent output", event.Err)
+			state.recordAgentError("agent output", event.Err)
 		}
 		if event.Output == nil {
 			continue
@@ -348,7 +358,7 @@ func (c *CallbackHandler) collectAgentMessages(state *spanState, events *adk.Asy
 		if event.Output.MessageOutput != nil {
 			message, err := event.Output.MessageOutput.GetMessage()
 			if err != nil {
-				state.recordError("agent message", err)
+				state.recordAgentError("agent message", err)
 			} else if message != nil {
 				messages = append(messages, message)
 			}
@@ -372,7 +382,7 @@ func (c *CallbackHandler) collectAgenticMessages(state *spanState, events *adk.A
 			continue
 		}
 		if event.Err != nil {
-			state.recordError("agent output", event.Err)
+			state.recordAgentError("agent output", event.Err)
 		}
 		if event.Output == nil {
 			continue
@@ -380,7 +390,7 @@ func (c *CallbackHandler) collectAgenticMessages(state *spanState, events *adk.A
 		if event.Output.MessageOutput != nil {
 			message, err := event.Output.MessageOutput.GetMessage()
 			if err != nil {
-				state.recordError("agent message", err)
+				state.recordAgentError("agent message", err)
 			} else if message != nil {
 				messages = append(messages, message)
 			}
@@ -404,6 +414,16 @@ func (c *CallbackHandler) setAgentOutput(state *spanState, messages, customized 
 		return ""
 	}
 	return c.setJSONAttribute(state, "langfuse.observation.output", output)
+}
+
+func (s *spanState) recordAgentError(operation string, err error) {
+	var retryErr *adk.WillRetryError
+	if errors.As(err, &retryErr) {
+		// The failed attempt is recorded on the model observation. This event
+		// tells consumers to continue; exhaustion arrives as a separate error.
+		return
+	}
+	s.recordError(operation, err)
 }
 
 func (s *spanState) recordError(operation string, err error) (string, string) {
@@ -453,7 +473,7 @@ func (s *spanState) recordError(operation string, err error) (string, string) {
 	s.attributes.setString("langfuse.observation.level", "ERROR")
 	s.attributes.setString("langfuse.observation.status_message", message)
 	s.attributes.setString("langfuse.observation.metadata.eino_callback_error", message)
-	if s.run != nil {
+	if s.run != nil && s.enclosingAgent == nil {
 		s.run.recordError(message, err)
 	}
 	return "", ""

--- a/callbacks/langfuse/v2/handler.go
+++ b/callbacks/langfuse/v2/handler.go
@@ -87,6 +87,7 @@ type spanAttributeWriter struct {
 	prepare   func(string) string
 	remaining int
 	losses    *lossReporter
+	output    string
 }
 
 func (c *CallbackHandler) OnStart(ctx context.Context, info *callbacks.RunInfo, input callbacks.CallbackInput) context.Context {
@@ -148,6 +149,7 @@ func (c *CallbackHandler) OnError(ctx context.Context, info *callbacks.RunInfo, 
 		callbackErr = errors.New("eino callback failed without an error")
 	}
 	c.async.run(func() {
+		defer state.recoverCallbackPanic("error callback", true)
 		<-state.inputDone
 		status, cause := state.recordError("callback", callbackErr)
 		switch status {
@@ -174,6 +176,8 @@ func (c *CallbackHandler) OnStartWithStreamInput(ctx context.Context, info *call
 	ctx, state := c.startSpan(ctx, info)
 	c.async.run(func() {
 		defer close(state.inputDone)
+		// Publish input completion only after recording any collector panic.
+		defer state.recoverCallbackPanic("stream input callback", false)
 		defer closeStream(input)
 		inputs, err := receiveAll(input)
 		if err != nil {
@@ -193,6 +197,7 @@ func (c *CallbackHandler) OnEndWithStreamOutput(ctx context.Context, info *callb
 		return ctx
 	}
 	c.async.run(func() {
+		defer state.recoverCallbackPanic("stream output callback", true)
 		defer closeStream(output)
 		outputs, completionStart, err := receiveAllWithFirst(output)
 		if err != nil {
@@ -331,6 +336,7 @@ func (c *CallbackHandler) endAgentOutput(state *spanState, info *callbacks.RunIn
 			return false
 		}
 		c.async.run(func() {
+			defer state.recoverCallbackPanic("agent output callback", true)
 			<-state.inputDone
 			state.end(c.collectAgentMessages(state, converted.Events))
 		})
@@ -342,6 +348,7 @@ func (c *CallbackHandler) endAgentOutput(state *spanState, info *callbacks.RunIn
 			return false
 		}
 		c.async.run(func() {
+			defer state.recoverCallbackPanic("agentic output callback", true)
 			<-state.inputDone
 			state.end(c.collectAgenticMessages(state, converted.Events))
 		})
@@ -435,6 +442,40 @@ func (c *CallbackHandler) setAgentOutput(state *spanState, messages, customized 
 	return serialized
 }
 
+// recoverCallbackPanic runs inside the collector goroutine. Input collectors
+// leave finalization to OnEnd/OnError so a telemetry failure cannot end the span
+// before the actual result arrives. Terminal collectors always release the span.
+func (s *spanState) recoverCallbackPanic(operation string, terminal bool) {
+	if recovered := recover(); recovered != nil {
+		if terminal {
+			<-s.inputDone
+			// Cleanup must also run if recording the diagnostic itself panics.
+			defer func() { s.end(s.attributes.outputValue()) }()
+		}
+		err := recoveredPanic(operation, recovered)
+		s.recordCallbackPanic(err)
+	}
+}
+
+func (s *spanState) recordCallbackPanic(err error) {
+	message := err.Error()
+	// Callback failures are telemetry diagnostics, not an Agent terminal error.
+	if s.run != nil {
+		s.run.recordCallbackPanic(message)
+	}
+	s.outcomeMu.Lock()
+	failed := s.failed
+	s.failed = true
+	s.outcomeMu.Unlock()
+	s.span.RecordError(err, trace.WithStackTrace(true))
+	if !failed {
+		s.span.SetStatus(codes.Error, message)
+		s.attributes.setString("langfuse.observation.level", "ERROR")
+		s.attributes.setString("langfuse.observation.status_message", message)
+	}
+	s.attributes.setString("langfuse.observation.metadata.eino_callback_panic", message)
+}
+
 func (s *spanState) recordAgentError(operation string, err error) {
 	var retryErr *adk.WillRetryError
 	if errors.As(err, &retryErr) {
@@ -515,10 +556,10 @@ func (s *spanState) recordError(operation string, err error) (string, string) {
 
 func (s *spanState) end(output string) {
 	s.endOnce.Do(func() {
-		s.span.End()
 		if s.run != nil {
-			s.run.childEnded(output, s.outermostAgent)
+			defer s.run.childEnded(output, s.outermostAgent)
 		}
+		s.span.End()
 	})
 }
 
@@ -662,8 +703,17 @@ func (w *spanAttributeWriter) setString(key, value string) string {
 	}
 	if prepared != "" {
 		w.span.SetAttributes(attribute.String(key, prepared))
+		if key == "langfuse.observation.output" {
+			w.output = prepared
+		}
 	}
 	return prepared
+}
+
+func (w *spanAttributeWriter) outputValue() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.output
 }
 
 func (w *spanAttributeWriter) setInt(key string, value int) {

--- a/callbacks/langfuse/v2/trace.go
+++ b/callbacks/langfuse/v2/trace.go
@@ -74,6 +74,9 @@ type traceRun struct {
 	autoEnd         bool
 	endRequested    bool
 	terminalOutput  string
+	explicitOutput  string
+	agentOutput     string
+	hasAgentOutput  bool
 	ended           bool
 	failed          bool
 	lastOutput      string
@@ -132,7 +135,7 @@ func (c *CallbackHandler) StartTrace(ctx context.Context, opts ...TraceOption) c
 func (c *CallbackHandler) EndTrace(ctx context.Context, output string) {
 	run, _ := ctx.Value(traceRunKey{}).(*traceRun)
 	if run != nil {
-		run.requestEnd(output)
+		run.requestEnd(output, true)
 	}
 }
 
@@ -240,13 +243,16 @@ func (r *traceRun) childStarted() bool {
 	return true
 }
 
-func (r *traceRun) childEnded(output string) {
+func (r *traceRun) childEnded(output string, outermostAgent bool) {
 	r.mu.Lock()
 	if r.ended {
 		r.mu.Unlock()
 		return
 	}
-	if output != "" {
+	if outermostAgent {
+		r.agentOutput = output
+		r.hasAgentOutput = true
+	} else if output != "" {
 		r.lastOutput = output
 	}
 	if r.active > 0 {
@@ -286,34 +292,40 @@ func (r *traceRun) contextEnded(ctx context.Context) {
 	if causeText, interrupted := interruptionCause(cause); interrupted {
 		message := "trace context: interrupted"
 		r.recordInterruption(message, causeText)
-		r.requestEnd(interruptedOutput(causeText))
+		r.requestEnd(interruptedOutput(causeText), false)
 		return
 	}
 	if errors.Is(err, context.Canceled) {
 		if errors.Is(cause, context.Canceled) {
-			r.requestEnd("")
+			r.requestEnd("", false)
 			return
 		}
 		causeText := cause.Error()
 		message := "trace context: cancelled"
 		message += ": " + causeText
 		r.recordCancellation(message, causeText)
-		r.requestEnd(cancelledOutput(causeText))
+		r.requestEnd(cancelledOutput(causeText), false)
 		return
 	}
 	message := "trace context: " + cause.Error()
 	r.recordError(message, cause)
-	r.requestEnd(errorOutput(cause.Error()))
+	r.requestEnd(errorOutput(cause.Error()), false)
 }
 
-func (r *traceRun) requestEnd(output string) {
+func (r *traceRun) requestEnd(output string, explicit bool) {
 	r.mu.Lock()
 	if r.ended {
 		r.mu.Unlock()
 		return
 	}
 	r.endRequested = true
-	r.terminalOutput = output
+	if explicit {
+		if output != "" {
+			r.explicitOutput = output
+		}
+	} else if output != "" {
+		r.terminalOutput = output
+	}
 	shouldEnd := r.active == 0
 	r.mu.Unlock()
 	if shouldEnd {
@@ -370,8 +382,14 @@ func (r *traceRun) end(output string) {
 	}
 	r.ended = true
 	if output == "" {
-		output = r.terminalOutput
-		if output == "" {
+		switch {
+		case r.explicitOutput != "":
+			output = r.explicitOutput
+		case r.terminalOutput != "":
+			output = r.terminalOutput
+		case r.hasAgentOutput:
+			output = r.agentOutput
+		default:
 			output = r.lastOutput
 		}
 	}

--- a/callbacks/langfuse/v2/trace.go
+++ b/callbacks/langfuse/v2/trace.go
@@ -346,6 +346,14 @@ func (r *traceRun) recordError(message string, err error) {
 	r.attributeWriter.setString("langfuse.observation.status_message", message)
 }
 
+func (r *traceRun) recordCallbackPanic(message string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.ended {
+		r.attributeWriter.setString("langfuse.observation.metadata.eino_callback_panic", message)
+	}
+}
+
 func (r *traceRun) recordCancellation(message, cause string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -397,14 +405,16 @@ func (r *traceRun) end(output string) {
 	onEnd := r.onEnd
 	r.mu.Unlock()
 
+	// Even a caller-supplied span processor may panic while ending a span.
+	// Always release registry membership and completion waiters.
+	defer close(r.done)
+	if onEnd != nil {
+		defer onEnd()
+	}
 	if output != "" {
 		r.attributeWriter.setString("langfuse.observation.output", output)
 	}
 	span.End()
-	if onEnd != nil {
-		onEnd()
-	}
-	close(r.done)
 }
 
 func (r *traceRunRegistry) add(run *traceRun) {


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title matches the format: <type>(optional scope): <description>.
- [x] The description is user-oriented and clear.
- [ ] Attach a separate user-documentation PR if required. Both module READMEs are updated in this PR.

#### (Optional) Translate the PR title into Chinese.
修复 Langfuse 在重试和回调 panic 场景下的 Agent 状态与输出记录。

#### More detailed description
An ADK model attempt can fail and then recover, but its callback currently marks the application root ERROR permanently. A late failed child collector can also overwrite the final Agent output. Separately, recovering a collector panic only releases the async task count: its span remains active and prevents the root from ending even when Flush succeeds.

This PR fixes these related observation lifecycle issues:

- Scope model, tool, and nested-Agent errors to their own observations. The outermost Agent's terminal error determines root failure. Retry exhaustion and execution limits still fail the Agent/root; cancellation and interruption retain their existing handling. Calls outside an Agent retain root error propagation.
- Treat WillRetryError as a recovery notification in both ordinary and typed Agent collectors. Preserve operation, SDK attempt value, error, and rejection reason in Agent metadata, including successful provider responses rejected by ShouldRetry. The count measures notifications rather than completed retries. Diagnostics respect attribute limits and do not displace an already recorded Agent output.
- Prefer an explicit EndTrace result, then context termination output, then the outermost Agent result. Late nested observations cannot overwrite that result; calls without an Agent retain the child-output fallback.
- Recover terminal collector panics with span-aware cleanup, retain already recorded output, and release root child counts exactly once. Input collector panics publish their diagnostic before unblocking the normal end/error callback. Internal telemetry panics are recorded on the affected observation and in root metadata without independently failing the application root. Completion waiters and registry membership are also released if span ending panics.

#### Validation
- `go test -race . -count=1 -timeout=120s` in `callbacks/langfuse/v2` passed.
- Tests cover real ADK streaming retry/failover and exhaustion; output rejection diagnostics; ordinary/typed Agents; nested and standalone calls; delayed child output; cancellation; and interrupted tools.
- Panic regressions cover stream/Agent/error collectors, input completion, preserved output, stream closure, diagnostic failures, and child/root span-end failures.
- Downstream integration race tests using Eino v0.9.15 passed with the published fork dependency, covering recovered model errors, rejected empty output, execution budget, available-points limits, and iteration limits.

#### Which issue(s) this PR fixes
No linked issue.

#### User documentation
Updated `callbacks/langfuse/v2/README.md` and `README_zh.md` in this PR.
